### PR TITLE
fix: don't process old blocks

### DIFF
--- a/modules/blocks/process.js
+++ b/modules/blocks/process.js
@@ -389,6 +389,8 @@ Process.prototype.onReceiveBlock = function (block) {
     } else {
       if (block.id === lastBlock.id) {
         library.logger.debug('Block already processed', block.id);
+      } else if (block.height < lastBlock.height) {
+        library.logger.debug('Received old block', block.id);
       } else {
         library.logger.warn([
           'Discarded the received block because it does not match the current chain.',


### PR DESCRIPTION
We were printing "discarded block" for already processed blocks
![image](https://github.com/user-attachments/assets/f1b55b12-4d56-4d3d-9c61-d6b48ae52235)
