### PR TITLE
fix: default query parser does not support `types[]`

### DIFF
--- a/app.js
+++ b/app.js
@@ -375,6 +375,7 @@ d.run(function () {
       scope.network.app.use(require('express-domain-middleware'));
       scope.network.app.set('view engine', 'ejs');
       scope.network.app.set('views', path.join(__dirname, 'public'));
+      scope.network.app.set('query parser', 'extended');
       scope.network.app.use(scope.network.express.static(path.join(__dirname, 'public')));
       scope.network.app.use(bodyParser.raw({
         limit: '2mb'

--- a/test/api/transactions.js
+++ b/test/api/transactions.js
@@ -428,6 +428,22 @@ describe('GET /api/transactions', function () {
     });
   });
 
+  it('using bracket-style types should be ok', function (done) {
+    const types = [node.txTypes.VOTE, node.txTypes.DELEGATE];
+    const params = types.map((type) => 'types[]=' + type).join('&');
+
+    node.get('/api/transactions?' + params, function (err, res) {
+      node.expect(res.body).to.have.property('success').to.be.true;
+      node.expect(res.body).to.have.property('transactions').that.is.an('array');
+      for (var i = 0; i < res.body.transactions.length; i++) {
+        if (res.body.transactions[i]) {
+          node.expect(res.body.transactions[i].type).to.be.oneOf(types);
+        }
+      }
+      done();
+    });
+  });
+
   it('using noClutter param should be ok', function (done) {
     node.get('/api/transactions?noClutter=1', function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;


### PR DESCRIPTION
## Description

Use `qs` to parse params.

## Related issue

Closes #156 

## How to test

Test the endpoint using `adamant-api-jsclient` or directly with browser/cURL:

```
/api/transactions?types[]=0&types[]=8
```

## Notes for reviewers

https://expressjs.com/en/guide/migrating-5.html#req.query

## Checklist

- [x] Code is formatted
- [ ] Tests added/updated (if needed)
- [ ] Documentation updated (if needed)
- [x] Changes tested in all relevant environments
