### PR TITLE
Feat: Add generic startup config overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ ssl/
 # Config files
 config.json
 test/config.json
-test/config.override.json
+test/config.overrides.json
 test/config.overrides.env
 sftp-config.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ ssl/
 # Config files
 config.json
 test/config.json
+test/config.override.json
+test/config.overrides.env
 sftp-config.json
 
 # Logs

--- a/README.md
+++ b/README.md
@@ -50,6 +50,46 @@ You may want to test the node in a safe environment before running a `mainnet` n
 
 Refer to [ADAMANT Node Testnet](https://docs.adamant.im/own-node/testnet.html) section of documentation.
 
+### Configuration Overrides
+
+Startup config can be overridden without editing `config.json` or `test/config.json`.
+Overrides are applied in this order: selected config file, `--config-overrides` env-style file, repeated `--config-set` values, then legacy CLI shortcuts such as `--port`, `--address`, `--peers`, `--log`, and `--snapshot`.
+The final resolved config is validated against the node config schema before startup.
+
+Use dot paths that match the config object shape:
+
+```sh
+node app.js \
+  --config test/config.json \
+  --genesis test/genesisBlock.json \
+  --config-set consensusActivationHeights.fairSystem=4359465 \
+  --config-set 'redis={ "url": "redis://127.0.0.1:6379/1", "password": null }'
+```
+
+The same flags work through npm scripts:
+
+```sh
+npm run start -- --config-set port=36667
+npm run start:testnet -- --config-set api.access.public=true
+```
+
+An env-style override file can contain one `key=value` override per line:
+
+```dotenv
+consensusActivationHeights.fairSystem=4359465
+redis={ "url": "redis://127.0.0.1:6379/1", "password": null }
+```
+
+Run with:
+
+```sh
+node app.js --config-overrides ./local.overrides.env
+```
+
+Values are parsed as JSON first, so numbers, booleans, `null`, arrays, and objects keep their types. Non-JSON values are treated as strings. Unknown paths, unsafe path segments, malformed JSON arrays or objects, and schema-invalid values fail before startup.
+
+Be careful when overriding `consensusActivationHeights.*`: using activation heights that do not match the selected network can make a node diverge from that network.
+
 ## Tests
 
 Refer to [CONTRIBUTING.md](./.github/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Refer to [ADAMANT Node Testnet](https://docs.adamant.im/own-node/testnet.html) s
 ### Configuration Overrides
 
 Startup config can be overridden without editing `config.json` or `test/config.json`.
-Overrides are applied in this order: selected config file, `--config-overrides` env-style file, repeated `--config-set` values, then legacy CLI shortcuts such as `--port`, `--address`, `--peers`, `--log`, and `--snapshot`.
+Overrides are applied in this order: selected config file, `--config-overrides` file, repeated `--config-set` values, then legacy CLI shortcuts such as `--port`, `--address`, `--peers`, `--log`, and `--snapshot`.
 The final resolved config is validated against the node config schema before startup.
 
 Use dot paths that match the config object shape:
@@ -73,7 +73,7 @@ npm run start -- --config-set port=36667
 npm run start:testnet -- --config-set api.access.public=true
 ```
 
-An env-style override file can contain one `key=value` override per line:
+The `--config-overrides` file type is selected by extension. Any non-`.json` file is parsed as env-style content with one `key=value` override per line:
 
 ```dotenv
 consensusActivationHeights.fairSystem=4359465
@@ -83,7 +83,33 @@ redis={ "url": "redis://127.0.0.1:6379/1", "password": null }
 Run with:
 
 ```sh
-node app.js --config-overrides ./local.overrides.env
+node app.js \
+  --config test/config.json \
+  --genesis test/genesisBlock.json \
+  --config-overrides test/config.overrides.env
+```
+
+Files ending in `.json` are parsed as nested JSON partial overrides:
+
+```json
+{
+  "consensusActivationHeights": {
+    "fairSystem": 4359465
+  },
+  "redis": {
+    "url": "redis://127.0.0.1:6379/1",
+    "password": null
+  }
+}
+```
+
+Run with:
+
+```sh
+node app.js \
+  --config test/config.json \
+  --genesis test/genesisBlock.json \
+  --config-overrides test/config.overrides.json
 ```
 
 Values are parsed as JSON first, so numbers, booleans, `null`, arrays, and objects keep their types. Non-JSON values are treated as strings. Unknown paths, unsafe path segments, malformed JSON arrays or objects, and schema-invalid values fail before startup.

--- a/app.js
+++ b/app.js
@@ -66,6 +66,8 @@ program
     .version(packageJson.version)
     .option('-c, --config <path>', 'config.json file path')
     .option('-g, --genesis <path>', 'genesisBlock.json file path')
+    .option('--config-overrides <path>', 'env-style config override file path')
+    .option('--config-set <key=value>', 'config override as dot.path=value', collectOption, [])
     .option('-p, --port <port>', 'listening port number')
     .option('-a, --address <ip>', 'listening host name or ip')
     .option('-x, --peers [peers...]', 'peers list')
@@ -79,41 +81,12 @@ var programOpts = program.opts();
  * @property {object} - The default list of configuration options. Can be updated by CLI.
  * @default 'config.json'
  */
-var appConfig = require('./helpers/config.js')(programOpts.config);
+var appConfig = require('./helpers/config.js')(programOpts.config, {
+  file: programOpts.configOverrides,
+  sets: programOpts.configSet,
+  overrides: getLegacyCliConfigOverrides(programOpts)
+});
 var genesisblock = require(path.resolve(process.cwd(), (programOpts.genesis || 'genesisBlock.json')));
-
-if (programOpts.port) {
-  appConfig.port = programOpts.port;
-}
-
-if (programOpts.address) {
-  appConfig.address = programOpts.address;
-}
-
-if (programOpts.peers) {
-  if (typeof programOpts.peers === 'string') {
-    appConfig.peers.list = programOpts.peers.split(',').map(function (peer) {
-      peer = peer.split(':');
-      return {
-        ip: peer.shift(),
-        port: peer.shift() || appConfig.port
-      };
-    });
-  } else {
-    appConfig.peers.list = [];
-  }
-}
-
-if (programOpts.log) {
-  appConfig.consoleLog.enabled = true;
-  appConfig.consoleLog.level = programOpts.log;
-}
-
-if (programOpts.snapshot) {
-  appConfig.loading.snapshot = Math.abs(
-      Math.floor(programOpts.snapshot)
-  );
-}
 
 // Define top endpoint availability
 process.env.TOP = appConfig.topAccounts;
@@ -182,6 +155,8 @@ var logger = new Logger({
   debugLog: appConfig.debugLog,
   consoleLog: appConfig.consoleLog
 });
+
+logConfigEvents(logger, appConfig.__configEvents);
 
 // Trying to get last git commit
 try {
@@ -813,6 +788,136 @@ d.run(function () {
     }
   });
 });
+
+/**
+ * Collects a repeatable Commander option.
+ * @param {string} value - Option value.
+ * @param {Array<string>} previous - Previously collected values.
+ */
+function collectOption (value, previous) {
+  previous.push(value);
+  return previous;
+}
+
+/**
+ * Converts legacy CLI shortcuts into config override entries.
+ * Generic overrides are applied first, and these shortcuts keep the historical
+ * highest precedence among startup config changes.
+ * @param {object} options - Commander options.
+ */
+function getLegacyCliConfigOverrides (options) {
+  var overrides = [];
+
+  if (options.port) {
+    overrides.push({
+      path: 'port',
+      value: Number(options.port),
+      source: '--port'
+    });
+  }
+
+  if (options.address) {
+    overrides.push({
+      path: 'address',
+      value: options.address,
+      source: '--address'
+    });
+  }
+
+  if (options.peers) {
+    overrides.push({
+      path: 'peers.list',
+      value: function (configData) {
+        return parsePeersOption(options.peers, configData.port);
+      },
+      source: '--peers'
+    });
+  }
+
+  if (options.log) {
+    overrides.push({
+      path: 'consoleLog.enabled',
+      value: true,
+      source: '--log'
+    });
+
+    overrides.push({
+      path: 'consoleLog.level',
+      value: options.log,
+      source: '--log'
+    });
+  }
+
+  if (options.snapshot) {
+    overrides.push({
+      path: 'loading.snapshot',
+      value: Math.abs(Math.floor(options.snapshot)),
+      source: '--snapshot'
+    });
+  }
+
+  return overrides;
+}
+
+/**
+ * Parses the legacy comma-separated peers option.
+ * @param {string|boolean} peers - Commander peers option.
+ * @param {string} port - Optional CLI port override.
+ */
+function parsePeersOption (peers, port) {
+  if (Array.isArray(peers)) {
+    if (!peers.length) {
+      return [];
+    }
+
+    peers = peers.join(',');
+  }
+
+  if (typeof peers !== 'string') {
+    return [];
+  }
+
+  return peers.split(',').map(function (peer) {
+    peer = peer.split(':');
+
+    return {
+      ip: peer.shift(),
+      port: Number(peer.shift() || port)
+    };
+  });
+}
+
+/**
+ * Logs config startup events after logger initialization.
+ * @param {Logger} logger - Logger instance.
+ * @param {Array<object>} events - Config events.
+ */
+function logConfigEvents (logger, events) {
+  (events || []).forEach(function (event) {
+    logger.info(
+        'config',
+        'Parameter ' +
+        event.path +
+        ' overridden by ' +
+        event.source +
+        ' with value: ' +
+        formatConfigLogValue(event.value),
+        { value: event.value }
+    );
+  });
+}
+
+/**
+ * Formats a config value for startup logs.
+ * @param {*} value - Redacted config value.
+ */
+function formatConfigLogValue (value) {
+  if (typeof value === 'string') {
+    return '\'' + value + '\'';
+  }
+
+  return JSON.stringify(value);
+}
 
 /**
  * Event reporting an uncaughtException.

--- a/app.js
+++ b/app.js
@@ -66,7 +66,7 @@ program
     .version(packageJson.version)
     .option('-c, --config <path>', 'config.json file path')
     .option('-g, --genesis <path>', 'genesisBlock.json file path')
-    .option('--config-overrides <path>', 'env-style config override file path')
+    .option('--config-overrides <path>', 'env-style or JSON config override file path')
     .option('--config-set <key=value>', 'config override as dot.path=value', collectOption, [])
     .option('-p, --port <port>', 'listening port number')
     .option('-a, --address <ip>', 'listening host name or ip')

--- a/helpers/config.js
+++ b/helpers/config.js
@@ -5,16 +5,18 @@ var path = require('path');
 var z_schema = require('./z_schema.js');
 var configSchema = require('../schema/config.js');
 var constants = require('../helpers/constants.js');
+var configOverrides = require('./configOverrides.js');
 
 /**
  * Loads config.json file
  * @param {string} configPath
+ * @param {object} overrideOptions
  *
  * @memberof module:helpers
  * @implements {validateForce}
  * @return {Object} configData
  */
-function Config (configPath) {
+function Config (configPath, overrideOptions) {
   try {
     const configJson = fs.readFileSync(path.resolve(process.cwd(), (configPath || 'config.json')), 'utf8');
 
@@ -30,9 +32,21 @@ function Config (configPath) {
     const configData = JSON.parse(configJson);
     const defaultConfigData = JSON.parse(defaultConfigJson);
     const legacyLoggingConfig = getLegacyLoggingConfig(configData);
+    const configEvents = [];
 
     deepMergeMissing(configData, defaultConfigData);
     applyLegacyLoggingConfig(configData, legacyLoggingConfig);
+    configOverrides.applyOverrides(
+        configData,
+        configOverrides.resolveOverrides(overrideOptions),
+        configSchema.config,
+        configEvents
+    );
+
+    Object.defineProperty(configData, '__configEvents', {
+      value: configEvents,
+      enumerable: false
+    });
 
     var validator = new z_schema();
     var valid = validator.validate(configData, configSchema.config);

--- a/helpers/configOverrides.js
+++ b/helpers/configOverrides.js
@@ -14,7 +14,7 @@ var sensitivePathPattern = /(secret|password|passphrase|privatekey|private_key|t
 /**
  * Resolves override sources into parsed config override entries.
  * @param {object} options - Override options.
- * @param {string} [options.file] - Env-style override file path.
+ * @param {string} [options.file] - Env-style or JSON override file path.
  * @param {Array<string>} [options.sets] - Direct key=value overrides.
  * @param {Array<object>} [options.overrides] - Pre-parsed override entries.
  */
@@ -68,12 +68,27 @@ function applyOverrides (configData, entries, schema, events) {
 }
 
 /**
- * Parses an env-style override file.
+ * Parses an override file. `.json` files use nested JSON object syntax;
+ * all other extensions use env-style key=value syntax.
  * @param {string} filePath - Override file path.
  */
 function parseOverrideFile (filePath) {
   var resolvedPath = path.resolve(process.cwd(), filePath);
   var content = fs.readFileSync(resolvedPath, 'utf8');
+
+  if (path.extname(resolvedPath).toLowerCase() === '.json') {
+    return parseJsonOverrideFile(content, resolvedPath);
+  }
+
+  return parseEnvOverrideFile(content, resolvedPath);
+}
+
+/**
+ * Parses an env-style override file.
+ * @param {string} content - File content.
+ * @param {string} resolvedPath - Resolved file path.
+ */
+function parseEnvOverrideFile (content, resolvedPath) {
   var entries = [];
 
   content.split(/\r?\n/).forEach(function (line, index) {
@@ -88,6 +103,61 @@ function parseOverrideFile (filePath) {
 
   return entries;
 }
+
+/**
+ * Parses a JSON override file.
+ * @param {string} content - File content.
+ * @param {string} resolvedPath - Resolved file path.
+ */
+function parseJsonOverrideFile (content, resolvedPath) {
+  var json;
+
+  try {
+    json = JSON.parse(content);
+  } catch (error) {
+    throw Error('Invalid JSON config override file "' + resolvedPath + '": ' + error.message);
+  }
+
+  if (!json || typeof json !== 'object' || Array.isArray(json)) {
+    throw Error('Invalid JSON config override file "' + resolvedPath + '": root value must be an object');
+  }
+
+  return flattenJsonOverrideObject(json, [], '--config-overrides ' + resolvedPath);
+}
+
+/**
+ * Converts a nested JSON override object into override entries.
+ * @param {object} object - JSON object.
+ * @param {Array<string>} prefix - Current dot path prefix.
+ * @param {string} source - Human-readable source for logs and errors.
+ */
+function flattenJsonOverrideObject (object, prefix, source) {
+  return Object.keys(object).reduce(function (entries, key) {
+    var overridePath = prefix.concat(parseOverridePath(key));
+    var value = object[key];
+
+    if (isPlainObject(value)) {
+      return entries.concat(flattenJsonOverrideObject(value, overridePath, source));
+    } else {
+      entries.push({
+        path: overridePath,
+        value: value,
+        source: source
+      });
+    }
+
+    return entries;
+  }, []);
+}
+
+/**
+ * Checks whether a value is a plain object.
+ * @param {*} value - Value to check.
+ */
+function isPlainObject (value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
 
 /**
  * Parses a single key=value override.

--- a/helpers/configOverrides.js
+++ b/helpers/configOverrides.js
@@ -113,7 +113,10 @@ function parseJsonOverrideFile (content, resolvedPath) {
   var json;
 
   try {
-    json = JSON.parse(content);
+    json = assertNoUnsafeKeys(
+        JSON.parse(content),
+        'JSON config override file "' + resolvedPath + '"'
+    );
   } catch (error) {
     throw Error('Invalid JSON config override file "' + resolvedPath + '": ' + error.message);
   }
@@ -218,13 +221,16 @@ function parseOverrideValue (rawValue, overridePath) {
   }
 
   try {
-    return JSON.parse(value);
+    return assertNoUnsafeKeys(JSON.parse(value), 'config override "' + overridePath + '"');
   } catch (error) {
     var singleQuotedValue = stripSingleOuterQuotes(value);
 
     if (singleQuotedValue !== value) {
       try {
-        return JSON.parse(singleQuotedValue);
+        return assertNoUnsafeKeys(
+            JSON.parse(singleQuotedValue),
+            'config override "' + overridePath + '"'
+        );
       } catch (singleQuoteError) {
         if (singleQuotedValue[0] === '{' || singleQuotedValue[0] === '[') {
           throw Error(
@@ -245,6 +251,35 @@ function parseOverrideValue (rawValue, overridePath) {
 
     return value;
   }
+}
+
+/**
+ * Rejects parsed JSON override values with prototype-polluting keys.
+ * @param {*} value - Parsed JSON value.
+ * @param {string} source - Human-readable source for error messages.
+ */
+function assertNoUnsafeKeys (value, source) {
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach(function (item) {
+      assertNoUnsafeKeys(item, source);
+    });
+
+    return value;
+  }
+
+  Object.keys(value).forEach(function (key) {
+    if (unsafePathSegments[key]) {
+      throw Error('Invalid ' + source + ': unsafe key "' + key + '"');
+    }
+
+    assertNoUnsafeKeys(value[key], source);
+  });
+
+  return value;
 }
 
 /**

--- a/helpers/configOverrides.js
+++ b/helpers/configOverrides.js
@@ -1,0 +1,324 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+
+var unsafePathSegments = {
+  __proto__: true,
+  constructor: true,
+  prototype: true
+};
+
+var sensitivePathPattern = /(secret|password|passphrase|privatekey|private_key|token|apikey|api_key|authorization|auth)/i;
+
+/**
+ * Resolves override sources into parsed config override entries.
+ * @param {object} options - Override options.
+ * @param {string} [options.file] - Env-style override file path.
+ * @param {Array<string>} [options.sets] - Direct key=value overrides.
+ * @param {Array<object>} [options.overrides] - Pre-parsed override entries.
+ */
+function resolveOverrides (options) {
+  options = options || {};
+
+  var entries = [];
+
+  if (options.file) {
+    entries = entries.concat(parseOverrideFile(options.file));
+  }
+
+  (options.sets || []).forEach(function (override) {
+    entries.push(parseOverride(override, '--config-set'));
+  });
+
+  (options.overrides || []).forEach(function (override) {
+    entries.push({
+      path: parseOverridePath(override.path),
+      value: override.value,
+      source: override.source || 'command line'
+    });
+  });
+
+  return entries;
+}
+
+/**
+ * Applies parsed overrides to a config object.
+ * @param {object} configData - Config object to mutate.
+ * @param {Array<object>} entries - Parsed override entries.
+ * @param {object} schema - Config schema used to reject unknown paths.
+ * @param {Array<object>} [events] - Applied override event sink.
+ */
+function applyOverrides (configData, entries, schema, events) {
+  entries.forEach(function (entry) {
+    var value = typeof entry.value === 'function' ? entry.value(configData) : entry.value;
+
+    setConfigValue(configData, entry.path, value, schema);
+
+    if (events) {
+      events.push({
+        path: entry.path.join('.'),
+        source: entry.source,
+        value: redactConfigValue(entry.path, value)
+      });
+    }
+  });
+
+  return configData;
+}
+
+/**
+ * Parses an env-style override file.
+ * @param {string} filePath - Override file path.
+ */
+function parseOverrideFile (filePath) {
+  var resolvedPath = path.resolve(process.cwd(), filePath);
+  var content = fs.readFileSync(resolvedPath, 'utf8');
+  var entries = [];
+
+  content.split(/\r?\n/).forEach(function (line, index) {
+    var trimmedLine = line.trim();
+
+    if (!trimmedLine || trimmedLine[0] === '#') {
+      return;
+    }
+
+    entries.push(parseOverride(trimmedLine, '--config-overrides ' + resolvedPath + ':' + (index + 1)));
+  });
+
+  return entries;
+}
+
+/**
+ * Parses a single key=value override.
+ * @param {string} override - Override string.
+ * @param {string} source - Human-readable source for error messages.
+ */
+function parseOverride (override, source) {
+  var separatorIndex = override.indexOf('=');
+
+  if (separatorIndex === -1) {
+    throw Error('Invalid config override from ' + source + ': expected key=value');
+  }
+
+  var overridePath = override.slice(0, separatorIndex).trim();
+  var rawValue = override.slice(separatorIndex + 1).trim();
+
+  return {
+    path: parseOverridePath(overridePath),
+    value: parseOverrideValue(rawValue, overridePath),
+    source: source
+  };
+}
+
+/**
+ * Parses and validates a dot-path.
+ * @param {string} overridePath - Dot-separated config path.
+ */
+function parseOverridePath (overridePath) {
+  if (!overridePath) {
+    throw Error('Invalid config override path: path must not be empty');
+  }
+
+  var parts = overridePath.split('.');
+
+  parts.forEach(function (part) {
+    if (!part) {
+      throw Error('Invalid config override path "' + overridePath + '": empty path segment');
+    }
+
+    if (unsafePathSegments[part]) {
+      throw Error('Invalid config override path "' + overridePath + '": unsafe path segment');
+    }
+  });
+
+  return parts;
+}
+
+/**
+ * Parses JSON-compatible values and falls back to plain strings.
+ * @param {string} rawValue - Raw override value.
+ * @param {string} overridePath - Override path for error messages.
+ */
+function parseOverrideValue (rawValue, overridePath) {
+  var value = rawValue.trim();
+
+  if (value === '') {
+    return '';
+  }
+
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    var singleQuotedValue = stripSingleOuterQuotes(value);
+
+    if (singleQuotedValue !== value) {
+      try {
+        return JSON.parse(singleQuotedValue);
+      } catch (singleQuoteError) {
+        if (singleQuotedValue[0] === '{' || singleQuotedValue[0] === '[') {
+          throw Error(
+              'Invalid JSON value for config override "' +
+              overridePath +
+              '": ' +
+              singleQuoteError.message
+          );
+        }
+
+        return singleQuotedValue;
+      }
+    }
+
+    if (value[0] === '{' || value[0] === '[') {
+      throw Error('Invalid JSON value for config override "' + overridePath + '": ' + error.message);
+    }
+
+    return value;
+  }
+}
+
+/**
+ * Removes matching single quotes around a value.
+ * @param {string} value - Raw value.
+ */
+function stripSingleOuterQuotes (value) {
+  if (value.length < 2) {
+    return value;
+  }
+
+  var first = value[0];
+  var last = value[value.length - 1];
+
+  if (first === '\'' && last === '\'') {
+    return value.slice(1, -1);
+  }
+
+  return value;
+}
+
+/**
+ * Writes a config value at a dot path after checking the schema path exists.
+ * @param {object} configData - Config object to mutate.
+ * @param {Array<string>} overridePath - Parsed config path.
+ * @param {*} value - Override value.
+ * @param {object} schema - Config schema.
+ */
+function setConfigValue (configData, overridePath, value, schema) {
+  if (!hasPathInSchema(schema, overridePath)) {
+    throw Error('Invalid config override path "' + overridePath.join('.') + '": path is not defined in config schema');
+  }
+
+  var target = configData;
+  var schemaNode = schema;
+
+  for (var i = 0; i < overridePath.length - 1; i++) {
+    var part = overridePath[i];
+
+    schemaNode = schemaNode.properties[part];
+
+    if (target[part] === undefined && schemaAllowsType(schemaNode, 'object')) {
+      target[part] = {};
+    }
+
+    if (
+      typeof target[part] !== 'object' ||
+      target[part] === null ||
+      Array.isArray(target[part])
+    ) {
+      throw Error('Invalid config override path "' + overridePath.join('.') + '": parent path is not an object');
+    }
+
+    target = target[part];
+  }
+
+  target[overridePath[overridePath.length - 1]] = value;
+}
+
+/**
+ * Checks that a path is known by the JSON schema.
+ * @param {object} schema - Current schema node.
+ * @param {Array<string>} overridePath - Remaining path parts.
+ */
+function hasPathInSchema (schema, overridePath) {
+  if (!overridePath.length) {
+    return true;
+  }
+
+  if (!schema || !schema.properties) {
+    return false;
+  }
+
+  var part = overridePath[0];
+
+  if (!Object.prototype.hasOwnProperty.call(schema.properties, part)) {
+    return false;
+  }
+
+  return hasPathInSchema(schema.properties[part], overridePath.slice(1));
+}
+
+/**
+ * Checks whether a schema node allows a JSON type.
+ * @param {object} schema - Schema node.
+ * @param {string} type - JSON type.
+ */
+function schemaAllowsType (schema, type) {
+  if (!schema) {
+    return false;
+  }
+
+  if (Array.isArray(schema.type)) {
+    return schema.type.indexOf(type) !== -1;
+  }
+
+  return schema.type === type;
+}
+
+/**
+ * Redacts sensitive config override values based on their dot path.
+ * @param {Array<string>} overridePath - Parsed config path.
+ * @param {*} value - Applied override value.
+ */
+function redactConfigValue (overridePath, value) {
+  if (overridePath.some(function (part) {
+    return sensitivePathPattern.test(part);
+  })) {
+    return 'XXXXXXXXXX';
+  }
+
+  return redactNestedConfigValue(value);
+}
+
+/**
+ * Redacts sensitive keys inside object override values.
+ * @param {*} value - Value to redact.
+ */
+function redactNestedConfigValue (value) {
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(function (item) {
+      return redactNestedConfigValue(item);
+    });
+  }
+
+  return Object.keys(value).reduce(function (result, key) {
+    result[key] = sensitivePathPattern.test(key) ?
+      'XXXXXXXXXX' :
+      redactNestedConfigValue(value[key]);
+
+    return result;
+  }, {});
+}
+
+module.exports = {
+  applyOverrides: applyOverrides,
+  parseOverride: parseOverride,
+  parseOverrideFile: parseOverrideFile,
+  parseOverridePath: parseOverridePath,
+  parseOverrideValue: parseOverrideValue,
+  redactConfigValue: redactConfigValue,
+  resolveOverrides: resolveOverrides
+};

--- a/schema/config.js
+++ b/schema/config.js
@@ -352,6 +352,10 @@ module.exports = {
             type: 'integer',
             minimum: 1,
             maximum: 5000
+          },
+          snapshot: {
+            type: 'integer',
+            minimum: 0
           }
         },
         required: ['loadPerIteration']

--- a/schema/config.js
+++ b/schema/config.js
@@ -355,7 +355,7 @@ module.exports = {
           },
           snapshot: {
             type: 'integer',
-            minimum: 0
+            minimum: 1
           }
         },
         required: ['loadPerIteration']

--- a/test/unit/helpers/configOverrides.js
+++ b/test/unit/helpers/configOverrides.js
@@ -1,0 +1,246 @@
+'use strict';
+
+const { expect } = require('chai');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const sinon = require('sinon');
+
+const Config = require('../../../helpers/config.js');
+const configOverrides = require('../../../helpers/configOverrides.js');
+const configSchema = require('../../../schema/config.js');
+
+describe('configOverrides', () => {
+  let tempDir;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'adamant-config-overrides-'));
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function writeTempFile (fileName, content) {
+    const filePath = path.join(tempDir, fileName);
+
+    fs.writeFileSync(filePath, content);
+
+    return filePath;
+  }
+
+  describe('parseOverride()', () => {
+    it('should parse dot-path scalar values as JSON-compatible values', () => {
+      const override = configOverrides.parseOverride(
+          'consensusActivationHeights.fairSystem=4359465',
+          'test'
+      );
+
+      expect(override.path).to.deep.equal(['consensusActivationHeights', 'fairSystem']);
+      expect(override.value).to.equal(4359465);
+    });
+
+    it('should parse whole object values', () => {
+      const override = configOverrides.parseOverride(
+          'redis={ "url": "redis://127.0.0.1:6379/1", "password": null }',
+          'test'
+      );
+
+      expect(override.path).to.deep.equal(['redis']);
+      expect(override.value).to.deep.equal({
+        url: 'redis://127.0.0.1:6379/1',
+        password: null
+      });
+    });
+
+    it('should preserve non-JSON values as strings', () => {
+      const override = configOverrides.parseOverride('consoleLog.level=debug', 'test');
+
+      expect(override.value).to.equal('debug');
+    });
+
+    it('should preserve JSON string values as strings', () => {
+      const override = configOverrides.parseOverride('db.password="123"', 'test');
+
+      expect(override.value).to.equal('123');
+    });
+
+    it('should fail fast on malformed JSON objects', () => {
+      expect(() => configOverrides.parseOverride('redis={ bad json }', 'test'))
+          .to.throw(/Invalid JSON value/);
+    });
+  });
+
+  describe('parseOverrideFile()', () => {
+    it('should parse env-style override files', () => {
+      const filePath = writeTempFile('overrides.env', [
+        '# local test overrides',
+        'consensusActivationHeights.fairSystem=4359465',
+        'redis=\'{ "url": "redis://127.0.0.1:6379/1", "password": null }\''
+      ].join('\n'));
+
+      const entries = configOverrides.parseOverrideFile(filePath);
+
+      expect(entries).to.have.length(2);
+      expect(entries[0].path).to.deep.equal(['consensusActivationHeights', 'fairSystem']);
+      expect(entries[0].value).to.equal(4359465);
+      expect(entries[1].path).to.deep.equal(['redis']);
+      expect(entries[1].value.password).to.equal(null);
+    });
+  });
+
+  describe('applyOverrides()', () => {
+    it('should apply nested scalar and whole-object overrides', () => {
+      const configData = {
+        consensusActivationHeights: {
+          fairSystem: 1,
+          spaceship: 2
+        },
+        redis: {
+          url: 'redis://127.0.0.1:6379/0',
+          password: 'secret'
+        }
+      };
+      const entries = [
+        configOverrides.parseOverride('consensusActivationHeights.fairSystem=4359465', 'test'),
+        configOverrides.parseOverride('redis={ "url": "redis://127.0.0.1:6379/1", "password": null }', 'test')
+      ];
+
+      configOverrides.applyOverrides(configData, entries, configSchema.config);
+
+      expect(configData.consensusActivationHeights.fairSystem).to.equal(4359465);
+      expect(configData.redis).to.deep.equal({
+        url: 'redis://127.0.0.1:6379/1',
+        password: null
+      });
+    });
+
+    it('should collect redacted override events', () => {
+      const configData = {
+        db: {
+          password: 'old-password'
+        },
+        redis: {
+          url: 'redis://127.0.0.1:6379/0',
+          password: 'old-password'
+        }
+      };
+      const entries = [
+        configOverrides.parseOverride('db.password="new-password"', '--config-set'),
+        configOverrides.parseOverride(
+            'redis={ "url": "redis://127.0.0.1:6379/1", "password": "new-password" }',
+            '--config-set'
+        )
+      ];
+      const events = [];
+
+      configOverrides.applyOverrides(configData, entries, configSchema.config, events);
+
+      expect(events).to.deep.equal([
+        {
+          path: 'db.password',
+          source: '--config-set',
+          value: 'XXXXXXXXXX'
+        },
+        {
+          path: 'redis',
+          source: '--config-set',
+          value: {
+            url: 'redis://127.0.0.1:6379/1',
+            password: 'XXXXXXXXXX'
+          }
+        }
+      ]);
+      expect(JSON.stringify(events)).not.to.include('new-password');
+    });
+
+    it('should reject unknown schema paths', () => {
+      const configData = {};
+      const entries = [
+        configOverrides.parseOverride('unknown.path=1', 'test')
+      ];
+
+      expect(() => configOverrides.applyOverrides(configData, entries, configSchema.config))
+          .to.throw(/path is not defined in config schema/);
+    });
+
+    it('should reject unsafe path segments', () => {
+      expect(() => configOverrides.parseOverride('db.__proto__.polluted=true', 'test'))
+          .to.throw(/unsafe path segment/);
+    });
+
+    it('should create missing optional object parents for schema-defined paths', () => {
+      const configData = {};
+      const entries = [
+        configOverrides.parseOverride('cors.origin="*"', 'test')
+      ];
+
+      configOverrides.applyOverrides(configData, entries, configSchema.config);
+
+      expect(configData.cors.origin).to.equal('*');
+    });
+  });
+
+  describe('Config()', () => {
+    const testConfigPath = path.join(__dirname, '../../config.json');
+
+    it('should validate and return configs with direct overrides', () => {
+      const config = Config(testConfigPath, {
+        sets: [
+          'consensusActivationHeights.fairSystem=4359465',
+          'redis={ "url": "redis://127.0.0.1:6379/1", "password": null }'
+        ]
+      });
+
+      expect(config.consensusActivationHeights.fairSystem).to.equal(4359465);
+      expect(config.redis).to.deep.equal({
+        url: 'redis://127.0.0.1:6379/1',
+        password: null
+      });
+      expect(config.__configEvents).to.deep.equal([
+        {
+          path: 'consensusActivationHeights.fairSystem',
+          source: '--config-set',
+          value: 4359465
+        },
+        {
+          path: 'redis',
+          source: '--config-set',
+          value: {
+            url: 'redis://127.0.0.1:6379/1',
+            password: 'XXXXXXXXXX'
+          }
+        }
+      ]);
+    });
+
+    it('should apply config file, env-file, direct, and legacy overrides in order', () => {
+      const overrideFile = writeTempFile('overrides.env', 'port=36668\n');
+      const config = Config(testConfigPath, {
+        file: overrideFile,
+        sets: ['port=36669'],
+        overrides: [
+          {
+            path: 'port',
+            value: 36670,
+            source: '--port'
+          }
+        ]
+      });
+
+      expect(config.port).to.equal(36670);
+    });
+
+    it('should fail during schema validation for invalid override value types', () => {
+      sinon.stub(console, 'error');
+      sinon.stub(process, 'exit').throws(new Error('process.exit'));
+
+      expect(() => Config(testConfigPath, {
+        sets: ['port=not-an-integer']
+      })).to.throw('process.exit');
+      expect(process.exit.calledWith(1)).to.be.true;
+      expect(console.error.firstCall.args[1]).to.include('Failed to validate config data');
+    });
+  });
+});

--- a/test/unit/helpers/configOverrides.js
+++ b/test/unit/helpers/configOverrides.js
@@ -70,6 +70,16 @@ describe('configOverrides', () => {
       expect(() => configOverrides.parseOverride('redis={ bad json }', 'test'))
           .to.throw(/Invalid JSON value/);
     });
+
+    it('should reject unsafe keys inside direct JSON values', () => {
+      expect(() => configOverrides.parseOverride('redis={ "__proto__": { "polluted": true } }', 'test'))
+          .to.throw(/unsafe key "__proto__"/);
+    });
+
+    it('should reject unsafe keys inside single-quoted JSON values', () => {
+      expect(() => configOverrides.parseOverride('redis=\'{ "constructor": { "polluted": true } }\'', 'test'))
+          .to.throw(/unsafe key "constructor"/);
+    });
   });
 
   describe('parseOverrideFile()', () => {
@@ -134,6 +144,21 @@ describe('configOverrides', () => {
 
       expect(() => configOverrides.parseOverrideFile(filePath))
           .to.throw(/root value must be an object/);
+    });
+
+    it('should reject unsafe keys inside JSON override files', () => {
+      const filePath = writeTempFile('overrides.json', JSON.stringify({
+        forging: {
+          secret: [
+            {
+              prototype: true
+            }
+          ]
+        }
+      }));
+
+      expect(() => configOverrides.parseOverrideFile(filePath))
+          .to.throw(/unsafe key "prototype"/);
     });
   });
 
@@ -230,7 +255,7 @@ describe('configOverrides', () => {
   });
 
   describe('Config()', () => {
-    const testConfigPath = path.join(__dirname, '../../config.json');
+    const testConfigPath = path.join(__dirname, '../../config.default.json');
 
     it('should validate and return configs with direct overrides', () => {
       const config = Config(testConfigPath, {
@@ -301,6 +326,17 @@ describe('configOverrides', () => {
 
       expect(() => Config(testConfigPath, {
         sets: ['port=not-an-integer']
+      })).to.throw('process.exit');
+      expect(process.exit.calledWith(1)).to.be.true;
+      expect(console.error.firstCall.args[1]).to.include('Failed to validate config data');
+    });
+
+    it('should fail during schema validation for zero snapshot override', () => {
+      sinon.stub(console, 'error');
+      sinon.stub(process, 'exit').throws(new Error('process.exit'));
+
+      expect(() => Config(testConfigPath, {
+        sets: ['loading.snapshot=0']
       })).to.throw('process.exit');
       expect(process.exit.calledWith(1)).to.be.true;
       expect(console.error.firstCall.args[1]).to.include('Failed to validate config data');

--- a/test/unit/helpers/configOverrides.js
+++ b/test/unit/helpers/configOverrides.js
@@ -88,6 +88,53 @@ describe('configOverrides', () => {
       expect(entries[1].path).to.deep.equal(['redis']);
       expect(entries[1].value.password).to.equal(null);
     });
+
+    it('should parse JSON override files as nested partial overrides', () => {
+      const filePath = writeTempFile('overrides.json', JSON.stringify({
+        consensusActivationHeights: {
+          fairSystem: 4359465
+        },
+        redis: {
+          url: 'redis://127.0.0.1:6379/1',
+          password: null
+        },
+        forging: {
+          secret: []
+        }
+      }));
+
+      const entries = configOverrides.parseOverrideFile(filePath);
+
+      expect(entries).to.deep.equal([
+        {
+          path: ['consensusActivationHeights', 'fairSystem'],
+          value: 4359465,
+          source: '--config-overrides ' + filePath
+        },
+        {
+          path: ['redis', 'url'],
+          value: 'redis://127.0.0.1:6379/1',
+          source: '--config-overrides ' + filePath
+        },
+        {
+          path: ['redis', 'password'],
+          value: null,
+          source: '--config-overrides ' + filePath
+        },
+        {
+          path: ['forging', 'secret'],
+          value: [],
+          source: '--config-overrides ' + filePath
+        }
+      ]);
+    });
+
+    it('should reject JSON override files with non-object roots', () => {
+      const filePath = writeTempFile('overrides.json', '[]');
+
+      expect(() => configOverrides.parseOverrideFile(filePath))
+          .to.throw(/root value must be an object/);
+    });
   });
 
   describe('applyOverrides()', () => {
@@ -230,6 +277,22 @@ describe('configOverrides', () => {
       });
 
       expect(config.port).to.equal(36670);
+    });
+
+    it('should apply JSON override files before direct overrides', () => {
+      const overrideFile = writeTempFile('overrides.json', JSON.stringify({
+        port: 36668,
+        consensusActivationHeights: {
+          fairSystem: 4359465
+        }
+      }));
+      const config = Config(testConfigPath, {
+        file: overrideFile,
+        sets: ['port=36669']
+      });
+
+      expect(config.port).to.equal(36669);
+      expect(config.consensusActivationHeights.fairSystem).to.equal(4359465);
     });
 
     it('should fail during schema validation for invalid override value types', () => {


### PR DESCRIPTION
## Description

Adds generic startup configuration overrides so operators and local/test automation can override config values without editing `config.json` or `test/config.json`.

Implemented override paths use the existing config object shape and support:

- repeated direct overrides with `--config-set key=value`
- env-style override files with `--config-overrides path/to/file.env`
- JSON partial override files with `--config-overrides path/to/file.json`
- JSON-compatible values for numbers, booleans, `null`, arrays, and objects
- schema validation after defaults, override files, direct overrides, and legacy CLI shortcuts are resolved
- startup logging in the `config` namespace with sensitive values redacted

Legacy startup shortcuts (`--port`, `--address`, `--peers`, `--log`, `--snapshot`) are routed through the same validated override flow and keep the highest override precedence.

## Related issue

Closes #221.

## How to test

```sh
npm run test:single -- test/unit/helpers/configOverrides.js
npm run test:unit:fast
ESLINT_USE_FLAT_CONFIG=false npx eslint app.js helpers/config.js helpers/configOverrides.js schema/config.js test/unit/helpers/configOverrides.js
node app.js --help
npm run start -- --help
npm run start:testnet -- --help
```

Result:

- focused config override tests: 17 passing
- fast unit suite: 727 passing
- ESLint: 0 errors; existing JSDoc warnings remain in pre-existing `app.js` and `helpers/config.js` comments

## Checklist

- [x] English-only repository output
- [x] No consensus behavior changed directly
- [x] Existing schema validation is preserved for the final resolved config
- [x] Sensitive override values are redacted from config override logs
- [x] README documents direct, env-style, and JSON override usage
- [x] Focused tests cover parsing, validation failures, precedence, redaction, env files, and JSON files

## Risk notes

This changes startup configuration resolution, not block, transaction, serialization, reward, fee, delegate, or round logic. Operators can still override consensus-sensitive config keys such as `consensusActivationHeights.*`; README warns that using network-incompatible activation heights can make a node diverge.

API tests and live local testnet startup were not run for this PR.
