### PR TITLE
Fix SQL migrations

### DIFF
--- a/sql/migrations/20241218010631_addTimestampMs.sql
+++ b/sql/migrations/20241218010631_addTimestampMs.sql
@@ -5,7 +5,7 @@
 BEGIN;
 
 -- Add timestampMs column to Transactions
-ALTER TABLE "trs" ADD COLUMN "timestampMs" BIGINT;
+ALTER TABLE "trs" ADD COLUMN IF NOT EXISTS "timestampMs" BIGINT;
 
 -- Add timestampMs index
 CREATE INDEX IF NOT EXISTS "timestamp_ms" ON "trs"("timestampMs");

--- a/sql/migrations/20250417154132_mergeBlockIntoTransactions.sql
+++ b/sql/migrations/20250417154132_mergeBlockIntoTransactions.sql
@@ -5,8 +5,8 @@
 BEGIN;
 
 -- Create new columns and indexes
-ALTER TABLE "trs" ADD COLUMN "height" INT;
-ALTER TABLE "trs" ADD COLUMN "blockTimestamp" INT;
+ALTER TABLE "trs" ADD COLUMN "height" INT DEFAULT 0;
+ALTER TABLE "trs" ADD COLUMN "blockTimestamp" INT DEFAULT 0;
 
 -- Update existing transactions
 UPDATE trs


### PR DESCRIPTION
## `20241218010631_addTimestampMs.sql`

It's just about idempotency

## `20250417154132_mergeBlockIntoTransactions.sql`

`ADD COLUMN` with constraint `NOT NULL` fails if table is not empty:

```text
ERROR:  column "height" of relation "trs" contains null values
```

Specifying default value resolves the issue.

Steps to reproduce locally:

```text
=# create table add_column_test(id int);
CREATE TABLE
=# insert into add_column_test values (1);
INSERT 0 1
=# alter table add_column_test add column "new" int not null;
ERROR:  column "new" of relation "add_column_test" contains null values
=# alter table add_column_test add column "new" int not null default 0;
ALTER TABLE
```

