### PR TITLE
feat: merge `loader/status` and `loader/status/sync` endpoints into `node/status`

### DIFF
--- a/modules/loader.js
+++ b/modules/loader.js
@@ -755,6 +755,44 @@ Loader.prototype.syncing = function () {
 };
 
 /**
+ * Returns current blockchain height to achieve if in sync process;
+ * Returns `0` if syncing done.
+ *
+ * @returns {number}
+ */
+Loader.prototype.getBlocksToSync = function () {
+  return __private.blocksToSync;
+}
+
+/**
+ * Returns last blockchain height when syncing.
+ *
+ * @returns {number}
+ */
+Loader.prototype.getHeight = function () {
+  return __private.lastBlock.height;
+}
+
+/**
+ * Returns if the blockchain is in sync process.
+ *
+ * @returns {boolean}
+ */
+Loader.prototype.loaded = function () {
+  return __private.loaded;
+}
+
+
+/**
+ * Returns total synced blocks.
+ *
+ * @returns {number}
+ */
+Loader.prototype.getTotalBlocks = function () {
+  return __private.total;
+}
+
+/**
  * Calls helpers.sandbox.callMethod().
  * @implements module:helpers#callMethod
  * @param {function} call - Method to call.

--- a/modules/node.js
+++ b/modules/node.js
@@ -60,7 +60,8 @@ Node.prototype.onBind = function (scope) {
   modules = {
     blocks: scope.blocks,
     transport: scope.transport,
-    system: scope.system
+    system: scope.system,
+    loader: scope.loader,
   };
 };
 
@@ -121,6 +122,14 @@ Node.prototype.shared = {
     }
     return setImmediate(cb, null,
         {
+          loader: {
+            loaded: modules.loader.loaded(),
+            now: modules.loader.getHeight(),
+            syncing: modules.loader.syncing(),
+            consensus: modules.transport.consensus(),
+            blocks: modules.loader.getBlocksToSync(),
+            blocksCount: modules.loader.getTotalBlocks(),
+          },
           network: {
             broadhash: modules.system.getBroadhash(),
             epoch: constants.epochTime,


### PR DESCRIPTION
Added properties to the response of the `/api/node/status` endpoint:

```ts
interface Response {
 loader: {
    loaded: boolean;
    now: number;
    syncing: boolean;
    consensus: number;
    blocks: number;
    blocksCount: number;
  }
  // ...
}
```