### PR TITLE
fix: transaction pool doesn't propertly remove transactions

### DIFF
--- a/logic/transactionPool.js
+++ b/logic/transactionPool.js
@@ -40,14 +40,14 @@ function TransactionPool (broadcastInterval, releaseLimit, transaction, bus, log
   };
   self = this;
 
-  self.unconfirmed = { transactions: [], index: {} };
-  self.bundled = { transactions: [], index: {} };
-  self.queued = { transactions: [], index: {} };
-  self.multisignature = { transactions: [], index: {} };
+  self.unconfirmed = new Map();
+  self.bundled = new Map();
+  self.queued = new Map();
+  self.multisignature = new Map();
+
   self.expiryInterval = 30000;
   self.bundledInterval = library.config.broadcasts.broadcastInterval;
   self.bundleLimit = library.config.broadcasts.releaseLimit;
-  self.processed = 0;
 
   // Bundled transaction timer
   function nextBundle (cb) {
@@ -97,11 +97,11 @@ TransactionPool.prototype.bind = function (accounts, transactions, loader) {
  */
 TransactionPool.prototype.transactionInPool = function (id) {
   return [
-    self.unconfirmed.index[id],
-    self.bundled.index[id],
-    self.queued.index[id],
-    self.multisignature.index[id]
-  ].filter(Boolean).length > 0;
+    self.unconfirmed,
+    self.bundled,
+    self.queued,
+    self.multisignature,
+  ].some((queue) => queue.has(id));
 };
 
 /**
@@ -110,8 +110,7 @@ TransactionPool.prototype.transactionInPool = function (id) {
  * @return {transaction[]}
  */
 TransactionPool.prototype.getUnconfirmedTransaction = function (id) {
-  var index = self.unconfirmed.index[id];
-  return self.unconfirmed.transactions[index];
+  return self.unconfirmed.get(id);
 };
 
 /**
@@ -121,8 +120,7 @@ TransactionPool.prototype.getUnconfirmedTransaction = function (id) {
  * @todo This function is never called
  */
 TransactionPool.prototype.getBundledTransaction = function (id) {
-  var index = self.bundled.index[id];
-  return self.bundled.transactions[index];
+  return self.bundled.get(id);
 };
 
 /**
@@ -131,8 +129,7 @@ TransactionPool.prototype.getBundledTransaction = function (id) {
  * @return {transaction[]}
  */
 TransactionPool.prototype.getQueuedTransaction = function (id) {
-  var index = self.queued.index[id];
-  return self.queued.transactions[index];
+  return self.queued.get(id);
 };
 
 /**
@@ -141,8 +138,7 @@ TransactionPool.prototype.getQueuedTransaction = function (id) {
  * @return {transaction[]}
  */
 TransactionPool.prototype.getMultisignatureTransaction = function (id) {
-  var index = self.multisignature.index[id];
-  return self.multisignature.transactions[index];
+  return self.multisignature.get(id);
 };
 
 /**
@@ -152,7 +148,7 @@ TransactionPool.prototype.getMultisignatureTransaction = function (id) {
  * @return {getTransactionList} Calls getTransactionList
  */
 TransactionPool.prototype.getUnconfirmedTransactionList = function (reverse, limit) {
-  return __private.getTransactionList(self.unconfirmed.transactions, reverse, limit);
+  return __private.getTransactionList(self.unconfirmed, reverse, limit);
 };
 
 /**
@@ -162,7 +158,7 @@ TransactionPool.prototype.getUnconfirmedTransactionList = function (reverse, lim
  * @return {getTransactionList} Calls getTransactionList
  */
 TransactionPool.prototype.getBundledTransactionList = function (reverse, limit) {
-  return __private.getTransactionList(self.bundled.transactions, reverse, limit);
+  return __private.getTransactionList(self.bundled, reverse, limit);
 };
 
 /**
@@ -172,7 +168,7 @@ TransactionPool.prototype.getBundledTransactionList = function (reverse, limit) 
  * @return {getTransactionList} Calls getTransactionList
  */
 TransactionPool.prototype.getQueuedTransactionList = function (reverse, limit) {
-  return __private.getTransactionList(self.queued.transactions, reverse, limit);
+  return __private.getTransactionList(self.queued, reverse, limit);
 };
 
 /**
@@ -185,11 +181,11 @@ TransactionPool.prototype.getQueuedTransactionList = function (reverse, limit) {
  */
 TransactionPool.prototype.getMultisignatureTransactionList = function (reverse, ready, limit) {
   if (ready) {
-    return __private.getTransactionList(self.multisignature.transactions, reverse).filter(function (transaction) {
+    return __private.getTransactionList(self.multisignature, reverse).filter(function (transaction) {
       return transaction.ready;
     });
   } else {
-    return __private.getTransactionList(self.multisignature.transactions, reverse, limit);
+    return __private.getTransactionList(self.multisignature, reverse, limit);
   }
 };
 
@@ -235,9 +231,8 @@ TransactionPool.prototype.addUnconfirmedTransaction = function (transaction) {
     self.removeQueuedTransaction(transaction.id);
   }
 
-  if (self.unconfirmed.index[transaction.id] === undefined) {
-    const index = self.unconfirmed.transactions.push(transaction) - 1;
-    self.unconfirmed.index[transaction.id] = index;
+  if (self.unconfirmed.get(transaction.id) === undefined) {
+    self.unconfirmed.set(transaction.id, transaction);
   }
 };
 /**
@@ -248,12 +243,7 @@ TransactionPool.prototype.addUnconfirmedTransaction = function (transaction) {
  * @param {string} id
  */
 TransactionPool.prototype.removeUnconfirmedTransaction = function (id) {
-  var index = self.unconfirmed.index[id];
-
-  if (index !== undefined) {
-    self.unconfirmed.transactions.splice(index, 1);
-    delete self.unconfirmed.index[id];
-  }
+  self.unconfirmed.delete(id);
 
   self.removeQueuedTransaction(id);
   self.removeMultisignatureTransaction(id);
@@ -264,7 +254,7 @@ TransactionPool.prototype.removeUnconfirmedTransaction = function (id) {
  * @return {number} unconfirmed length
  */
 TransactionPool.prototype.countUnconfirmed = function () {
-  return Object.keys(self.unconfirmed.index).length;
+  return self.unconfirmed.size;
 };
 
 /**
@@ -272,9 +262,8 @@ TransactionPool.prototype.countUnconfirmed = function () {
  * @param {transaction} transaction
  */
 TransactionPool.prototype.addBundledTransaction = function (transaction) {
-  if (self.bundled.index[transaction.id] === undefined) {
-    const index = self.bundled.transactions.push(transaction) - 1;
-    self.bundled.index[transaction.id] = index;
+  if (self.bundled.get(transaction.id) === undefined) {
+    self.bundled.set(transaction.id, transaction);
   }
 };
 
@@ -283,12 +272,7 @@ TransactionPool.prototype.addBundledTransaction = function (transaction) {
  * @param {string} id
  */
 TransactionPool.prototype.removeBundledTransaction = function (id) {
-  var index = self.bundled.index[id];
-
-  if (index !== undefined) {
-    self.bundled.transactions.splice(index, 1);
-    delete self.bundled.index[id];
-  }
+  self.bundled.delete(id);
 };
 
 /**
@@ -296,7 +280,7 @@ TransactionPool.prototype.removeBundledTransaction = function (id) {
  * @return {number} total bundled index
  */
 TransactionPool.prototype.countBundled = function () {
-  return Object.keys(self.bundled.index).length;
+  return self.bundled.size;
 };
 
 /**
@@ -304,9 +288,8 @@ TransactionPool.prototype.countBundled = function () {
  * @param {transaction} transaction
  */
 TransactionPool.prototype.addQueuedTransaction = function (transaction) {
-  if (self.queued.index[transaction.id] === undefined) {
-    const index = self.queued.transactions.push(transaction) - 1;
-    self.queued.index[transaction.id] = index;
+  if (self.queued.get(transaction.id) === undefined) {
+    self.queued.set(transaction.id, transaction);
   }
 };
 
@@ -315,12 +298,7 @@ TransactionPool.prototype.addQueuedTransaction = function (transaction) {
  * @param {string} id
  */
 TransactionPool.prototype.removeQueuedTransaction = function (id) {
-  var index = self.queued.index[id];
-
-  if (index !== undefined) {
-    self.queued.transactions.splice(index, 1);
-    delete self.queued.index[id];
-  }
+  self.queued.delete(id);
 };
 
 /**
@@ -328,7 +306,7 @@ TransactionPool.prototype.removeQueuedTransaction = function (id) {
  * @return {number} total queued index
  */
 TransactionPool.prototype.countQueued = function () {
-  return Object.keys(self.queued.index).length;
+  return self.queued.size;
 };
 
 /**
@@ -336,9 +314,8 @@ TransactionPool.prototype.countQueued = function () {
  * @param {transaction} transaction
  */
 TransactionPool.prototype.addMultisignatureTransaction = function (transaction) {
-  if (self.multisignature.index[transaction.id] === undefined) {
-    const index = self.multisignature.transactions.push(transaction) - 1;
-    self.multisignature.index[transaction.id] = index;
+  if (self.multisignature.get(transaction.id) === undefined) {
+    self.multisignature.set(transaction.id, transaction);
   }
 };
 
@@ -347,12 +324,7 @@ TransactionPool.prototype.addMultisignatureTransaction = function (transaction) 
  * @param {string} id
  */
 TransactionPool.prototype.removeMultisignatureTransaction = function (id) {
-  var index = self.multisignature.index[id];
-
-  if (index !== undefined) {
-    self.multisignature.transactions.splice(index, 1);
-    delete self.multisignature.index[id];
-  }
+  self.multisignature.delete(id);
 };
 
 /**
@@ -360,7 +332,7 @@ TransactionPool.prototype.removeMultisignatureTransaction = function (id) {
  * @return {number} total multisignature index
  */
 TransactionPool.prototype.countMultisignature = function () {
-  return Object.keys(self.multisignature.index).length;
+  return self.multisignature.size;
 };
 
 /**
@@ -376,21 +348,6 @@ TransactionPool.prototype.receiveTransactions = function (transactions, broadcas
     self.processUnconfirmedTransaction(transaction, broadcast, cb);
   }, function (err) {
     return setImmediate(cb, err, transactions);
-  });
-};
-
-/**
- * Regenerates indexes for all queues: bundled, queued,
- * multisignature and unconfirmed.
- */
-TransactionPool.prototype.reindexQueues = function () {
-  ['bundled', 'queued', 'multisignature', 'unconfirmed'].forEach(function (queue) {
-    self[queue].index = {};
-    self[queue].transactions = self[queue].transactions.filter(Boolean);
-    self[queue].transactions.forEach(function (transaction) {
-      const index = self[queue].transactions.findIndex((tx) => tx.id === transaction.id);
-      self[queue].index[transaction.id] = index;
-    });
   });
 };
 
@@ -441,7 +398,6 @@ TransactionPool.prototype.processBundled = function (cb) {
  * If transaction bundled, calls queue transaction.
  * Calls processVerifyTransaction.
  * @implements {transactionInPool}
- * @implements {reindexQueues}
  * @implements {queueTransaction}
  * @implements {processVerifyTransaction}
  * @param {transaction} transaction
@@ -452,12 +408,6 @@ TransactionPool.prototype.processBundled = function (cb) {
 TransactionPool.prototype.processUnconfirmedTransaction = function (transaction, broadcast, cb) {
   if (self.transactionInPool(transaction.id)) {
     return setImmediate(cb, 'Transaction is already processed: ' + transaction.id);
-  } else {
-    self.processed++;
-    if (self.processed > 1000) {
-      self.reindexQueues();
-      self.processed = 1;
-    }
   }
 
   if (transaction.bundled) {
@@ -639,15 +589,7 @@ TransactionPool.prototype.fillPool = function (cb) {
  * @return {transaction[]}
  */
 __private.getTransactionList = function (transactions, reverse, limit) {
-  var a = [];
-
-  for (var i = 0; i < transactions.length; i++) {
-    var transaction = transactions[i];
-
-    if (transaction !== false) {
-      a.push(transaction);
-    }
-  }
+  let a = Array.from(transactions.values());
 
   a = reverse ? a.reverse() : a;
 

--- a/logic/transactionPool.js
+++ b/logic/transactionPool.js
@@ -393,8 +393,6 @@ TransactionPool.prototype.processBundled = function (cb) {
 };
 
 /**
- * If transaction is not already processed and processed is greater than 1000,
- * calls reindex queues.
  * If transaction bundled, calls queue transaction.
  * Calls processVerifyTransaction.
  * @implements {transactionInPool}

--- a/logic/transactionPool.js
+++ b/logic/transactionPool.js
@@ -236,8 +236,7 @@ TransactionPool.prototype.addUnconfirmedTransaction = function (transaction) {
   }
 
   if (self.unconfirmed.index[transaction.id] === undefined) {
-    self.unconfirmed.transactions.push(transaction);
-    var index = self.unconfirmed.transactions.indexOf(transaction);
+    const index = self.unconfirmed.transactions.push(transaction) - 1;
     self.unconfirmed.index[transaction.id] = index;
   }
 };
@@ -252,7 +251,7 @@ TransactionPool.prototype.removeUnconfirmedTransaction = function (id) {
   var index = self.unconfirmed.index[id];
 
   if (index !== undefined) {
-    self.unconfirmed.transactions[index] = false;
+    self.unconfirmed.transactions.splice(index, 1);
     delete self.unconfirmed.index[id];
   }
 
@@ -274,8 +273,7 @@ TransactionPool.prototype.countUnconfirmed = function () {
  */
 TransactionPool.prototype.addBundledTransaction = function (transaction) {
   if (self.bundled.index[transaction.id] === undefined) {
-    self.bundled.transactions.push(transaction);
-    var index = self.bundled.transactions.indexOf(transaction);
+    const index = self.bundled.transactions.push(transaction) - 1;
     self.bundled.index[transaction.id] = index;
   }
 };
@@ -288,7 +286,7 @@ TransactionPool.prototype.removeBundledTransaction = function (id) {
   var index = self.bundled.index[id];
 
   if (index !== undefined) {
-    self.bundled.transactions[index] = false;
+    self.bundled.transactions.splice(index, 1);
     delete self.bundled.index[id];
   }
 };
@@ -307,8 +305,7 @@ TransactionPool.prototype.countBundled = function () {
  */
 TransactionPool.prototype.addQueuedTransaction = function (transaction) {
   if (self.queued.index[transaction.id] === undefined) {
-    self.queued.transactions.push(transaction);
-    var index = self.queued.transactions.indexOf(transaction);
+    const index = self.queued.transactions.push(transaction) - 1;
     self.queued.index[transaction.id] = index;
   }
 };
@@ -321,7 +318,7 @@ TransactionPool.prototype.removeQueuedTransaction = function (id) {
   var index = self.queued.index[id];
 
   if (index !== undefined) {
-    self.queued.transactions[index] = false;
+    self.queued.transactions.splice(index, 1);
     delete self.queued.index[id];
   }
 };
@@ -340,8 +337,7 @@ TransactionPool.prototype.countQueued = function () {
  */
 TransactionPool.prototype.addMultisignatureTransaction = function (transaction) {
   if (self.multisignature.index[transaction.id] === undefined) {
-    self.multisignature.transactions.push(transaction);
-    var index = self.multisignature.transactions.indexOf(transaction);
+    const index = self.multisignature.transactions.push(transaction) - 1;
     self.multisignature.index[transaction.id] = index;
   }
 };
@@ -354,7 +350,7 @@ TransactionPool.prototype.removeMultisignatureTransaction = function (id) {
   var index = self.multisignature.index[id];
 
   if (index !== undefined) {
-    self.multisignature.transactions[index] = false;
+    self.multisignature.transactions.splice(index, 1);
     delete self.multisignature.index[id];
   }
 };
@@ -392,7 +388,7 @@ TransactionPool.prototype.reindexQueues = function () {
     self[queue].index = {};
     self[queue].transactions = self[queue].transactions.filter(Boolean);
     self[queue].transactions.forEach(function (transaction) {
-      var index = self[queue].transactions.indexOf(transaction);
+      const index = self[queue].transactions.findIndex((tx) => tx.id === transaction.id);
       self[queue].index[transaction.id] = index;
     });
   });

--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -965,9 +965,9 @@ Transactions.prototype.shared = {
     library.db.query(sql.count).then(function (transactionsCount) {
       return setImmediate(cb, null, {
         confirmed: transactionsCount[0].count,
-        multisignature: __private.transactionPool.multisignature.transactions.length,
-        unconfirmed: __private.transactionPool.unconfirmed.transactions.length,
-        queued: __private.transactionPool.queued.transactions.length
+        multisignature: __private.transactionPool.countMultisignature(),
+        unconfirmed: __private.transactionPool.countUnconfirmed(),
+        queued: __private.transactionPool.countQueued()
       });
     }, function (err) {
       return setImmediate(cb, 'Unable to count transactions');

--- a/test/unit/logic/transactionPool.js
+++ b/test/unit/logic/transactionPool.js
@@ -1,269 +1,327 @@
-
 const { expect } = require('chai');
 const { removeQueuedJobs } = require('../../common/globalAfter.js');
 
 const TransactionPool = require('../../../logic/transactionPool.js');
 
 describe('TransactionPool', () => {
-	let transactionPool;
+  let transactionPool;
 
-	const singleTransaction = {
-		id: '17190511997607511181',
-		senderPublicKey: '108f664525da4610f54d6c366a1533fef081ca0eb322c470efb29c0bd250d0a0',
-		receivedAt: new Date(),
-	};
+  const singleTransaction = {
+    id: '17190511997607511181',
+    senderPublicKey:
+      '108f664525da4610f54d6c366a1533fef081ca0eb322c470efb29c0bd250d0a0',
+    receivedAt: new Date(),
+  };
 
-	const someTransactions = [
-		{
-			id: '16207561138663598511',
-			senderPublicKey: 'b80bb6459608dcdeb9a98d1f2b0111b2bf11e53ef2933e6769bb0198e3a97aae',
-			receivedAt: new Date(),
-		},
-		{
-			id: '8787084714365585523',
-			senderPublicKey: 'b0b4d346382aa07b23c0b733d040424532201b9eb22004b66a79d4b44e9d1449',
-			receivedAt: new Date(),
-		},
-		{
-			id: '14422771217432719682',
-			senderPublicKey: 'cef765962b59710195fe09f1f7fa6968dd0f12324447c0ce62779c8f7fefd5fb',
-			receivedAt: new Date(),
-		},
-	];
+  const someTransactions = [
+    {
+      id: '16207561138663598511',
+      senderPublicKey:
+        'b80bb6459608dcdeb9a98d1f2b0111b2bf11e53ef2933e6769bb0198e3a97aae',
+      receivedAt: new Date(),
+    },
+    {
+      id: '8787084714365585523',
+      senderPublicKey:
+        'b0b4d346382aa07b23c0b733d040424532201b9eb22004b66a79d4b44e9d1449',
+      receivedAt: new Date(),
+    },
+    {
+      id: '14422771217432719682',
+      senderPublicKey:
+        'cef765962b59710195fe09f1f7fa6968dd0f12324447c0ce62779c8f7fefd5fb',
+      receivedAt: new Date(),
+    },
+  ];
 
-	beforeEach(() => removeQueuedJobs());
+  beforeEach(() => removeQueuedJobs());
 
-	beforeEach(() => {
-		transactionPool = new TransactionPool(1000, 10, {}, { message: () => {} }, console);
-	});
+  beforeEach(() => {
+    transactionPool = new TransactionPool(
+      1000,
+      10,
+      {},
+      { message: () => {} },
+      console
+    );
+  });
 
-	afterEach(() => removeQueuedJobs());
+  afterEach(() => removeQueuedJobs());
 
-	describe('addUnconfirmedTransaction()', () => {
-		it('should add a new transaction in empty list', () => {
-			expect(transactionPool.getUnconfirmedTransactionList()).to.be.empty;
+  describe('addUnconfirmedTransaction()', () => {
+    it('should add a new transaction in empty list', () => {
+      expect(transactionPool.getUnconfirmedTransactionList()).to.be.empty;
 
-			transactionPool.addUnconfirmedTransaction(singleTransaction);
-			expect(transactionPool.getUnconfirmedTransactionList()).to.eql([singleTransaction]);
-		});
+      transactionPool.addUnconfirmedTransaction(singleTransaction);
+      expect(transactionPool.getUnconfirmedTransactionList()).to.eql([
+        singleTransaction,
+      ]);
+    });
 
-		it('should add new transactions and not duplicate them', () => {
-			transactionPool.addUnconfirmedTransaction(singleTransaction);
-			transactionPool.addUnconfirmedTransaction(singleTransaction);
-			expect(transactionPool.getUnconfirmedTransactionList()).to.have.lengthOf(1);
+    it('should add new transactions and not duplicate them', () => {
+      transactionPool.addUnconfirmedTransaction(singleTransaction);
+      transactionPool.addUnconfirmedTransaction(singleTransaction);
+      expect(transactionPool.getUnconfirmedTransactionList()).to.have.lengthOf(
+        1
+      );
 
-			someTransactions.forEach(trx => transactionPool.addUnconfirmedTransaction(trx));
-			expect(transactionPool.getUnconfirmedTransactionList()).to.have.lengthOf(1 + someTransactions.length);
-		});
-	});
+      someTransactions.forEach((trx) =>
+        transactionPool.addUnconfirmedTransaction(trx)
+      );
+      expect(transactionPool.getUnconfirmedTransactionList()).to.have.lengthOf(
+        1 + someTransactions.length
+      );
+    });
+  });
 
-	describe('removeUnconfirmedTransaction()', () => {
-		it('should remove an existing transaction by ID', () => {
-			transactionPool.addUnconfirmedTransaction(singleTransaction);
-			expect(transactionPool.getUnconfirmedTransaction(singleTransaction.id)).to.eql(singleTransaction);
+  describe('removeUnconfirmedTransaction()', () => {
+    it('should remove an existing transaction by ID', () => {
+      transactionPool.addUnconfirmedTransaction(singleTransaction);
+      expect(
+        transactionPool.getUnconfirmedTransaction(singleTransaction.id)
+      ).to.eql(singleTransaction);
 
-			transactionPool.removeUnconfirmedTransaction(singleTransaction.id);
-			expect(transactionPool.getUnconfirmedTransaction(singleTransaction.id)).to.be.undefined;
-			expect(transactionPool.getUnconfirmedTransactionList()).to.be.empty;
-		});
+      transactionPool.removeUnconfirmedTransaction(singleTransaction.id);
+      expect(transactionPool.getUnconfirmedTransaction(singleTransaction.id)).to
+        .be.undefined;
+      expect(transactionPool.getUnconfirmedTransactionList()).to.be.empty;
+    });
 
-		it('should remove just one transaction from a bigger list', () => {
-			[singleTransaction, ...someTransactions].forEach(trx => transactionPool.addUnconfirmedTransaction(trx));
-			expect(transactionPool.getUnconfirmedTransactionList()).to.have.lengthOf(1 + someTransactions.length);
+    it('should remove just one transaction from a bigger list', () => {
+      [singleTransaction, ...someTransactions].forEach((trx) =>
+        transactionPool.addUnconfirmedTransaction(trx)
+      );
+      expect(transactionPool.getUnconfirmedTransactionList()).to.have.lengthOf(
+        1 + someTransactions.length
+      );
 
-			transactionPool.removeUnconfirmedTransaction(someTransactions[1].id);
+      transactionPool.removeUnconfirmedTransaction(someTransactions[1].id);
 
-			const remaining = transactionPool.getUnconfirmedTransactionList();
-			expect(remaining).to.not.include(someTransactions[1]);
-			expect(remaining).to.include(someTransactions[0]);
-			expect(remaining).to.include(singleTransaction);
-		});
-	});
+      const remaining = transactionPool.getUnconfirmedTransactionList();
+      expect(remaining).to.not.include(someTransactions[1]);
+      expect(remaining).to.include(someTransactions[0]);
+      expect(remaining).to.include(singleTransaction);
+    });
+  });
 
-	describe('transactionInPool()', () => {
-		it('should return false when the pool is empty', () => {
-			expect(transactionPool.transactionInPool(singleTransaction.id)).to.be.false;
-		});
+  describe('transactionInPool()', () => {
+    it('should return false when the pool is empty', () => {
+      expect(transactionPool.transactionInPool(singleTransaction.id)).to.be
+        .false;
+    });
 
-		it('should return true for unconfirmed transactions in the pool', () => {
-			transactionPool.addUnconfirmedTransaction(singleTransaction);
-			expect(transactionPool.transactionInPool(singleTransaction.id)).to.be.true;
-		});
+    it('should return true for unconfirmed transactions in the pool', () => {
+      transactionPool.addUnconfirmedTransaction(singleTransaction);
+      expect(transactionPool.transactionInPool(singleTransaction.id)).to.be
+        .true;
+    });
 
-		it('should return true for bundled transactions in the pool', () => {
-			transactionPool.addBundledTransaction(singleTransaction);
-			expect(transactionPool.transactionInPool(singleTransaction.id)).to.be.true;
-		});
+    it('should return true for bundled transactions in the pool', () => {
+      transactionPool.addBundledTransaction(singleTransaction);
+      expect(transactionPool.transactionInPool(singleTransaction.id)).to.be
+        .true;
+    });
 
-		it('should return true for queued transactions in the pool', () => {
-			transactionPool.addQueuedTransaction(singleTransaction);
-			expect(transactionPool.transactionInPool(singleTransaction.id)).to.be.true;
-		});
+    it('should return true for queued transactions in the pool', () => {
+      transactionPool.addQueuedTransaction(singleTransaction);
+      expect(transactionPool.transactionInPool(singleTransaction.id)).to.be
+        .true;
+    });
 
-		it('should return true for multisignature transactions in the pool', () => {
-			transactionPool.addMultisignatureTransaction(singleTransaction);
-			expect(transactionPool.transactionInPool(singleTransaction.id)).to.be.true;
-		});
-	});
+    it('should return true for multisignature transactions in the pool', () => {
+      transactionPool.addMultisignatureTransaction(singleTransaction);
+      expect(transactionPool.transactionInPool(singleTransaction.id)).to.be
+        .true;
+    });
+  });
 
-	describe('Bundled transactions', () => {
-		describe('addBundledTransaction()', () => {
-			it('should add a bundled transaction', () => {
-				expect(transactionPool.countBundled()).to.equal(0);
-				transactionPool.addBundledTransaction(singleTransaction);
-				expect(transactionPool.countBundled()).to.equal(1);
-				expect(transactionPool.getBundledTransactionList()).to.eql([singleTransaction]);
-			});
+  describe('Bundled transactions', () => {
+    describe('addBundledTransaction()', () => {
+      it('should add a bundled transaction', () => {
+        expect(transactionPool.countBundled()).to.equal(0);
+        transactionPool.addBundledTransaction(singleTransaction);
+        expect(transactionPool.countBundled()).to.equal(1);
+        expect(transactionPool.getBundledTransactionList()).to.eql([
+          singleTransaction,
+        ]);
+      });
 
-			it('should not add the same bundled transaction twice', () => {
-				transactionPool.addBundledTransaction(singleTransaction);
-				transactionPool.addBundledTransaction(singleTransaction);
-				expect(transactionPool.countBundled()).to.equal(1);
-			});
-		});
+      it('should not add the same bundled transaction twice', () => {
+        transactionPool.addBundledTransaction(singleTransaction);
+        transactionPool.addBundledTransaction(singleTransaction);
+        expect(transactionPool.countBundled()).to.equal(1);
+      });
+    });
 
-		describe('removeBundledTransaction()', () => {
-			it('should remove an existing bundled transaction by ID', () => {
-				transactionPool.addBundledTransaction(singleTransaction);
-				expect(transactionPool.countBundled()).to.equal(1);
+    describe('removeBundledTransaction()', () => {
+      it('should remove an existing bundled transaction by ID', () => {
+        transactionPool.addBundledTransaction(singleTransaction);
+        expect(transactionPool.countBundled()).to.equal(1);
 
-				transactionPool.removeBundledTransaction(singleTransaction.id);
-				expect(transactionPool.countBundled()).to.equal(0);
-				expect(transactionPool.getBundledTransactionList()).to.eql([]);
-			});
-		});
+        transactionPool.removeBundledTransaction(singleTransaction.id);
+        expect(transactionPool.countBundled()).to.equal(0);
+        expect(transactionPool.getBundledTransactionList()).to.eql([]);
+      });
+    });
 
-		describe('getBundledTransactionList()', () => {
-			it('should return an empty list if none are bundled', () => {
-				expect(transactionPool.getBundledTransactionList()).to.be.empty;
-			});
+    describe('getBundledTransactionList()', () => {
+      it('should return an empty list if none are bundled', () => {
+        expect(transactionPool.getBundledTransactionList()).to.be.empty;
+      });
 
-			it('should retrieve a reversed sub-list', () => {
-				someTransactions.forEach(tx => transactionPool.addBundledTransaction(tx));
+      it('should retrieve a reversed sub-list', () => {
+        someTransactions.forEach((tx) =>
+          transactionPool.addBundledTransaction(tx)
+        );
 
-				const normalOrder = transactionPool.getBundledTransactionList(false);
-				expect(normalOrder).to.eql(someTransactions);
+        const normalOrder = transactionPool.getBundledTransactionList(false);
+        expect(normalOrder).to.eql(someTransactions);
 
-				const reversed = transactionPool.getBundledTransactionList(true);
-				expect(reversed).to.eql([...someTransactions].reverse());
+        const reversed = transactionPool.getBundledTransactionList(true);
+        expect(reversed).to.eql([...someTransactions].reverse());
 
-				const limited = transactionPool.getBundledTransactionList(false, 2);
-				expect(limited).to.have.lengthOf(2);
-				expect(limited).to.eql(someTransactions.slice(0, 2));
-			});
-		});
-	});
+        const limited = transactionPool.getBundledTransactionList(false, 2);
+        expect(limited).to.have.lengthOf(2);
+        expect(limited).to.eql(someTransactions.slice(0, 2));
+      });
+    });
+  });
 
-	describe('Queued transactions', () => {
-		describe('addQueuedTransaction()', () => {
-			it('should add a queued transaction', () => {
-				expect(transactionPool.countQueued()).to.equal(0);
-				transactionPool.addQueuedTransaction(singleTransaction);
-				expect(transactionPool.countQueued()).to.equal(1);
-				expect(transactionPool.getQueuedTransactionList()).to.eql([singleTransaction]);
-			});
+  describe('Queued transactions', () => {
+    describe('addQueuedTransaction()', () => {
+      it('should add a queued transaction', () => {
+        expect(transactionPool.countQueued()).to.equal(0);
+        transactionPool.addQueuedTransaction(singleTransaction);
+        expect(transactionPool.countQueued()).to.equal(1);
+        expect(transactionPool.getQueuedTransactionList()).to.eql([
+          singleTransaction,
+        ]);
+      });
 
-			it('should not add the same queued transaction twice', () => {
-				transactionPool.addQueuedTransaction(singleTransaction);
-				transactionPool.addQueuedTransaction(singleTransaction);
-				expect(transactionPool.countQueued()).to.equal(1);
-			});
-		});
+      it('should not add the same queued transaction twice', () => {
+        transactionPool.addQueuedTransaction(singleTransaction);
+        transactionPool.addQueuedTransaction(singleTransaction);
+        expect(transactionPool.countQueued()).to.equal(1);
+      });
+    });
 
-		describe('removeQueuedTransaction()', () => {
-			it('should remove the queued transaction by ID', () => {
-				transactionPool.addQueuedTransaction(singleTransaction);
-				expect(transactionPool.countQueued()).to.equal(1);
+    describe('removeQueuedTransaction()', () => {
+      it('should remove the queued transaction by ID', () => {
+        transactionPool.addQueuedTransaction(singleTransaction);
+        expect(transactionPool.countQueued()).to.equal(1);
 
-				transactionPool.removeQueuedTransaction(singleTransaction.id);
-				expect(transactionPool.countQueued()).to.equal(0);
-			});
-		});
+        transactionPool.removeQueuedTransaction(singleTransaction.id);
+        expect(transactionPool.countQueued()).to.equal(0);
+      });
+    });
 
-		describe('getQueuedTransactionList()', () => {
-			it('should return an empty list if none are queued', () => {
-				expect(transactionPool.getQueuedTransactionList()).to.be.empty;
-			});
+    describe('getQueuedTransactionList()', () => {
+      it('should return an empty list if none are queued', () => {
+        expect(transactionPool.getQueuedTransactionList()).to.be.empty;
+      });
 
-			it('should retrieve a reversed sub-list', () => {
-				someTransactions.forEach(tx => transactionPool.addQueuedTransaction(tx));
+      it('should retrieve a reversed sub-list', () => {
+        someTransactions.forEach((tx) =>
+          transactionPool.addQueuedTransaction(tx)
+        );
 
-				const normalOrder = transactionPool.getQueuedTransactionList(false);
-				expect(normalOrder).to.eql(someTransactions);
+        const normalOrder = transactionPool.getQueuedTransactionList(false);
+        expect(normalOrder).to.eql(someTransactions);
 
-				const reversed = transactionPool.getQueuedTransactionList(true);
-				expect(reversed).to.eql([...someTransactions].reverse());
+        const reversed = transactionPool.getQueuedTransactionList(true);
+        expect(reversed).to.eql([...someTransactions].reverse());
 
-				const limited = transactionPool.getQueuedTransactionList(false, 2);
-				expect(limited).to.have.lengthOf(2);
-				expect(limited).to.eql(someTransactions.slice(0, 2));
-			});
-		});
-	});
+        const limited = transactionPool.getQueuedTransactionList(false, 2);
+        expect(limited).to.have.lengthOf(2);
+        expect(limited).to.eql(someTransactions.slice(0, 2));
+      });
+    });
+  });
 
-	describe('Multisignature transactions', () => {
-		describe('addMultisignatureTransaction()', () => {
-			it('should add a multisignature transaction', () => {
-				expect(transactionPool.countMultisignature()).to.equal(0);
-				transactionPool.addMultisignatureTransaction(singleTransaction);
-				expect(transactionPool.countMultisignature()).to.equal(1);
-			});
+  describe('Multisignature transactions', () => {
+    describe('addMultisignatureTransaction()', () => {
+      it('should add a multisignature transaction', () => {
+        expect(transactionPool.countMultisignature()).to.equal(0);
+        transactionPool.addMultisignatureTransaction(singleTransaction);
+        expect(transactionPool.countMultisignature()).to.equal(1);
+      });
 
-			it('should not add the same multisignature transaction twice', () => {
-				transactionPool.addMultisignatureTransaction(singleTransaction);
-				transactionPool.addMultisignatureTransaction(singleTransaction);
-				expect(transactionPool.countMultisignature()).to.equal(1);
-			});
-		});
+      it('should not add the same multisignature transaction twice', () => {
+        transactionPool.addMultisignatureTransaction(singleTransaction);
+        transactionPool.addMultisignatureTransaction(singleTransaction);
+        expect(transactionPool.countMultisignature()).to.equal(1);
+      });
+    });
 
-		describe('removeMultisignatureTransaction()', () => {
-			it('should remove the multisignature transaction by ID', () => {
-				transactionPool.addMultisignatureTransaction(singleTransaction);
-				expect(transactionPool.countMultisignature()).to.equal(1);
+    describe('removeMultisignatureTransaction()', () => {
+      it('should remove the multisignature transaction by ID', () => {
+        transactionPool.addMultisignatureTransaction(singleTransaction);
+        expect(transactionPool.countMultisignature()).to.equal(1);
 
-				transactionPool.removeMultisignatureTransaction(singleTransaction.id);
-				expect(transactionPool.countMultisignature()).to.equal(0);
-			});
-		});
+        transactionPool.removeMultisignatureTransaction(singleTransaction.id);
+        expect(transactionPool.countMultisignature()).to.equal(0);
+      });
+    });
 
-		describe('getMultisignatureTransactionList()', () => {
-			it('should return an empty list if none are multisignature', () => {
-				expect(transactionPool.getMultisignatureTransactionList(false, false)).to.be.empty;
-			});
+    describe('getMultisignatureTransactionList()', () => {
+      it('should return an empty list if none are multisignature', () => {
+        expect(transactionPool.getMultisignatureTransactionList(false, false))
+          .to.be.empty;
+      });
 
-			it('should retrieve a reversed sub-list', () => {
-				someTransactions.forEach(tx => transactionPool.addMultisignatureTransaction(tx));
+      it('should retrieve a reversed sub-list', () => {
+        someTransactions.forEach((tx) =>
+          transactionPool.addMultisignatureTransaction(tx)
+        );
 
-				const normalOrder = transactionPool.getMultisignatureTransactionList(false, false);
-				expect(normalOrder).to.eql(someTransactions);
+        const normalOrder = transactionPool.getMultisignatureTransactionList(
+          false,
+          false
+        );
+        expect(normalOrder).to.eql(someTransactions);
 
-				const reversed = transactionPool.getMultisignatureTransactionList(true, false);
-				expect(reversed).to.eql([...someTransactions].reverse());
-			});
+        const reversed = transactionPool.getMultisignatureTransactionList(
+          true,
+          false
+        );
+        expect(reversed).to.eql([...someTransactions].reverse());
+      });
 
-			it('should filter out only `ready` multisignature transactions', () => {
-				const multiTxs = [
-					{ id: someTransactions[0].id, ready: false },
-					{ id: someTransactions[1].id, ready: true },
-					{ id: someTransactions[2].id, ready: true },
-				];
-				multiTxs.forEach(tx => transactionPool.addMultisignatureTransaction(tx));
+      it('should filter out only `ready` multisignature transactions', () => {
+        const multiTxs = [
+          { id: someTransactions[0].id, ready: false },
+          { id: someTransactions[1].id, ready: true },
+          { id: someTransactions[2].id, ready: true },
+        ];
+        multiTxs.forEach((tx) =>
+          transactionPool.addMultisignatureTransaction(tx)
+        );
 
-				const readyOnly = transactionPool.getMultisignatureTransactionList(false, true);
-				expect(readyOnly).to.have.lengthOf(2);
-				expect(readyOnly.map(t => t.id)).to.eql([someTransactions[1].id, someTransactions[2].id]);
-			});
-		});
-	});
+        const readyOnly = transactionPool.getMultisignatureTransactionList(
+          false,
+          true
+        );
+        expect(readyOnly).to.have.lengthOf(2);
+        expect(readyOnly.map((t) => t.id)).to.eql([
+          someTransactions[1].id,
+          someTransactions[2].id,
+        ]);
+      });
+    });
+  });
 
-	describe('countUnconfirmed()', () => {
-		it('should return 0 when there are no unconfirmed transactions', () => {
-			expect(transactionPool.countUnconfirmed()).to.equal(0);
-		});
+  describe('countUnconfirmed()', () => {
+    it('should return 0 when there are no unconfirmed transactions', () => {
+      expect(transactionPool.countUnconfirmed()).to.equal(0);
+    });
 
-		it('should return correct count for unconfirmed transactions', () => {
-			someTransactions.forEach(tx => transactionPool.addUnconfirmedTransaction(tx));
-			expect(transactionPool.countUnconfirmed()).to.equal(someTransactions.length);
-		});
-	});
+    it('should return correct count for unconfirmed transactions', () => {
+      someTransactions.forEach((tx) =>
+        transactionPool.addUnconfirmedTransaction(tx)
+      );
+      expect(transactionPool.countUnconfirmed()).to.equal(
+        someTransactions.length
+      );
+    });
+  });
 });

--- a/test/unit/logic/transactionPool.js
+++ b/test/unit/logic/transactionPool.js
@@ -1,0 +1,269 @@
+
+const { expect } = require('chai');
+const { removeQueuedJobs } = require('../../common/globalAfter.js');
+
+const TransactionPool = require('../../../logic/transactionPool.js');
+
+describe('TransactionPool', () => {
+	let transactionPool;
+
+	const singleTransaction = {
+		id: '17190511997607511181',
+		senderPublicKey: '108f664525da4610f54d6c366a1533fef081ca0eb322c470efb29c0bd250d0a0',
+		receivedAt: new Date(),
+	};
+
+	const someTransactions = [
+		{
+			id: '16207561138663598511',
+			senderPublicKey: 'b80bb6459608dcdeb9a98d1f2b0111b2bf11e53ef2933e6769bb0198e3a97aae',
+			receivedAt: new Date(),
+		},
+		{
+			id: '8787084714365585523',
+			senderPublicKey: 'b0b4d346382aa07b23c0b733d040424532201b9eb22004b66a79d4b44e9d1449',
+			receivedAt: new Date(),
+		},
+		{
+			id: '14422771217432719682',
+			senderPublicKey: 'cef765962b59710195fe09f1f7fa6968dd0f12324447c0ce62779c8f7fefd5fb',
+			receivedAt: new Date(),
+		},
+	];
+
+	beforeEach(() => removeQueuedJobs());
+
+	beforeEach(() => {
+		transactionPool = new TransactionPool(1000, 10, {}, { message: () => {} }, console);
+	});
+
+	afterEach(() => removeQueuedJobs());
+
+	describe('addUnconfirmedTransaction()', () => {
+		it('should add a new transaction in empty list', () => {
+			expect(transactionPool.getUnconfirmedTransactionList()).to.be.empty;
+
+			transactionPool.addUnconfirmedTransaction(singleTransaction);
+			expect(transactionPool.getUnconfirmedTransactionList()).to.eql([singleTransaction]);
+		});
+
+		it('should add new transactions and not duplicate them', () => {
+			transactionPool.addUnconfirmedTransaction(singleTransaction);
+			transactionPool.addUnconfirmedTransaction(singleTransaction);
+			expect(transactionPool.getUnconfirmedTransactionList()).to.have.lengthOf(1);
+
+			someTransactions.forEach(trx => transactionPool.addUnconfirmedTransaction(trx));
+			expect(transactionPool.getUnconfirmedTransactionList()).to.have.lengthOf(1 + someTransactions.length);
+		});
+	});
+
+	describe('removeUnconfirmedTransaction()', () => {
+		it('should remove an existing transaction by ID', () => {
+			transactionPool.addUnconfirmedTransaction(singleTransaction);
+			expect(transactionPool.getUnconfirmedTransaction(singleTransaction.id)).to.eql(singleTransaction);
+
+			transactionPool.removeUnconfirmedTransaction(singleTransaction.id);
+			expect(transactionPool.getUnconfirmedTransaction(singleTransaction.id)).to.be.undefined;
+			expect(transactionPool.getUnconfirmedTransactionList()).to.be.empty;
+		});
+
+		it('should remove just one transaction from a bigger list', () => {
+			[singleTransaction, ...someTransactions].forEach(trx => transactionPool.addUnconfirmedTransaction(trx));
+			expect(transactionPool.getUnconfirmedTransactionList()).to.have.lengthOf(1 + someTransactions.length);
+
+			transactionPool.removeUnconfirmedTransaction(someTransactions[1].id);
+
+			const remaining = transactionPool.getUnconfirmedTransactionList();
+			expect(remaining).to.not.include(someTransactions[1]);
+			expect(remaining).to.include(someTransactions[0]);
+			expect(remaining).to.include(singleTransaction);
+		});
+	});
+
+	describe('transactionInPool()', () => {
+		it('should return false when the pool is empty', () => {
+			expect(transactionPool.transactionInPool(singleTransaction.id)).to.be.false;
+		});
+
+		it('should return true for unconfirmed transactions in the pool', () => {
+			transactionPool.addUnconfirmedTransaction(singleTransaction);
+			expect(transactionPool.transactionInPool(singleTransaction.id)).to.be.true;
+		});
+
+		it('should return true for bundled transactions in the pool', () => {
+			transactionPool.addBundledTransaction(singleTransaction);
+			expect(transactionPool.transactionInPool(singleTransaction.id)).to.be.true;
+		});
+
+		it('should return true for queued transactions in the pool', () => {
+			transactionPool.addQueuedTransaction(singleTransaction);
+			expect(transactionPool.transactionInPool(singleTransaction.id)).to.be.true;
+		});
+
+		it('should return true for multisignature transactions in the pool', () => {
+			transactionPool.addMultisignatureTransaction(singleTransaction);
+			expect(transactionPool.transactionInPool(singleTransaction.id)).to.be.true;
+		});
+	});
+
+	describe('Bundled transactions', () => {
+		describe('addBundledTransaction()', () => {
+			it('should add a bundled transaction', () => {
+				expect(transactionPool.countBundled()).to.equal(0);
+				transactionPool.addBundledTransaction(singleTransaction);
+				expect(transactionPool.countBundled()).to.equal(1);
+				expect(transactionPool.getBundledTransactionList()).to.eql([singleTransaction]);
+			});
+
+			it('should not add the same bundled transaction twice', () => {
+				transactionPool.addBundledTransaction(singleTransaction);
+				transactionPool.addBundledTransaction(singleTransaction);
+				expect(transactionPool.countBundled()).to.equal(1);
+			});
+		});
+
+		describe('removeBundledTransaction()', () => {
+			it('should remove an existing bundled transaction by ID', () => {
+				transactionPool.addBundledTransaction(singleTransaction);
+				expect(transactionPool.countBundled()).to.equal(1);
+
+				transactionPool.removeBundledTransaction(singleTransaction.id);
+				expect(transactionPool.countBundled()).to.equal(0);
+				expect(transactionPool.getBundledTransactionList()).to.eql([]);
+			});
+		});
+
+		describe('getBundledTransactionList()', () => {
+			it('should return an empty list if none are bundled', () => {
+				expect(transactionPool.getBundledTransactionList()).to.be.empty;
+			});
+
+			it('should retrieve a reversed sub-list', () => {
+				someTransactions.forEach(tx => transactionPool.addBundledTransaction(tx));
+
+				const normalOrder = transactionPool.getBundledTransactionList(false);
+				expect(normalOrder).to.eql(someTransactions);
+
+				const reversed = transactionPool.getBundledTransactionList(true);
+				expect(reversed).to.eql([...someTransactions].reverse());
+
+				const limited = transactionPool.getBundledTransactionList(false, 2);
+				expect(limited).to.have.lengthOf(2);
+				expect(limited).to.eql(someTransactions.slice(0, 2));
+			});
+		});
+	});
+
+	describe('Queued transactions', () => {
+		describe('addQueuedTransaction()', () => {
+			it('should add a queued transaction', () => {
+				expect(transactionPool.countQueued()).to.equal(0);
+				transactionPool.addQueuedTransaction(singleTransaction);
+				expect(transactionPool.countQueued()).to.equal(1);
+				expect(transactionPool.getQueuedTransactionList()).to.eql([singleTransaction]);
+			});
+
+			it('should not add the same queued transaction twice', () => {
+				transactionPool.addQueuedTransaction(singleTransaction);
+				transactionPool.addQueuedTransaction(singleTransaction);
+				expect(transactionPool.countQueued()).to.equal(1);
+			});
+		});
+
+		describe('removeQueuedTransaction()', () => {
+			it('should remove the queued transaction by ID', () => {
+				transactionPool.addQueuedTransaction(singleTransaction);
+				expect(transactionPool.countQueued()).to.equal(1);
+
+				transactionPool.removeQueuedTransaction(singleTransaction.id);
+				expect(transactionPool.countQueued()).to.equal(0);
+			});
+		});
+
+		describe('getQueuedTransactionList()', () => {
+			it('should return an empty list if none are queued', () => {
+				expect(transactionPool.getQueuedTransactionList()).to.be.empty;
+			});
+
+			it('should retrieve a reversed sub-list', () => {
+				someTransactions.forEach(tx => transactionPool.addQueuedTransaction(tx));
+
+				const normalOrder = transactionPool.getQueuedTransactionList(false);
+				expect(normalOrder).to.eql(someTransactions);
+
+				const reversed = transactionPool.getQueuedTransactionList(true);
+				expect(reversed).to.eql([...someTransactions].reverse());
+
+				const limited = transactionPool.getQueuedTransactionList(false, 2);
+				expect(limited).to.have.lengthOf(2);
+				expect(limited).to.eql(someTransactions.slice(0, 2));
+			});
+		});
+	});
+
+	describe('Multisignature transactions', () => {
+		describe('addMultisignatureTransaction()', () => {
+			it('should add a multisignature transaction', () => {
+				expect(transactionPool.countMultisignature()).to.equal(0);
+				transactionPool.addMultisignatureTransaction(singleTransaction);
+				expect(transactionPool.countMultisignature()).to.equal(1);
+			});
+
+			it('should not add the same multisignature transaction twice', () => {
+				transactionPool.addMultisignatureTransaction(singleTransaction);
+				transactionPool.addMultisignatureTransaction(singleTransaction);
+				expect(transactionPool.countMultisignature()).to.equal(1);
+			});
+		});
+
+		describe('removeMultisignatureTransaction()', () => {
+			it('should remove the multisignature transaction by ID', () => {
+				transactionPool.addMultisignatureTransaction(singleTransaction);
+				expect(transactionPool.countMultisignature()).to.equal(1);
+
+				transactionPool.removeMultisignatureTransaction(singleTransaction.id);
+				expect(transactionPool.countMultisignature()).to.equal(0);
+			});
+		});
+
+		describe('getMultisignatureTransactionList()', () => {
+			it('should return an empty list if none are multisignature', () => {
+				expect(transactionPool.getMultisignatureTransactionList(false, false)).to.be.empty;
+			});
+
+			it('should retrieve a reversed sub-list', () => {
+				someTransactions.forEach(tx => transactionPool.addMultisignatureTransaction(tx));
+
+				const normalOrder = transactionPool.getMultisignatureTransactionList(false, false);
+				expect(normalOrder).to.eql(someTransactions);
+
+				const reversed = transactionPool.getMultisignatureTransactionList(true, false);
+				expect(reversed).to.eql([...someTransactions].reverse());
+			});
+
+			it('should filter out only `ready` multisignature transactions', () => {
+				const multiTxs = [
+					{ id: someTransactions[0].id, ready: false },
+					{ id: someTransactions[1].id, ready: true },
+					{ id: someTransactions[2].id, ready: true },
+				];
+				multiTxs.forEach(tx => transactionPool.addMultisignatureTransaction(tx));
+
+				const readyOnly = transactionPool.getMultisignatureTransactionList(false, true);
+				expect(readyOnly).to.have.lengthOf(2);
+				expect(readyOnly.map(t => t.id)).to.eql([someTransactions[1].id, someTransactions[2].id]);
+			});
+		});
+	});
+
+	describe('countUnconfirmed()', () => {
+		it('should return 0 when there are no unconfirmed transactions', () => {
+			expect(transactionPool.countUnconfirmed()).to.equal(0);
+		});
+
+		it('should return correct count for unconfirmed transactions', () => {
+			someTransactions.forEach(tx => transactionPool.addUnconfirmedTransaction(tx));
+			expect(transactionPool.countUnconfirmed()).to.equal(someTransactions.length);
+		});
+	});
+});


### PR DESCRIPTION
Rewrite the transaction pool to use `Map()` instead of manually update "indexes" and arrays.