### PR TITLE
feat: use timestampMs when sorting using timestamp

### DIFF
--- a/helpers/orderBy.js
+++ b/helpers/orderBy.js
@@ -78,4 +78,15 @@ function OrderBy (orderBy, options) {
   };
 }
 
+OrderBy.formatSQLSorting = (params) => {
+  const { sortField, sortMethod } = params;
+
+  if (sortField === 'timestamp') {
+    // prefer timestampMs then fallback to timestamp
+    return `"timestampMs" ${sortMethod}, "timestamp" ${sortMethod}`;
+  }
+
+  return `${sortField} ${sortMethod}`;
+}
+
 module.exports = OrderBy;

--- a/modules/chats.js
+++ b/modules/chats.js
@@ -179,7 +179,9 @@ __private.list = function (filter, cb) {
 
   var orderBy = OrderBy(
       filter.orderBy, {
-        sortFields: sql.sortFields
+        sortFields: sql.sortFields,
+        sortField: 'timestamp',
+        sortMethod: 'DESC',
       }
   );
 

--- a/modules/states.js
+++ b/modules/states.js
@@ -159,7 +159,9 @@ __private.list = function (filter, cb) {
 
   var orderBy = OrderBy(
       filter.orderBy, {
-        sortFields: sql.sortFields
+        sortFields: sql.sortFields,
+        sortField: 'timestamp',
+        sortMethod: 'DESC',
       }
   );
 

--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -186,6 +186,8 @@ __private.list = function (filter, cb) {
   var orderBy = OrderBy(
       filter.orderBy, {
         sortFields: sql.sortFields,
+        sortField: 'timestamp',
+        sortMethod: 'DESC',
         fieldPrefix: function (sortField) {
           if (['height'].indexOf(sortField) > -1) {
             return 'b_' + sortField;

--- a/sql/chats.js
+++ b/sql/chats.js
@@ -1,10 +1,12 @@
 'use strict';
 
+const { formatSQLSorting } = require('../helpers/orderBy.js');
+
 var ChatsSql = {
   sortFields: ['type', 'timestamp'],
   chatroomsSortDefaults: {
     sortField: 'timestamp',
-    sortMethod: 'desc'
+    sortMethod: 'DESC'
   },
   countByTransactionId: 'SELECT COUNT(*)::int AS "count" FROM chats WHERE "transactionId" = ${id}',
 
@@ -49,7 +51,7 @@ var ChatsSql = {
     return [
       'SELECT *, t_timestamp as timestamp FROM full_blocks_list',
         (params.where?.length ? 'WHERE ' + params.where.join(' AND ') : ''),
-        (params.sortField ? 'ORDER BY ' + [params.sortField, params.sortMethod].join(' ') : ''),
+        (params.sortField ? 'ORDER BY ' + formatSQLSorting(params) : ''),
       'LIMIT ${limit} OFFSET ${offset}'
     ].filter(Boolean).join(' ');
   },
@@ -64,7 +66,7 @@ var ChatsSql = {
       'FROM filtered',
       'LEFT OUTER JOIN mem_accounts ON address = filtered."t_recipientId"',
 
-      (params.sortField ? 'ORDER BY ' + [params.sortField, params.sortMethod].join(' ') : ''),
+      (params.sortField ? 'ORDER BY ' + formatSQLSorting(params) : ''),
       'LIMIT ${limit} OFFSET ${offset}'
     ].filter(Boolean).join(' ');
     return x;
@@ -129,7 +131,7 @@ var ChatsSql = {
       '  "b_id"',
       'FROM ranked',
       'WHERE rn = 1',
-          (params.sortField ? 'ORDER BY ' + [params.sortField, params.sortMethod].join(' ') : ''),
+          (params.sortField ? 'ORDER BY ' + formatSQLSorting(params) : ''),
       'LIMIT ${limit} OFFSET ${offset}'
     ].filter(Boolean).join(' ');
     return y;

--- a/sql/states.js
+++ b/sql/states.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { formatSQLSorting } = require('../helpers/orderBy.js');
+
 var StatesSql = {
   sortFields: ['type', 'timestamp'],
 
@@ -23,7 +25,7 @@ var StatesSql = {
 
       'SELECT COUNT(1)::INT FROM full_blocks_list',
       (params.where.length ? 'WHERE ' + params.where.join(' AND ') : ''),
-      (params.sortField ? 'ORDER BY ' + [params.sortField, params.sortMethod].join(' ') : '')
+      (params.sortField ? 'ORDER BY ' + formatSQLSorting(params) : '')
     ].filter(Boolean).join(' ');
   },
 
@@ -33,7 +35,7 @@ var StatesSql = {
 
       'SELECT *, t_timestamp as timestamp, b_timestamp as block_timestamp FROM full_blocks_list',
       (params.where.length ? 'WHERE ' + params.where.join(' AND ') : ''),
-      (params.sortField ? 'ORDER BY ' + [params.sortField, params.sortMethod].join(' ') : ''),
+      (params.sortField ? 'ORDER BY ' + formatSQLSorting(params) : ''),
       'LIMIT ${limit} OFFSET ${offset}'
     ].filter(Boolean).join(' ');
   },

--- a/sql/transactions.js
+++ b/sql/transactions.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { formatSQLSorting } = require('../helpers/orderBy.js');
+
 var TransactionsSql = {
   sortFields: [
     'id',
@@ -39,7 +41,7 @@ var TransactionsSql = {
       (params.where.length ? '(' + params.where.join(' ') + ')' : ''),
       // FIXME: Backward compatibility, should be removed after transitional period
       (params.where.length && params.owner ? ' AND ' + params.owner : params.owner),
-      (params.sortField ? 'ORDER BY ' + [params.sortField, params.sortMethod].join(' ') : ''),
+      (params.sortField ? 'ORDER BY ' + formatSQLSorting(params) : ''),
       'LIMIT ${limit} OFFSET ${offset}'
     ].filter(Boolean).join(' ');
   },
@@ -54,7 +56,7 @@ var TransactionsSql = {
       (params.where.length ? '(' + params.where.join(' ') + ')' : ''),
       // FIXME: Backward compatibility, should be removed after transitional period
       (params.where.length && params.owner ? ' AND ' + params.owner : params.owner),
-      (params.sortField ? 'ORDER BY ' + [params.sortField, params.sortMethod].join(' ') : ''),
+      (params.sortField ? 'ORDER BY ' + formatSQLSorting(params) : ''),
       'LIMIT ${limit} OFFSET ${offset}'
     ].filter(Boolean).join(' ');
   },


### PR DESCRIPTION
Sorting by multiple fields isn't commonly used in the blockchain, so I decided that making an exception for `timestamp` is safer than rewriting the entire `orderBy.js` module.