### PR TITLE
Fix CORS error for socket.io and add CORS config

### DIFF
--- a/app.js
+++ b/app.js
@@ -218,6 +218,10 @@ d.run(function () {
         throw Error(e);
       }
 
+      if (appConfig.cors) {
+        appConfig.cors.credentials = true;
+      }
+
       if (appConfig.dapp.masterrequired && !appConfig.dapp.masterpassword) {
         var randomstring = require('randomstring');
 

--- a/app.js
+++ b/app.js
@@ -278,8 +278,14 @@ d.run(function () {
      * `emit`.
      */
     clientWs: ['config', function (scope, cb) {
-      var ClientWs = require('./modules/clientWs');
-      cb(null, new ClientWs(scope.config.wsClient, logger));
+      const ClientWs = require('./modules/clientWs');
+
+      const clientWs = new ClientWs(
+        Object.assign(scope.config.wsClient, appConfig.cors),
+        logger
+      );
+
+      cb(null, clientWs);
     }],
     /**
      * Once config is completed, creates app, http & https servers & sockets with express.
@@ -307,14 +313,15 @@ d.run(function () {
       app.use(compression({
         level: 9
       }));
-      app.use(cors());
-      app.options('*', cors());
+      app.use(cors(appConfig.cors));
+      app.options('*', cors(appConfig.cors));
 
       var server = require('http').createServer(app);
 
       const { Server } = require('socket.io');
       const io = new Server(server, {
-        allowEIO3: true
+        allowEIO3: true,
+        cors: appConfig.cors
       });
 
       var privateKey, certificate, https, https_io;
@@ -330,7 +337,8 @@ d.run(function () {
         }, app);
 
         https_io = new Server(https, {
-          allowEIO3: true
+          allowEIO3: true,
+          cors: appConfig.cors
         });
       }
 

--- a/app.js
+++ b/app.js
@@ -281,7 +281,7 @@ d.run(function () {
       const ClientWs = require('./modules/clientWs');
 
       const clientWs = new ClientWs(
-        Object.assign(scope.config.wsClient, appConfig.cors),
+        Object.assign(scope.config.wsClient, { cors: appConfig.cors }),
         logger
       );
 

--- a/app.js
+++ b/app.js
@@ -218,9 +218,11 @@ d.run(function () {
         throw Error(e);
       }
 
-      if (appConfig.cors) {
-        appConfig.cors.credentials = true;
+      if (!appConfig.cors) {
+        appConfig.cors = { origin: true };
       }
+
+      appConfig.cors.credentials = true;
 
       if (appConfig.dapp.masterrequired && !appConfig.dapp.masterpassword) {
         var randomstring = require('randomstring');

--- a/helpers/router.js
+++ b/helpers/router.js
@@ -13,8 +13,6 @@ var extend = require('extend');
 var Router = function () {
   var router = require('express').Router();
 
-  router.use(httpApi.middleware.cors);
-
   router.map = function (root, config) {
     var router = this;
 

--- a/helpers/router.js
+++ b/helpers/router.js
@@ -13,6 +13,8 @@ var extend = require('extend');
 var Router = function () {
   var router = require('express').Router();
 
+  router.use(httpApi.middleware.cors);
+
   router.map = function (root, config) {
     var router = this;
 

--- a/modules/clientWs.js
+++ b/modules/clientWs.js
@@ -7,7 +7,8 @@ class ClientWs {
     }
     const port = config.portWS;
     const io = new Server(port, {
-      allowEIO3: true
+      allowEIO3: true,
+      cors: config.cors
     });
 
     this.describes = {};

--- a/schema/config.js
+++ b/schema/config.js
@@ -32,6 +32,15 @@ module.exports = {
       cacheEnabled: {
         type: 'boolean'
       },
+      cors: {
+        type: 'object',
+        origin: {
+          type: ['boolean', 'string', 'array']
+        },
+        methods: {
+          type: 'array'
+        }
+      },
       db: {
         type: 'object',
         properties: {


### PR DESCRIPTION
`cors` options for `config.json`:

* `origin`: Configures the **Access-Control-Allow-Origin** CORS header. Possible values:
  - `Boolean` - set `origin` to `true` to reflect the [request origin](http://tools.ietf.org/html/draft-abarth-origin-09), as defined by `req.header('Origin')`, or set it to `false` to disable CORS.
  - `String` - set `origin` to a specific origin. For example if you set it to `"http://example.com"` only requests from "http://example.com" will be allowed.
  - `Array` - set `origin` to an array of valid origins. For example `["http://example1.com", "http://example2.com/"]` will accept any request from "http://example1.com" or "example2.com".
* `methods`: Configures the **Access-Control-Allow-Methods** CORS header. Expects a comma-delimited string (ex: 'GET,PUT,POST') or an array (ex: `['GET', 'PUT', 'POST']`).

default is `{ origin: true }` - allows any origins
