### PR TITLE
Feat/count as number

### DIFF
--- a/modules/chatrooms.js
+++ b/modules/chatrooms.js
@@ -292,7 +292,7 @@ __private.listMessages = function (filter, cb) {
     where: where,
     whereOr: whereOr
   }), params).then(function (rows) {
-    const count = rows.length ? Number(rows[0].count) : 0;
+    const count = rows.length ? rows[0].count : 0;
     library.db.query(sql.listMessages({
       where: where,
       whereOr: whereOr,
@@ -324,7 +324,7 @@ __private.listMessages = function (filter, cb) {
           { address: transactions[0].senderId, publicKey: transactions[0].senderPublicKey },
           { address: transactions[0].recipientId, publicKey: transactions[0].recipientPublicKey }
         ] : [],
-        count: String(count + unconfirmedTransactions.length)
+        count: count + unconfirmedTransactions.length
       };
       return setImmediate(cb, null, data);
     }).catch(function (err) {

--- a/modules/chatrooms.js
+++ b/modules/chatrooms.js
@@ -142,7 +142,7 @@ __private.listChats = function (filter, cb) {
     where: where,
     whereOr: whereOr
   }), params).then(function (rows) {
-    const count = rows.length ? Number(rows[0].count) : 0;
+    const count = rows.length ? rows[0].count : 0;
     library.db.query(sql.listChats({
       where: where,
       whereOr: whereOr,
@@ -180,7 +180,7 @@ __private.listChats = function (filter, cb) {
 
       const data = {
         chats: Object.values(chats),
-        count: String(count + unconfirmedTransactions.length)
+        count: count + unconfirmedTransactions.length
       };
       return setImmediate(cb, null, data);
     }).catch(function (err) {

--- a/modules/chats.js
+++ b/modules/chats.js
@@ -219,7 +219,7 @@ __private.list = function (filter, cb) {
   library.db.query(sql.countList({
     where: where
   }), params).then(function (rows) {
-    const count = rows.length ? Number(rows[0].count) : 0;
+    const count = rows.length ? rows[0].count : 0;
     library.db.query(sql.list({
       where: where,
       sortField: orderBy.sortField,
@@ -246,7 +246,7 @@ __private.list = function (filter, cb) {
 
       var data = {
         transactions: transactions,
-        count: String(count + unconfirmedTransactions.length)
+        count: count + unconfirmedTransactions.length
       };
 
       return setImmediate(cb, null, data);

--- a/modules/states.js
+++ b/modules/states.js
@@ -200,7 +200,7 @@ __private.list = function (filter, cb) {
   library.db.query(sql.countList({
     where: where
   }), params).then(function (rows) {
-    var count = rows.length ? Number(rows[0].count) : 0;
+    var count = rows.length ? rows[0].count : 0;
     library.db.query(sql.list({
       where: where,
       sortField: orderBy.sortField,
@@ -226,7 +226,7 @@ __private.list = function (filter, cb) {
 
       var data = {
         transactions: transactions,
-        count: String(count + unconfirmedTransactions.length)
+        count: count + unconfirmedTransactions.length
       };
 
       return setImmediate(cb, null, data);

--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -240,7 +240,7 @@ __private.list = function (filter, cb) {
     where: where,
     owner: owner
   }), params).then(function (rows) {
-    var count = rows.length ? Number(rows[0].count) : 0;
+    var count = rows.length ? rows[0].count : 0;
     var sql_method = 'list';
     if (filter.returnAsset) {
       sql_method = 'listFull';
@@ -274,7 +274,7 @@ __private.list = function (filter, cb) {
 
       var data = {
         transactions: transactions,
-        count: String(count + unconfirmedTransactions.length)
+        count: count + unconfirmedTransactions.length
       };
 
       return setImmediate(cb, null, data);

--- a/sql/chats.js
+++ b/sql/chats.js
@@ -24,7 +24,7 @@ var ChatsSql = {
 
   countList: function (params) {
     return [
-      'SELECT COUNT(1) FROM full_trs_list',
+      'SELECT COUNT(1)::INT FROM full_trs_list',
       (params.where.length ? 'WHERE ' + params.where.join(' AND ') : ''),
       ((params.whereOr && params.whereOr.length) ? 'AND (' + params.whereOr.join(' OR ') + ')' : ''),
       (params.sortField ? 'ORDER BY ' + [params.sortField, params.sortMethod].join(' ') : '')

--- a/sql/chats.js
+++ b/sql/chats.js
@@ -25,9 +25,7 @@ var ChatsSql = {
   countList: function (params) {
     return [
       'SELECT COUNT(1)::INT FROM full_trs_list',
-      (params.where.length ? 'WHERE ' + params.where.join(' AND ') : ''),
-      ((params.whereOr && params.whereOr.length) ? 'AND (' + params.whereOr.join(' OR ') + ')' : ''),
-      (params.sortField ? 'ORDER BY ' + [params.sortField, params.sortMethod].join(' ') : '')
+          (params.where.length ? 'WHERE ' + params.where.join(' AND ') : '')
     ].filter(Boolean).join(' ');
   },
 
@@ -48,8 +46,10 @@ var ChatsSql = {
   },
   list: function (params) {
     return [
-      'SELECT COUNT(1) FROM full_trs_list',
-          (params.where.length ? 'WHERE ' + params.where.join(' AND ') : '')
+      'SELECT *, t_timestamp as timestamp FROM full_blocks_list',
+        (params.where.length ? 'WHERE ' + params.where.join(' AND ') : ''),
+        (params.sortField ? 'ORDER BY ' + [params.sortField, params.sortMethod].join(' ') : ''),
+      'LIMIT ${limit} OFFSET ${offset}'
     ].filter(Boolean).join(' ');
   },
   listMessages: function (params) {

--- a/sql/chats.js
+++ b/sql/chats.js
@@ -25,7 +25,8 @@ var ChatsSql = {
   countList: function (params) {
     return [
       'SELECT COUNT(1)::INT FROM full_trs_list',
-          (params.where.length ? 'WHERE ' + params.where.join(' AND ') : '')
+      (params.where.length   ? 'WHERE ' + params.where.join(' AND ') : ''),
+      (params.whereOr.length ? 'AND (' + params.whereOr.join(' OR ') + ')' : '')
     ].filter(Boolean).join(' ');
   },
 

--- a/sql/chats.js
+++ b/sql/chats.js
@@ -42,15 +42,12 @@ var ChatsSql = {
            (params.where.length   ? 'WHERE ' + params.where.join(' AND ') : ''),
            (params.whereOr.length ? 'AND (' + params.whereOr.join(' OR ') + ')' : ''),
       ')',
-      'SELECT COUNT(DISTINCT srt) FROM filtered'
+      'SELECT COUNT(DISTINCT srt)::INT FROM filtered'
     ].filter(Boolean).join(' ');
     return y;
   },
   list: function (params) {
     return [
-      'SELECT COUNT(1) FROM full_trs_list',
-          (params.where.length ? 'WHERE ' + params.where.join(' AND ') : '')
-    ].filter(Boolean).join(' ')[
       'SELECT COUNT(1) FROM full_trs_list',
           (params.where.length ? 'WHERE ' + params.where.join(' AND ') : '')
     ].filter(Boolean).join(' ');

--- a/sql/states.js
+++ b/sql/states.js
@@ -21,7 +21,7 @@ var StatesSql = {
   countList: function (params) {
     return [
 
-      'SELECT COUNT(1)  FROM full_blocks_list',
+      'SELECT COUNT(1)::INT FROM full_blocks_list',
       (params.where.length ? 'WHERE ' + params.where.join(' AND ') : ''),
       (params.sortField ? 'ORDER BY ' + [params.sortField, params.sortMethod].join(' ') : '')
     ].filter(Boolean).join(' ');

--- a/sql/transactions.js
+++ b/sql/transactions.js
@@ -21,7 +21,7 @@ var TransactionsSql = {
 
   countList: function (params) {
     return [
-      'SELECT COUNT(1) FROM trs_list',
+      'SELECT COUNT(1)::INT FROM trs_list',
       (params.where.length || params.owner ? 'WHERE' : ''),
       (params.where.length ? '(' + params.where.join(' ') + ')' : ''),
       // FIXME: Backward compatibility, should be removed after transitional period

--- a/test/api/chatrooms.js
+++ b/test/api/chatrooms.js
@@ -184,7 +184,7 @@ describe('GET /api/chatrooms/:ID/:ID', function () {
   it('should return the chat list for sender with no parameters', function (done) {
     getChats(sender.address, function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;
-      node.expect(res.body).to.have.property('count').to.equal('3'); // 2 chats and 1 direct transfer from iAccount
+      node.expect(res.body).to.have.property('count').to.equal(3); // 2 chats and 1 direct transfer from iAccount
       node.expect(res.body).to.have.property('chats').to.have.lengthOf(3);
       for (let i = 0; i < res.body.chats.length; i++) {
         node.expect(res.body.chats[i]).to.have.property('participants').to.have.lengthOf(2);
@@ -215,7 +215,7 @@ describe('GET /api/chatrooms/:ID/:ID', function () {
   it('should return the chat list for recipient1', function (done) {
     getChats(recipient1.address, function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;
-      node.expect(res.body).to.have.property('count').to.equal('3'); // 2 chats and 1 direct transfer from iAccount
+      node.expect(res.body).to.have.property('count').to.equal(3); // 2 chats and 1 direct transfer from iAccount
       node.expect(res.body).to.have.property('chats').to.have.lengthOf(3);
       for (let i = 0; i < res.body.chats.length; i++) {
         node.expect(res.body.chats[i]).to.have.property('participants').to.have.lengthOf(2);
@@ -237,7 +237,7 @@ describe('GET /api/chatrooms/:ID/:ID', function () {
   it('should return the chat list for recipient2', function (done) {
     getChats(recipient2.address, function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;
-      node.expect(res.body).to.have.property('count').to.equal('3'); // 2 chats and 1 direct transfer from iAccount
+      node.expect(res.body).to.have.property('count').to.equal(3); // 2 chats and 1 direct transfer from iAccount
       node.expect(res.body).to.have.property('chats').to.have.lengthOf(3);
       for (let i = 0; i < res.body.chats.length; i++) {
         node.expect(res.body.chats[i]).to.have.property('participants').to.have.lengthOf(2);
@@ -255,7 +255,7 @@ describe('GET /api/chatrooms/:ID/:ID', function () {
   it('should return the chat list for sender with limit', function (done) {
     getChats(sender.address, function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;
-      node.expect(res.body).to.have.property('count').to.equal('3');
+      node.expect(res.body).to.have.property('count').to.equal(3);
       node.expect(res.body).to.have.property('chats').to.have.lengthOf(1);
       for (let i = 0; i < res.body.chats.length; i++) {
         node.expect(res.body.chats[i]).to.have.property('participants').to.have.lengthOf(2);
@@ -270,7 +270,7 @@ describe('GET /api/chatrooms/:ID/:ID', function () {
   it('should return the chat list for sender with offset', function (done) {
     getChats(sender.address, function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;
-      node.expect(res.body).to.have.property('count').to.equal('3');
+      node.expect(res.body).to.have.property('count').to.equal(3);
       node.expect(res.body).to.have.property('chats').to.have.lengthOf(2);
       for (let i = 0; i < res.body.chats.length; i++) {
         node.expect(res.body.chats[i]).to.have.property('participants').to.have.lengthOf(2);
@@ -285,7 +285,7 @@ describe('GET /api/chatrooms/:ID/:ID', function () {
   it('should return the chat list for sender with both limit and offset', function (done) {
     getChats(sender.address, function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;
-      node.expect(res.body).to.have.property('count').to.equal('3');
+      node.expect(res.body).to.have.property('count').to.equal(3);
       node.expect(res.body).to.have.property('chats').to.have.lengthOf(1);
       for (let i = 0; i < res.body.chats.length; i++) {
         node.expect(res.body.chats[i]).to.have.property('participants').to.have.lengthOf(2);
@@ -300,7 +300,7 @@ describe('GET /api/chatrooms/:ID/:ID', function () {
   it('should return the chat list for sender with orderBy=timestamp:desc', function (done) {
     getChats(sender.address, function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;
-      node.expect(res.body).to.have.property('count').to.equal('3');
+      node.expect(res.body).to.have.property('count').to.equal(3);
       node.expect(res.body).to.have.property('chats').to.have.lengthOf(3);
       for (let i = 0; i < res.body.chats.length; i++) {
         node.expect(res.body.chats[i]).to.have.property('participants').to.have.lengthOf(2);
@@ -319,7 +319,7 @@ describe('GET /api/chatrooms/:ID/:ID', function () {
   it('should return the chat list for sender with orderBy=timestamp:asc', function (done) {
     getChats(sender.address, function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;
-      node.expect(res.body).to.have.property('count').to.equal('3');
+      node.expect(res.body).to.have.property('count').to.equal(3);
       node.expect(res.body).to.have.property('chats').to.have.lengthOf(3);
       for (let i = 0; i < res.body.chats.length; i++) {
         node.expect(res.body.chats[i]).to.have.property('participants').to.have.lengthOf(2);
@@ -338,7 +338,7 @@ describe('GET /api/chatrooms/:ID/:ID', function () {
   it('should return the chat list for recipient1', function (done) {
     getChats(recipient1.address, function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;
-      node.expect(res.body).to.have.property('count').to.equal('3');
+      node.expect(res.body).to.have.property('count').to.equal(3);
       node.expect(res.body).to.have.property('chats').to.have.lengthOf(3);
       for (let i = 0; i < res.body.chats.length; i++) {
         node.expect(res.body.chats[i]).to.have.property('participants').to.have.lengthOf(2);
@@ -353,7 +353,7 @@ describe('GET /api/chatrooms/:ID/:ID', function () {
   it('should return the messages between sender and recipient1', function (done) {
     getMessages(sender.address, recipient1.address, function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;
-      node.expect(res.body).to.have.property('count').to.equal('3'); // 2 messages and 1 direct transfer
+      node.expect(res.body).to.have.property('count').to.equal(3); // 2 messages and 1 direct transfer
       node.expect(res.body).to.have.property('messages').to.have.lengthOf(3);
       node.expect(res.body).to.have.property('participants').to.have.lengthOf(2);
       node.expect(res.body.participants[0].address).to.equal(sender.address);
@@ -367,7 +367,7 @@ describe('GET /api/chatrooms/:ID/:ID', function () {
   it('should return the messages between sender and recipient1 with a limit', function (done) {
     getMessages(sender.address, recipient1.address, function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;
-      node.expect(res.body).to.have.property('count').to.equal('3');
+      node.expect(res.body).to.have.property('count').to.equal(3);
       node.expect(res.body).to.have.property('messages').to.have.lengthOf(1);
       node.expect(res.body).to.have.property('participants').to.have.lengthOf(2);
       node.expect(res.body.participants[0].address).to.equal(sender.address);
@@ -383,7 +383,7 @@ describe('GET /api/chatrooms/:ID/:ID', function () {
   it('should return the messages between sender and recipient1 with an offset', function (done) {
     getMessages(sender.address, recipient1.address, function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;
-      node.expect(res.body).to.have.property('count').to.equal('3');
+      node.expect(res.body).to.have.property('count').to.equal(3);
       node.expect(res.body).to.have.property('messages').to.have.lengthOf(2);
       node.expect(res.body).to.have.property('participants').to.have.lengthOf(2);
       node.expect(res.body.participants[0].address).to.equal(sender.address);
@@ -399,7 +399,7 @@ describe('GET /api/chatrooms/:ID/:ID', function () {
   it('should return the messages between sender and recipient1 with an orderBy=timestamp:desc', function (done) {
     getMessages(sender.address, recipient1.address, function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;
-      node.expect(res.body).to.have.property('count').to.equal('3');
+      node.expect(res.body).to.have.property('count').to.equal(3);
       node.expect(res.body).to.have.property('messages').to.have.lengthOf(3);
       node.expect(res.body).to.have.property('participants').to.have.lengthOf(2);
       node.expect(res.body.participants[0].address).to.equal(sender.address);
@@ -419,7 +419,7 @@ describe('GET /api/chatrooms/:ID/:ID', function () {
   it('should return the messages between sender and recipient1 with an orderBy=timestamp:asc', function (done) {
     getMessages(sender.address, recipient1.address, function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;
-      node.expect(res.body).to.have.property('count').to.equal('3');
+      node.expect(res.body).to.have.property('count').to.equal(3);
       node.expect(res.body).to.have.property('messages').to.have.lengthOf(3);
       node.expect(res.body).to.have.property('participants').to.have.lengthOf(2);
       node.expect(res.body.participants[0].address).to.equal(sender.address);
@@ -439,7 +439,7 @@ describe('GET /api/chatrooms/:ID/:ID', function () {
   it('should return the messages between sender and recipient1 without direct transfers', function (done) {
     getMessages(sender.address, recipient1.address, function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;
-      node.expect(res.body).to.have.property('count').to.equal('2');
+      node.expect(res.body).to.have.property('count').to.equal(2);
       node.expect(res.body).to.have.property('messages').to.have.lengthOf(2);
       node.expect(res.body).to.have.property('participants').to.have.lengthOf(2);
       node.expect(res.body.participants[0].address).to.equal(sender.address);
@@ -455,7 +455,7 @@ describe('GET /api/chatrooms/:ID/:ID', function () {
   it('should return the messages between sender and recipient1 without direct transfers with a limit', function (done) {
     getMessages(sender.address, recipient1.address, function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;
-      node.expect(res.body).to.have.property('count').to.equal('2');
+      node.expect(res.body).to.have.property('count').to.equal(2);
       node.expect(res.body).to.have.property('messages').to.have.lengthOf(1);
       node.expect(res.body).to.have.property('participants').to.have.lengthOf(2);
       node.expect(res.body.participants[0].address).to.equal(sender.address);
@@ -472,7 +472,7 @@ describe('GET /api/chatrooms/:ID/:ID', function () {
   it('should return the messages between sender and recipient1 without direct transfers with an offset', function (done) {
     getMessages(sender.address, recipient1.address, function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;
-      node.expect(res.body).to.have.property('count').to.equal('2');
+      node.expect(res.body).to.have.property('count').to.equal(2);
       node.expect(res.body).to.have.property('messages').to.have.lengthOf(1);
       node.expect(res.body).to.have.property('participants').to.have.lengthOf(2);
       node.expect(res.body.participants[0].address).to.equal(sender.address);
@@ -489,7 +489,7 @@ describe('GET /api/chatrooms/:ID/:ID', function () {
   it('should return the messages between sender and recipient1 without direct transfers with an orderBy=timestamp:desc', function (done) {
     getMessages(sender.address, recipient1.address, function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;
-      node.expect(res.body).to.have.property('count').to.equal('2');
+      node.expect(res.body).to.have.property('count').to.equal(2);
       node.expect(res.body).to.have.property('messages').to.have.lengthOf(2);
       node.expect(res.body).to.have.property('participants').to.have.lengthOf(2);
       node.expect(res.body.participants[0].address).to.equal(sender.address);
@@ -510,7 +510,7 @@ describe('GET /api/chatrooms/:ID/:ID', function () {
   it('should return the messages between sender and recipient1 without direct transfers with an orderBy=timestamp:asc', function (done) {
     getMessages(sender.address, recipient1.address, function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;
-      node.expect(res.body).to.have.property('count').to.equal('2');
+      node.expect(res.body).to.have.property('count').to.equal(2);
       node.expect(res.body).to.have.property('messages').to.have.lengthOf(2);
       node.expect(res.body).to.have.property('participants').to.have.lengthOf(2);
       node.expect(res.body.participants[0].address).to.equal(sender.address);

--- a/test/api/delegates.js
+++ b/test/api/delegates.js
@@ -1284,7 +1284,7 @@ describe('GET /api/delegates/forging/getForgedByAccount', function () {
       node.expect(res.body).to.have.property('fees').that.is.a('string').and.eql('0');
       node.expect(res.body).to.have.property('rewards').that.is.a('string').and.eql('0');
       node.expect(res.body).to.have.property('forged').that.is.a('string').and.eql('0');
-      node.expect(res.body).to.have.property('count').that.is.a('string').and.eql('0');
+      node.expect(res.body).to.have.property('count').that.is.a('number').and.equal(0);
       done();
     });
   });
@@ -1329,7 +1329,7 @@ describe('GET /api/delegates/forging/getForgedByAccount', function () {
       node.expect(res.body).to.have.property('fees').that.is.a('string').and.eql('0');
       node.expect(res.body).to.have.property('rewards').that.is.a('string').and.eql('0');
       node.expect(res.body).to.have.property('forged').that.is.a('string').and.eql('0');
-      node.expect(res.body).to.have.property('count').that.is.a('string').and.eql('0');
+      node.expect(res.body).to.have.property('count').that.is.a('number').and.equal(0);
       done();
     });
   });
@@ -1342,7 +1342,7 @@ describe('GET /api/delegates/forging/getForgedByAccount', function () {
       node.expect(res.body).to.have.property('fees').that.is.a('string');
       node.expect(res.body).to.have.property('rewards').that.is.a('string');
       node.expect(res.body).to.have.property('forged').that.is.a('string');
-      node.expect(res.body).to.have.property('count').that.is.a('string');
+      node.expect(res.body).to.have.property('count').that.is.a('number');
       done();
     });
   });


### PR DESCRIPTION
- Return `count` in Public API responses as a number
- Fix SQL query for `/chats/get` endpoint

[Task](https://trello.com/c/92ZV41tt/132-fix-return-number-for-count-property-in-apis)