### PR TITLE
feat: improve testing developer experience

### DIFF
--- a/test/api/blocks.js
+++ b/test/api/blocks.js
@@ -136,8 +136,10 @@ describe('GET /blocks (cache)', function () {
 
   before(function (done) {
     modulesLoader.initCache(function (err, __cache) {
+      if (err) {
+        done(err);
+      }
       cache = __cache;
-      node.expect(err).to.not.exist;
       node.expect(__cache).to.be.an('object');
       return done(err, __cache);
     });
@@ -149,7 +151,9 @@ describe('GET /blocks (cache)', function () {
 
   afterEach(function (done) {
     cache.flushDb(function (err, status) {
-      node.expect(err).to.not.exist;
+      if (err) {
+        done(err);
+      }
       node.expect(status).to.equal('OK');
       done(err, status);
     });
@@ -164,7 +168,9 @@ describe('GET /blocks (cache)', function () {
       node.expect(res.body).to.have.property('blocks').that.is.an('array');
       var response = res.body;
       cache.getJsonForKey(url + params, function (err, res) {
-        node.expect(err).to.not.exist;
+        if (err) {
+          done(err);
+        }
         node.expect(res).to.eql(response);
         done();
       });

--- a/test/api/blocks.js
+++ b/test/api/blocks.js
@@ -136,10 +136,8 @@ describe('GET /blocks (cache)', function () {
 
   before(function (done) {
     modulesLoader.initCache(function (err, __cache) {
-      if (err) {
-        done(err);
-      }
       cache = __cache;
+      node.expect(err).to.not.exist;
       node.expect(__cache).to.be.an('object');
       return done(err, __cache);
     });
@@ -151,9 +149,7 @@ describe('GET /blocks (cache)', function () {
 
   afterEach(function (done) {
     cache.flushDb(function (err, status) {
-      if (err) {
-        done(err);
-      }
+      node.expect(err).to.not.exist;
       node.expect(status).to.equal('OK');
       done(err, status);
     });
@@ -168,9 +164,7 @@ describe('GET /blocks (cache)', function () {
       node.expect(res.body).to.have.property('blocks').that.is.an('array');
       var response = res.body;
       cache.getJsonForKey(url + params, function (err, res) {
-        if (err) {
-          done(err);
-        }
+        node.expect(err).to.not.exist;
         node.expect(res).to.eql(response);
         done();
       });

--- a/test/logger.js
+++ b/test/logger.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const readline = require('readline');
+
+const { SILENT, OUTPUT } = process.env;
+
+const MAX_LOG_LENGTH = 600;
+
+const log = (message, data) => {
+  const json = JSON.stringify(data);
+
+  let details = '';
+
+  if (data) {
+    details = json.length > MAX_LOG_LENGTH
+      ? `${json.slice(0, MAX_LOG_LENGTH)}...`
+      : json;
+  }
+
+  if (SILENT !== 'true') {
+    console.log(message, details);
+  }
+
+  if (OUTPUT) {
+    // remove terminal colors
+    const cleanMessage = message.replace(/\x1B\[[0-9;]*m/g, '');
+    fs.appendFileSync(OUTPUT, `${cleanMessage} ${json ?? ''}\n`, 'utf-8');
+  }
+};
+
+const logUpdate = (...args) => {
+  if (SILENT !== 'true') {
+    readline.clearLine(process.stdout, 0);
+    readline.cursorTo(process.stdout, 0);
+    process.stdout.write(`${args.join(' ')}`);
+  }
+}
+
+module.exports = {
+  log,
+  logUpdate,
+};

--- a/test/node.js
+++ b/test/node.js
@@ -12,6 +12,7 @@ const bignum = require('../helpers/bignum.js');
 const ByteBuffer = require('bytebuffer');
 const Mnemonic = require('bitcore-mnemonic');
 const transactionTypes = require('../helpers/transactionTypes.js');
+const testLogger = require('./logger.js');
 var packageJson = require('../package.json');
 
 // Requires
@@ -558,7 +559,6 @@ node.waitForNewBlock = function (height, blocksToWait, cb) {
   var actualHeight = height;
   var counter = 1;
   var target = height + blocksToWait;
-
   node.async.doWhilst(
       function (cb) {
         node.axios.get(node.baseUrl + '/api/blocks/getHeight')
@@ -567,7 +567,12 @@ node.waitForNewBlock = function (height, blocksToWait, cb) {
                 return cb(['Received bad response code', res.status, res.config.url].join(' '));
               }
 
-              node.debug('== Waiting for block:'.grey, 'Height:'.grey, res.data.height, 'Target:'.grey, target, 'Second:'.grey, counter++);
+              testLogger.logUpdate(
+                '== Waiting for block:'.grey,
+                'Height:'.grey, `${res.data.height}`.yellow,
+                'Target:'.grey, `${target}`.yellow,
+                'Second:'.grey, `${counter++}`.yellow,
+              );
 
               if (res.data.height >= target) {
                 height = res.data.height;
@@ -583,6 +588,7 @@ node.waitForNewBlock = function (height, blocksToWait, cb) {
         return testCb(null, target > height);
       },
       function (err) {
+        console.log('\n');
         if (err) {
           return setImmediate(cb, err);
         } else {
@@ -758,9 +764,9 @@ function abstractRequest (options, done) {
   }
 
   var verb = options.verb.toUpperCase();
-  node.debug(['> Path:'.grey, verb, options.path].join(' '));
+  testLogger.log(['> Path:'.grey, verb, options.path].join(' '));
   if (verb === 'POST' || verb === 'PUT') {
-    node.debug(['> Data:'.grey, JSON.stringify(options.params)].join(' '));
+    testLogger.log('> Data:'.grey, options.params);
   }
 
   if (done) {
@@ -769,7 +775,7 @@ function abstractRequest (options, done) {
         console.log(err, res)
       }
 
-      node.debug('> Response:'.grey, JSON.stringify(res.body));
+      testLogger.log('> Response:'.grey, res.body);
       done(err, res);
     });
   } else {


### PR DESCRIPTION
- trim long responses in terminal logs and print them in a file instead, specified by OUTPUT env variable, e.g.:

  ```
  OUTPUT=path/to/file npm run test:single test/api/blocks.js
  ```

- Write `Waiting for block` in a single line