### PR TITLE
feat(WebSocket): subscribe to asset chat types

### DIFF
--- a/helpers/tranasctionTypesBoundary.js
+++ b/helpers/tranasctionTypesBoundary.js
@@ -7,5 +7,13 @@ const transactionValues = Object
   .values(TransactionTypes)
   .filter((type) => typeof type === 'number');
 
+/**
+ * List of chat message transaction types
+ */
+const transactionChatAssetValues = Object.values(TransactionTypes.CHAT_MESSAGE_TYPES);
+
 exports.MIN_TRANSACTION_TYPE = Math.min(...transactionValues);
 exports.MAX_TRANSACTION_TYPE = Math.max(...transactionValues);
+
+exports.MIN_CHAT_MESSAGE_TRANSACTION_TYPE = Math.min(...transactionChatAssetValues);
+exports.MAX_CHAT_MESSAGE_TRANSACTION_TYPE = Math.max(...transactionChatAssetValues);

--- a/modules/clientWs.js
+++ b/modules/clientWs.js
@@ -34,6 +34,15 @@ class ClientWs {
           if (subscribed) {
             this.describes[socket.id] = describe;
           }
+        });
+
+        socket.on('assetChatTypes', (type) => {
+          const types = Array.isArray(type) ? type : [type];
+          const subscribed = describe.subscribeToAssetChatTypes(...types)
+
+          if (subscribed) {
+            this.describes[socket.id] = describe;
+          }
         })
 
         socket.on('disconnect', () => {


### PR DESCRIPTION
Automatically subscribes to tranasction type = 8 (message transaction) and watches for the subscribed `asset.chat.type`. Subscribing works the same way as for `types`.

```js
const signalMessageType = 3; 
socket.emit('assetChatTypes', signalMessageType);

socket.on('newTrans', (tx) => console.log(tx.asset.chat.type));
```