### PR TITLE
fix: skipping delegate slot

### DIFF
--- a/modules/blocks/process.js
+++ b/modules/blocks/process.js
@@ -368,7 +368,8 @@ Process.prototype.onReceiveBlock = function (block) {
   library.sequence.add(function (cb) {
     // When client is not loaded, is syncing or round is ticking
     // Do not receive new blocks as client is not ready
-    if (!__private.loaded || modules.loader.syncing() || modules.rounds.ticking()) {
+    const syncPending = !modules.loader.isReadyToSync() || modules.loader.syncing();
+    if (!__private.loaded || syncPending || modules.rounds.ticking()) {
       library.logger.debug('Client not ready to receive block', block.id);
       return;
     }

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -158,7 +158,8 @@ __private.forge = function (cb) {
 
   // When client is not loaded, is syncing or round is ticking
   // Do not try to forge new blocks as client is not ready
-  if (!__private.loaded || modules.loader.syncing() || !modules.rounds.loaded() || modules.rounds.ticking()) {
+  const syncPending = !modules.loader.isReadyToSync() || modules.loader.syncing();
+  if (!__private.loaded || syncPending || !modules.rounds.loaded() || modules.rounds.ticking()) {
     library.logger.debug('Client not ready to forge');
     return setImmediate(cb);
   }

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -14,6 +14,7 @@ require('colors');
 var modules, library, self, __private = {}, shared = {};
 
 __private.loaded = false;
+__private.ready = false;
 __private.isActive = false;
 __private.lastBlock = null;
 __private.genesisBlock = null;
@@ -782,6 +783,14 @@ Loader.prototype.loaded = function () {
   return __private.loaded;
 }
 
+/**
+ * Returns whether the blockchain has checked if it needs to sync
+ *
+ * @returns {boolean}
+ */
+Loader.prototype.isReadyToSync = function () {
+  return __private.ready;
+}
 
 /**
  * Returns total synced blocks.
@@ -826,6 +835,8 @@ Loader.prototype.onPeersReady = function () {
   library.logger.trace('Peers ready', { module: 'loader' });
   // Enforce sync early
   __private.syncTimer();
+
+  __private.ready = true;
 
   setImmediate(function load () {
     async.series({
@@ -898,6 +909,7 @@ Loader.prototype.onBlockchainReady = function () {
  */
 Loader.prototype.cleanup = function (cb) {
   __private.loaded = false;
+  __private.ready = false;
   return setImmediate(cb);
 };
 


### PR DESCRIPTION
Fixed a bug where the blockchain tried to forge a delegate before syncing had started leading to the warnings:

```
Skipping delegate slot
Skipping delegate slot
Skipping delegate slot
Skipping delegate slot
Skipping delegate slot
Skipping delegate slot
```