### PR TITLE
Feat: Add localnet management scripts

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -82,6 +82,17 @@ npm run start:testnet
 
 See [Test Environment](../README.md#Test-Environment) for reference.
 
+For multi-node local testing, use the localnet scripts:
+
+```sh
+npm run start:localnet -- --nodes 3
+npm run status:localnet
+npm run stop:localnet
+npm run drop:localnet
+```
+
+Localnet nodes write per-node `adamant_localnet.log` and `adamant_localnet_debug.log` files under `logs-localnet/node-N/` and runtime metadata under `.localnet/`. Use `npm run status:localnet` to check managed PIDs, `/api/node/status`, configured delegate counts, and the last successful forging timestamp. Always stop localnet with `npm run stop:localnet` so every node follows the graceful shutdown path. Localnet databases persist across normal stops; use `npm run stop:localnet -- --drop-on-stop` or `npm run drop:localnet` for a full localnet database cleanup.
+
 > [!CAUTION] > **Unit tests** should NOT be run in parallel to prevent disruption of the node's state, and the `testnet` should be run at least once before.
 
 To run a single test file, use the following command:

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ logs/*.log
 logs-mainnet/*.log
 logs-testnet/*.log
 logs-localnet/*.log
+logs-localnet/
 stacktrace*
 
 # Code Editors
@@ -32,6 +33,7 @@ test/.nyc_output
 
 # Temporary data
 tmp
+.localnet/
 *.swp
 *.swo
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ npm run drop:localnet
 
 `start:localnet` runs nodes in the background with:
 
-- `config.default.json` as the base config;
+- `test/config.default.json` as the base config;
 - `test/genesisBlock.json` as the genesis block;
 - `test/genesisPasses.json` as the genesis delegate passphrase source;
 - `--config-overrides test/config.localnet.json` by default;
@@ -154,7 +154,7 @@ Use `status:localnet` to inspect localnet without attaching to node processes:
 npm run status:localnet
 ```
 
-It reads the manifest, checks every managed PID, requests `/api/node/status` from every node, reports the number of configured forging delegates, and shows the last successful forging log timestamp with its age in seconds.
+It reads the manifest, checks every managed PID, requests `/api/node/status` and `/api/peers` from every node, reports the number of configured forging delegates, and shows the last successful forging log timestamp with its age in seconds. The reported broadhash consensus is calculated live from current connected peer records; if `/api/node/status` still has an older cached consensus value, status output shows it as `cached`.
 
 Localnet uses the testnet genesis block by default. The node derives `nethash` from `genesisBlock.payloadHash`, which is the SHA-256 payload hash verified from the genesis block transactions. It is not a random identifier. If you use a different genesis block, every localnet node must use the same genesis block and resulting nethash.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Refer to [ADAMANT Node Testnet](https://docs.adamant.im/own-node/testnet.html) s
 ### Configuration Overrides
 
 Startup config can be overridden without editing `config.json` or `test/config.json`.
-Overrides are applied in this order: selected config file, `--config-overrides` file, repeated `--config-set` values, then legacy CLI shortcuts such as `--port`, `--address`, `--peers`, `--log`, and `--snapshot`.
+Overrides are applied in this order: selected config file, each `--config-overrides` file in command-line order, repeated `--config-set` values, then legacy CLI shortcuts such as `--port`, `--address`, `--peers`, `--log`, and `--snapshot`.
 The final resolved config is validated against the node config schema before startup.
 
 Use dot paths that match the config object shape:
@@ -115,6 +115,80 @@ node app.js \
 Values are parsed as JSON first, so numbers, booleans, `null`, arrays, and objects keep their types. Non-JSON values are treated as strings. Unknown paths, unsafe path segments, malformed JSON arrays or objects, and schema-invalid values fail before startup.
 
 Be careful when overriding `consensusActivationHeights.*`: using activation heights that do not match the selected network can make a node diverge from that network.
+
+### Localnet
+
+Use localnet when you need several ADAMANT nodes on one machine without connecting to public peers:
+
+```sh
+npm run start:localnet -- --nodes 3
+npm run status:localnet
+npm run stop:localnet
+npm run drop:localnet
+```
+
+`start:localnet` runs nodes in the background with:
+
+- `config.default.json` as the base config;
+- `test/genesisBlock.json` as the genesis block;
+- `test/genesisPasses.json` as the genesis delegate passphrase source;
+- `--config-overrides test/config.localnet.json` by default;
+- one generated per-node override file under `.localnet/node-N/`.
+
+Every node gets isolated ports, PostgreSQL database names, Redis database indexes, process output files, and ADAMANT log files. The default log layout is:
+
+```text
+logs-localnet/
+  node-1/
+    adamant_localnet.log
+    adamant_localnet_debug.log
+  node-2/
+  node-3/
+```
+
+The localnet manifest is written to `.localnet/manifest.json` and includes node endpoints, PIDs, database names, Redis URLs, generated override paths, log paths, and configured delegate counts. Scenario tools can consume this manifest instead of guessing localnet ports.
+
+Use `status:localnet` to inspect localnet without attaching to node processes:
+
+```sh
+npm run status:localnet
+```
+
+It reads the manifest, checks every managed PID, requests `/api/node/status` from every node, reports the number of configured forging delegates, and shows the last successful forging log timestamp with its age in seconds.
+
+Localnet uses the testnet genesis block by default. The node derives `nethash` from `genesisBlock.payloadHash`, which is the SHA-256 payload hash verified from the genesis block transactions. It is not a random identifier. If you use a different genesis block, every localnet node must use the same genesis block and resulting nethash.
+
+By default, genesis delegate passphrases are distributed across localnet nodes. For one to three nodes, all nodes receive delegate passphrases. For more than three nodes, the last node is non-forging and the remaining nodes receive the passphrases as evenly as possible.
+
+By default, `start:localnet` tries to create missing per-node PostgreSQL databases and keeps them persistent across restarts:
+
+```text
+adamant_localnet_node_1
+adamant_localnet_node_2
+adamant_localnet_node_3
+```
+
+The created databases are owned by the configured node DB user, `adamanttest` by default. Database creation uses the current PostgreSQL user unless `--db-admin-user` is provided:
+
+```sh
+npm run start:localnet -- --nodes 3 --db-admin-user postgres
+```
+
+If the databases already exist, startup continues. If your local PostgreSQL user cannot create databases, create them manually, pass a PostgreSQL admin user, or start with `--skip-db-create` after the databases exist.
+
+`stop:localnet` reads `.localnet/manifest.json`, sends `SIGTERM` to every managed node, and waits for the normal ADAMANT cleanup path. It does not use forced process termination.
+
+Localnet databases are not dropped by default. To stop localnet and drop its PostgreSQL databases in one command:
+
+```sh
+npm run stop:localnet -- --drop-on-stop
+```
+
+Use `drop:localnet` when you want a full localnet database cleanup even if no nodes are currently running:
+
+```sh
+npm run drop:localnet
+```
 
 ## Tests
 

--- a/app.js
+++ b/app.js
@@ -66,7 +66,7 @@ program
     .version(packageJson.version)
     .option('-c, --config <path>', 'config.json file path')
     .option('-g, --genesis <path>', 'genesisBlock.json file path')
-    .option('--config-overrides <path>', 'env-style or JSON config override file path')
+    .option('--config-overrides <path>', 'env-style or JSON config override file path', collectOption, [])
     .option('--config-set <key=value>', 'config override as dot.path=value', collectOption, [])
     .option('-p, --port <port>', 'listening port number')
     .option('-a, --address <ip>', 'listening host name or ip')

--- a/helpers/configOverrides.js
+++ b/helpers/configOverrides.js
@@ -14,7 +14,7 @@ var sensitivePathPattern = /(secret|password|passphrase|privatekey|private_key|t
 /**
  * Resolves override sources into parsed config override entries.
  * @param {object} options - Override options.
- * @param {string} [options.file] - Env-style or JSON override file path.
+ * @param {string|Array<string>} [options.file] - Env-style or JSON override file path.
  * @param {Array<string>} [options.sets] - Direct key=value overrides.
  * @param {Array<object>} [options.overrides] - Pre-parsed override entries.
  */
@@ -23,9 +23,10 @@ function resolveOverrides (options) {
 
   var entries = [];
 
-  if (options.file) {
-    entries = entries.concat(parseOverrideFile(options.file));
-  }
+  // Keep repeatable override files ordered so later layers can override earlier ones.
+  normalizeOverrideFiles(options.file).forEach(function (filePath) {
+    entries = entries.concat(parseOverrideFile(filePath));
+  });
 
   (options.sets || []).forEach(function (override) {
     entries.push(parseOverride(override, '--config-set'));
@@ -40,6 +41,24 @@ function resolveOverrides (options) {
   });
 
   return entries;
+}
+
+/**
+ * Normalizes optional override file input into an ordered list.
+ * @param {string|Array<string>} files - Override file path or paths.
+ */
+function normalizeOverrideFiles (files) {
+  if (!files) {
+    return [];
+  }
+
+  if (Array.isArray(files)) {
+    return files.filter(function (filePath) {
+      return !!filePath;
+    });
+  }
+
+  return [files];
 }
 
 /**
@@ -425,5 +444,6 @@ module.exports = {
   parseOverridePath: parseOverridePath,
   parseOverrideValue: parseOverrideValue,
   redactConfigValue: redactConfigValue,
+  normalizeOverrideFiles: normalizeOverrideFiles,
   resolveOverrides: resolveOverrides
 };

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -460,11 +460,12 @@ Peers.prototype.discover = function (cb) {
 };
 
 /**
- * Filters peers with private or address or with the same nonce.
+ * Filters peers with private address or with the same nonce.
  * @param {peer[]} peers
- * @return {peer[]} Filtered list of peers
  */
 Peers.prototype.acceptable = function (peers) {
+  const allowPrivatePeers = !!(library.config.peers.options && library.config.peers.options.allowPrivatePeers);
+
   return _(peers)
       .uniqWith(function (a, b) {
       // Removing non-unique peers
@@ -473,12 +474,13 @@ Peers.prototype.acceptable = function (peers) {
       .filter(function (peer) {
         // Removing peers with private address or nonce equal to self
         const isJsAPI = peer.os === 'adm-js-api' || peer.os === 'lisk-js-api';
+        const isPrivatePeerAllowed = allowPrivatePeers || !ip.isPrivate(peer.ip);
 
         if ((process.env['NODE_ENV'] || '').toUpperCase() === 'TEST') {
           return peer.nonce !== modules.system.getNonce() && !isJsAPI;
         }
 
-        return !ip.isPrivate(peer.ip) && peer.nonce !== modules.system.getNonce() && !isJsAPI;
+        return isPrivatePeerAllowed && peer.nonce !== modules.system.getNonce() && !isJsAPI;
       }).value();
 };
 

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -107,11 +107,11 @@ __private.removePeer = function (options, extraMessage) {
  */
 __private.recordRequest = function (options) {
   return modules.peers.recordRequest(
-    options.peer.ip,
-    options.peer.port,
-    options.error,
+      options.peer.ip,
+      options.peer.port,
+      options.error
   );
-}
+};
 
 /**
  * Validates signatures body and for each signature calls receiveSignature.
@@ -413,7 +413,7 @@ Transport.prototype.getFromPeer = function (peer, options, cb) {
           }
 
           modules.peers.update(peer);
-          __private.recordRequest({ peer })
+          __private.recordRequest({ peer });
 
           return setImmediate(cb, null, { body: res.data, peer: peer });
         }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "scripts": {
     "start": "node app.js",
     "start:testnet": "node app.js --config test/config.json --genesis test/genesisBlock.json",
+    "start:localnet": "node scripts/localnet/start.js",
+    "stop:localnet": "node scripts/localnet/stop.js",
+    "status:localnet": "node scripts/localnet/status.js",
+    "drop:localnet": "node scripts/localnet/drop.js",
     "test:full": "npx grunt test --verbose",
     "test:single": "npx mocha --trace-uncaught",
     "test:unit": "npx mocha test/unit/* --trace-uncaught",

--- a/schema/config.js
+++ b/schema/config.js
@@ -261,6 +261,9 @@ module.exports = {
               },
               timeout: {
                 type: 'integer'
+              },
+              allowPrivatePeers: {
+                type: 'boolean'
               }
             },
             required: ['limits', 'timeout']

--- a/scripts/localnet/drop.js
+++ b/scripts/localnet/drop.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+'use strict';
+
+const { Command } = require('commander');
+const localnet = require('./localnet.js');
+
+const program = new Command();
+
+program
+    .description('Gracefully stop localnet and drop localnet PostgreSQL databases')
+    .option('--nodes <count>', 'fallback number of localnet databases', String(localnet.DEFAULTS.nodes))
+    .option('--runtime-dir <path>', 'generated runtime directory', localnet.DEFAULTS.runtimeDir)
+    .option('--logs-dir <path>', 'localnet log directory', localnet.DEFAULTS.logsDir)
+    .option('--timeout-ms <ms>', 'graceful shutdown timeout per node', String(localnet.DEFAULTS.stopTimeoutMs))
+    .option('--db-host <host>', 'PostgreSQL host', localnet.DEFAULTS.dbHost)
+    .option('--db-port <port>', 'PostgreSQL port', String(localnet.DEFAULTS.dbPort))
+    .option('--db-user <user>', 'node PostgreSQL owner/user', localnet.DEFAULTS.dbUser)
+    .option('--db-admin-user <user>', 'PostgreSQL user for dropping localnet databases')
+    .option('--db-admin-password <password>', 'PostgreSQL password for --db-admin-user')
+    .option('--db-name-prefix <prefix>', 'PostgreSQL database name prefix', localnet.DEFAULTS.dbNamePrefix)
+    .parse(process.argv);
+
+/**
+ * Drops localnet databases after graceful node shutdown.
+ */
+async function main () {
+  const options = program.opts();
+
+  options.stopTimeoutMs = options.timeoutMs;
+
+  const result = await localnet.dropLocalnet(options);
+
+  reportStopResult(result.stopResult);
+  reportDropResult(result.dropResult);
+
+  if (result.stopResult.timedOut.length || result.dropResult.failed.length) {
+    process.exit(1);
+  }
+}
+
+/**
+ * Prints stop status before dropping databases.
+ * @param {object} result - Localnet stop result.
+ */
+function reportStopResult (result) {
+  if (result.message) {
+    console.log(result.message);
+    return;
+  }
+
+  result.stopped.forEach(function (node) {
+    console.log('Stopped ' + node.id + ' pid ' + node.pid + '.');
+  });
+
+  result.missing.forEach(function (node) {
+    console.log('Already stopped or missing: ' + node.id + ' pid ' + node.pid + '.');
+  });
+
+  result.timedOut.forEach(function (node) {
+    console.error('Timed out waiting for graceful shutdown: ' + node.id + ' pid ' + node.pid + '.');
+  });
+}
+
+/**
+ * Prints database drop status.
+ * @param {object} result - Localnet database drop result.
+ */
+function reportDropResult (result) {
+  if (result.message) {
+    console.error(result.message);
+  }
+
+  result.dropped.forEach(function (databaseName) {
+    console.log('Dropped database ' + databaseName + '.');
+  });
+
+  result.skipped.forEach(function (databaseName) {
+    console.log('Database already absent: ' + databaseName + '.');
+  });
+
+  result.failed.forEach(function (failure) {
+    console.error('Failed to drop database ' + failure.database + ': ' + failure.error);
+  });
+}
+
+main().catch(function (error) {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/scripts/localnet/localnet.js
+++ b/scripts/localnet/localnet.js
@@ -211,7 +211,10 @@ async function stopLocalnet (input) {
       continue;
     }
 
-    process.kill(node.pid, 'SIGTERM');
+    if (!sendGracefulShutdownSignal(node.pid)) {
+      missing.push(node);
+      continue;
+    }
 
     // Do not escalate to SIGKILL; callers must inspect timedOut and decide manually.
     const exited = await waitForExit(node.pid, options.stopTimeoutMs);
@@ -558,13 +561,13 @@ function getLocalnetDatabaseNames (options, manifest) {
  * @param {object} options - Normalized localnet options.
  */
 function listLocalnetDatabases (options) {
-  const escapedPrefix = options.dbNamePrefix.replace(/'/g, '\'\'').replace(/_/g, '\\_');
+  const escapedPrefix = escapePostgresLikePattern(options.dbNamePrefix);
   const result = runPostgresCommand('psql', [
     '-d',
     'postgres',
     '-At',
     '-c',
-    'SELECT datname FROM pg_database WHERE datname LIKE \'' + escapedPrefix + '%\' ESCAPE \'\\\\\' ORDER BY datname'
+    'SELECT datname FROM pg_database WHERE datname LIKE \'' + escapedPrefix + '%\' ESCAPE E\'\\\\\' ORDER BY datname'
   ], options);
 
   if (result.status !== 0) {
@@ -577,6 +580,19 @@ function listLocalnetDatabases (options) {
         return databaseName.trim();
       })
       .filter(Boolean);
+}
+
+/**
+ * Escapes user-controlled text for a PostgreSQL LIKE pattern string literal and returns the quoted prefix.
+ * @param {string} value - Raw LIKE prefix text.
+ */
+function escapePostgresLikePattern (value) {
+  // Backslash must be escaped first because the query uses it as the LIKE escape character.
+  return String(value)
+      .replace(/\\/g, '\\\\')
+      .replace(/%/g, '\\%')
+      .replace(/_/g, '\\_')
+      .replace(/'/g, '\'\'');
 }
 
 /**
@@ -667,6 +683,23 @@ function isProcessRunning (pid) {
     return true;
   } catch (error) {
     return error.code === 'EPERM';
+  }
+}
+
+/**
+ * Sends the graceful shutdown signal to a node process and returns whether the signal was sent.
+ * @param {number} pid - Process ID.
+ */
+function sendGracefulShutdownSignal (pid) {
+  try {
+    process.kill(pid, 'SIGTERM');
+    return true;
+  } catch (error) {
+    if (error.code === 'ESRCH') {
+      return false;
+    }
+
+    throw error;
   }
 }
 

--- a/scripts/localnet/localnet.js
+++ b/scripts/localnet/localnet.js
@@ -1,0 +1,846 @@
+'use strict';
+
+const childProcess = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULTS = {
+  nodes: 3,
+  config: 'config.default.json',
+  genesis: 'test/genesisBlock.json',
+  genesisPasses: 'test/genesisPasses.json',
+  configOverrides: ['test/config.localnet.json'],
+  runtimeDir: '.localnet',
+  logsDir: 'logs-localnet',
+  bindAddress: '127.0.0.1',
+  basePort: 36670,
+  baseWsPort: 36770,
+  dbHost: 'localhost',
+  dbPort: 5432,
+  dbUser: 'adamanttest',
+  dbPassword: 'password',
+  dbAdminUser: null,
+  dbAdminPassword: null,
+  dbNamePrefix: 'adamant_localnet_node_',
+  redisUrl: 'redis://127.0.0.1:6379/10',
+  redisDbBase: 10,
+  stopTimeoutMs: 120000
+};
+
+/**
+ * Normalizes CLI/test input into a complete localnet option object.
+ * @param {object} input - Partial localnet options.
+ */
+function normalizeOptions (input) {
+  input = input || {};
+
+  const cwd = path.resolve(input.cwd || process.cwd());
+  const configOverrides = normalizePathList(
+      input.configOverrides !== undefined ? input.configOverrides : DEFAULTS.configOverrides
+  );
+
+  return {
+    cwd,
+    nodes: parsePositiveInteger(input.nodes, 'nodes', DEFAULTS.nodes),
+    config: normalizeRelativePath(input.config || DEFAULTS.config),
+    genesis: normalizeRelativePath(input.genesis || DEFAULTS.genesis),
+    genesisPasses: normalizeRelativePath(input.genesisPasses || DEFAULTS.genesisPasses),
+    delegateSecrets: Array.isArray(input.delegateSecrets) ? input.delegateSecrets.slice() : null,
+    configOverrides,
+    runtimeDir: path.resolve(cwd, input.runtimeDir || DEFAULTS.runtimeDir),
+    logsDir: path.resolve(cwd, input.logsDir || DEFAULTS.logsDir),
+    bindAddress: input.bindAddress || DEFAULTS.bindAddress,
+    basePort: parsePort(input.basePort, 'basePort', DEFAULTS.basePort),
+    baseWsPort: parsePort(input.baseWsPort, 'baseWsPort', DEFAULTS.baseWsPort),
+    dbHost: input.dbHost || DEFAULTS.dbHost,
+    dbPort: parsePort(input.dbPort, 'dbPort', DEFAULTS.dbPort),
+    dbUser: input.dbUser || DEFAULTS.dbUser,
+    dbPassword: input.dbPassword !== undefined ? input.dbPassword : DEFAULTS.dbPassword,
+    dbAdminUser: input.dbAdminUser !== undefined ? input.dbAdminUser : DEFAULTS.dbAdminUser,
+    dbAdminPassword: input.dbAdminPassword !== undefined ? input.dbAdminPassword : DEFAULTS.dbAdminPassword,
+    dbNamePrefix: input.dbNamePrefix || DEFAULTS.dbNamePrefix,
+    redisUrl: input.redisUrl || DEFAULTS.redisUrl,
+    redisDbBase: parseNonNegativeInteger(input.redisDbBase, 'redisDbBase', DEFAULTS.redisDbBase),
+    skipDbCreate: !!input.skipDbCreate,
+    dropOnStop: !!(input.dropOnStop || input.drop_on_stop),
+    force: !!input.force,
+    stopTimeoutMs: parsePositiveInteger(input.stopTimeoutMs, 'stopTimeoutMs', DEFAULTS.stopTimeoutMs)
+  };
+}
+
+/**
+ * Builds node definitions, generated override payloads, and startup commands.
+ * @param {object} options - Normalized localnet options.
+ */
+function buildLocalnetPlan (options) {
+  const nodes = [];
+  const delegateSecrets = options.delegateSecrets || loadGenesisDelegateSecrets(options);
+  const delegateSecretBatches = distributeDelegateSecrets(delegateSecrets, options.nodes);
+
+  for (let index = 1; index <= options.nodes; index++) {
+    const nodeId = 'node-' + index;
+    const port = options.basePort + index - 1;
+    const wsClientPort = options.baseWsPort + index - 1;
+    const logDir = path.join(options.logsDir, nodeId);
+    const runtimeDir = path.join(options.runtimeDir, nodeId);
+    const dbName = options.dbNamePrefix + index;
+    const redisUrl = withRedisDatabase(options.redisUrl, options.redisDbBase + index - 1);
+
+    nodes.push({
+      id: nodeId,
+      index,
+      host: options.bindAddress,
+      port,
+      wsClientPort,
+      apiUrl: 'http://' + options.bindAddress + ':' + port,
+      wsClientUrl: 'ws://' + options.bindAddress + ':' + wsClientPort,
+      logDir,
+      runtimeDir,
+      overrideFile: path.join(runtimeDir, 'config.overrides.json'),
+      stdoutFile: path.join(logDir, 'stdout.log'),
+      stderrFile: path.join(logDir, 'stderr.log'),
+      generalLogFile: path.join(logDir, 'adamant_localnet.log'),
+      debugLogFile: path.join(logDir, 'adamant_localnet_debug.log'),
+      delegateSecrets: delegateSecretBatches[index - 1],
+      delegateSecretsCount: delegateSecretBatches[index - 1].length,
+      db: {
+        host: options.dbHost,
+        port: options.dbPort,
+        database: dbName,
+        user: options.dbUser
+      },
+      redis: {
+        url: redisUrl
+      }
+    });
+  }
+
+  nodes.forEach(function (node) {
+    // Localnet uses static peer lists so nodes do not connect to public testnet peers.
+    node.peers = nodes
+        .filter(function (peerNode) {
+          return peerNode.id !== node.id;
+        })
+        .map(function (peerNode) {
+          return {
+            ip: peerNode.host,
+            port: peerNode.port
+          };
+        });
+
+    node.overrides = buildNodeOverrides(node, options);
+    node.args = buildNodeArgs(node, options);
+    node.command = ['node'].concat(node.args).join(' ');
+  });
+
+  return {
+    manifestPath: getManifestPath(options),
+    options,
+    nodes
+  };
+}
+
+/**
+ * Starts every localnet node in detached/headless mode.
+ * @param {object} input - Partial localnet options.
+ */
+function startLocalnet (input) {
+  const options = normalizeOptions(input);
+  const plan = buildLocalnetPlan(options);
+
+  assertNoRunningLocalnet(plan.manifestPath, options.force);
+  ensureDirectory(options.runtimeDir);
+  ensureDirectory(options.logsDir);
+
+  plan.nodes.forEach(function (node) {
+    ensureDirectory(node.runtimeDir);
+    ensureDirectory(node.logDir);
+    writeJsonFile(node.overrideFile, node.overrides);
+  });
+
+  if (!options.skipDbCreate) {
+    plan.nodes.forEach(function (node) {
+      ensureDatabase(node, options);
+    });
+  }
+
+  const manifest = buildManifest(plan, []);
+  writeJsonFile(plan.manifestPath, manifest);
+
+  plan.nodes.forEach(function (node) {
+    const child = spawnNode(node, options);
+    node.pid = child.pid;
+    node.startedAt = new Date().toISOString();
+    manifest.nodes.push(toManifestNode(node));
+    // Persist after every spawn so stop:localnet can clean up a partially started network.
+    writeJsonFile(plan.manifestPath, manifest);
+  });
+
+  manifest.status = 'running';
+  writeJsonFile(plan.manifestPath, manifest);
+
+  return manifest;
+}
+
+/**
+ * Stops every managed localnet process through the node graceful shutdown path.
+ * @param {object} input - Partial localnet options.
+ */
+async function stopLocalnet (input) {
+  const options = normalizeOptions(input);
+  const manifestPath = getManifestPath(options);
+
+  if (!fs.existsSync(manifestPath)) {
+    return {
+      manifestPath,
+      stopped: [],
+      missing: [],
+      timedOut: [],
+      message: 'No localnet manifest found.'
+    };
+  }
+
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const stopped = [];
+  const missing = [];
+  const timedOut = [];
+
+  for (const node of manifest.nodes || []) {
+    if (!node.pid || !isProcessRunning(node.pid)) {
+      missing.push(node);
+      continue;
+    }
+
+    process.kill(node.pid, 'SIGTERM');
+
+    // Do not escalate to SIGKILL; callers must inspect timedOut and decide manually.
+    const exited = await waitForExit(node.pid, options.stopTimeoutMs);
+
+    if (exited) {
+      stopped.push(node);
+    } else {
+      timedOut.push(node);
+    }
+  }
+
+  manifest.status = timedOut.length ? 'stopping-timeout' : 'stopped';
+  manifest.stoppedAt = new Date().toISOString();
+  manifest.stopResult = {
+    stopped: stopped.map(function (node) {
+      return node.id;
+    }),
+    missing: missing.map(function (node) {
+      return node.id;
+    }),
+    timedOut: timedOut.map(function (node) {
+      return node.id;
+    })
+  };
+  writeJsonFile(manifestPath, manifest);
+
+  let dropResult = null;
+  if (options.dropOnStop && !timedOut.length) {
+    dropResult = dropLocalnetDatabases(options, manifest);
+    manifest.dropResult = dropResult;
+    writeJsonFile(manifestPath, manifest);
+  }
+
+  return {
+    manifestPath,
+    stopped,
+    missing,
+    timedOut,
+    dropResult
+  };
+}
+
+/**
+ * Builds the generated config override JSON for one localnet node.
+ * @param {object} node - Localnet node definition.
+ * @param {object} options - Normalized localnet options.
+ */
+function buildNodeOverrides (node, options) {
+  return {
+    port: node.port,
+    address: options.bindAddress,
+    generalLog: {
+      fileName: toRelativePath(options.cwd, node.generalLogFile)
+    },
+    debugLog: {
+      fileName: toRelativePath(options.cwd, node.debugLogFile)
+    },
+    db: {
+      database: node.db.database
+    },
+    redis: {
+      url: node.redis.url
+    },
+    forging: {
+      secret: node.delegateSecrets
+    },
+    peers: {
+      list: node.peers,
+      options: {
+        allowPrivatePeers: true
+      }
+    },
+    wsClient: {
+      portWS: node.wsClientPort
+    }
+  };
+}
+
+/**
+ * Builds the app.js argv list for one localnet node.
+ * @param {object} node - Localnet node definition.
+ * @param {object} options - Normalized localnet options.
+ */
+function buildNodeArgs (node, options) {
+  const args = [
+    'app.js',
+    '--config',
+    options.config,
+    '--genesis',
+    options.genesis
+  ];
+
+  options.configOverrides.forEach(function (overrideFile) {
+    args.push('--config-overrides', overrideFile);
+  });
+
+  // Generated per-node overrides are last so ports/logs/databases stay isolated.
+  args.push('--config-overrides', toRelativePath(options.cwd, node.overrideFile));
+
+  return args;
+}
+
+/**
+ * Builds a localnet manifest document.
+ * @param {object} plan - Localnet plan.
+ * @param {Array<object>} nodes - Manifest node entries.
+ */
+function buildManifest (plan, nodes) {
+  return {
+    version: 1,
+    status: 'starting',
+    startedAt: new Date().toISOString(),
+    cwd: plan.options.cwd,
+    baseConfig: plan.options.config,
+    genesisBlock: plan.options.genesis,
+    genesisPasses: plan.options.genesisPasses,
+    configOverrides: plan.options.configOverrides,
+    generatedRuntimeDir: toRelativePath(plan.options.cwd, plan.options.runtimeDir),
+    logsDir: toRelativePath(plan.options.cwd, plan.options.logsDir),
+    nodes
+  };
+}
+
+/**
+ * Converts an internal node definition into public manifest metadata.
+ * @param {object} node - Localnet node definition.
+ */
+function toManifestNode (node) {
+  return {
+    id: node.id,
+    index: node.index,
+    pid: node.pid,
+    startedAt: node.startedAt,
+    host: node.host,
+    port: node.port,
+    wsClientPort: node.wsClientPort,
+    apiUrl: node.apiUrl,
+    wsClientUrl: node.wsClientUrl,
+    peers: node.peers,
+    db: node.db,
+    redis: node.redis,
+    runtimeDir: node.runtimeDir,
+    logDir: node.logDir,
+    overrideFile: node.overrideFile,
+    stdoutFile: node.stdoutFile,
+    stderrFile: node.stderrFile,
+    generalLogFile: node.generalLogFile,
+    debugLogFile: node.debugLogFile,
+    delegateSecretsCount: node.delegateSecretsCount,
+    command: node.command
+  };
+}
+
+/**
+ * Loads genesis delegate passphrases used to enable localnet forging.
+ * @param {object} options - Normalized localnet options.
+ */
+function loadGenesisDelegateSecrets (options) {
+  const genesisPassesPath = path.resolve(options.cwd, options.genesisPasses);
+  const genesisPasses = JSON.parse(fs.readFileSync(genesisPassesPath, 'utf8'));
+
+  if (!genesisPasses.delegates || !Array.isArray(genesisPasses.delegates)) {
+    throw Error('Invalid genesis passes file "' + options.genesisPasses + '": expected delegates array');
+  }
+
+  return genesisPasses.delegates.map(function (delegate) {
+    return delegate.secret;
+  }).filter(Boolean);
+}
+
+/**
+ * Splits delegate passphrases across localnet nodes.
+ * @param {Array<string>} delegateSecrets - Forging passphrases from genesis delegates.
+ * @param {number} nodeCount - Number of localnet nodes.
+ */
+function distributeDelegateSecrets (delegateSecrets, nodeCount) {
+  const batches = Array.from({ length: nodeCount }, function () {
+    return [];
+  });
+  const forgingNodeCount = nodeCount > 3 ? nodeCount - 1 : nodeCount;
+
+  delegateSecrets.forEach(function (secret, index) {
+    batches[index % forgingNodeCount].push(secret);
+  });
+
+  return batches;
+}
+
+/**
+ * Spawns one ADAMANT node as a detached background process.
+ * @param {object} node - Localnet node definition.
+ * @param {object} options - Normalized localnet options.
+ */
+function spawnNode (node, options) {
+  const stdout = fs.openSync(node.stdoutFile, 'a');
+  const stderr = fs.openSync(node.stderrFile, 'a');
+  let child;
+
+  try {
+    child = childProcess.spawn(process.execPath, node.args, {
+      cwd: options.cwd,
+      detached: true,
+      stdio: ['ignore', stdout, stderr]
+    });
+  } finally {
+    // The detached child owns the duplicated descriptors; the parent must not leak them.
+    fs.closeSync(stdout);
+    fs.closeSync(stderr);
+  }
+
+  child.unref();
+
+  return child;
+}
+
+/**
+ * Ensures the PostgreSQL database for one localnet node exists.
+ * @param {object} node - Localnet node definition.
+ * @param {object} options - Normalized localnet options.
+ */
+function ensureDatabase (node, options) {
+  const result = runPostgresCommand('createdb', [
+    '-O',
+    options.dbUser,
+    node.db.database
+  ], options);
+
+  if (result.status === 0) {
+    return;
+  }
+
+  const output = [result.stdout, result.stderr, result.error && result.error.message]
+      .filter(Boolean)
+      .join('\n');
+
+  if (/already exists/i.test(output)) {
+    return;
+  }
+
+  throw Error(
+      'Failed to create PostgreSQL database "' +
+      node.db.database +
+      '". Create it manually, rerun with --skip-db-create, or pass --db-admin-user. ' +
+      output
+  );
+}
+
+/**
+ * Stops a localnet if needed and drops all matching localnet databases.
+ * @param {object} input - Partial localnet options.
+ */
+async function dropLocalnet (input) {
+  const options = normalizeOptions(input);
+  const stopResult = await stopLocalnet(options);
+
+  if (stopResult.timedOut.length) {
+    return {
+      stopResult,
+      dropResult: {
+        dropped: [],
+        skipped: [],
+        failed: [],
+        message: 'Database drop skipped because some nodes did not stop gracefully.'
+      }
+    };
+  }
+
+  const manifest = fs.existsSync(stopResult.manifestPath) ?
+    JSON.parse(fs.readFileSync(stopResult.manifestPath, 'utf8')) :
+    null;
+  const dropResult = dropLocalnetDatabases(options, manifest);
+
+  return {
+    stopResult,
+    dropResult
+  };
+}
+
+/**
+ * Drops localnet databases found by prefix and manifest metadata.
+ * @param {object} options - Normalized localnet options.
+ * @param {?object} manifest - Localnet manifest, when available.
+ */
+function dropLocalnetDatabases (options, manifest) {
+  const databaseNames = getLocalnetDatabaseNames(options, manifest);
+  const result = {
+    dropped: [],
+    skipped: [],
+    failed: []
+  };
+
+  databaseNames.forEach(function (databaseName) {
+    const dropResult = runPostgresCommand('dropdb', [
+      '--if-exists',
+      databaseName
+    ], options);
+    const output = formatCommandOutput(dropResult);
+
+    if (dropResult.status === 0) {
+      result.dropped.push(databaseName);
+    } else if (/does not exist/i.test(output)) {
+      result.skipped.push(databaseName);
+    } else {
+      result.failed.push({
+        database: databaseName,
+        error: output
+      });
+    }
+  });
+
+  return result;
+}
+
+/**
+ * Finds database names to drop from PostgreSQL metadata and manifest fallback.
+ * @param {object} options - Normalized localnet options.
+ * @param {?object} manifest - Localnet manifest, when available.
+ */
+function getLocalnetDatabaseNames (options, manifest) {
+  const names = new Set();
+  const listedNames = listLocalnetDatabases(options);
+
+  listedNames.forEach(function (databaseName) {
+    names.add(databaseName);
+  });
+
+  (manifest && manifest.nodes || []).forEach(function (node) {
+    if (node.db && node.db.database) {
+      names.add(node.db.database);
+    }
+  });
+
+  if (!names.size) {
+    for (let index = 1; index <= options.nodes; index++) {
+      names.add(options.dbNamePrefix + index);
+    }
+  }
+
+  return Array.from(names).sort();
+}
+
+/**
+ * Lists localnet databases by configured prefix.
+ * @param {object} options - Normalized localnet options.
+ */
+function listLocalnetDatabases (options) {
+  const escapedPrefix = options.dbNamePrefix.replace(/'/g, '\'\'').replace(/_/g, '\\_');
+  const result = runPostgresCommand('psql', [
+    '-d',
+    'postgres',
+    '-At',
+    '-c',
+    'SELECT datname FROM pg_database WHERE datname LIKE \'' + escapedPrefix + '%\' ESCAPE \'\\\\\' ORDER BY datname'
+  ], options);
+
+  if (result.status !== 0) {
+    return [];
+  }
+
+  return (result.stdout || '')
+      .split(/\r?\n/)
+      .map(function (databaseName) {
+        return databaseName.trim();
+      })
+      .filter(Boolean);
+}
+
+/**
+ * Runs a PostgreSQL CLI command with localnet admin connection flags.
+ * @param {string} command - PostgreSQL CLI command name.
+ * @param {Array<string>} args - Command-specific arguments.
+ * @param {object} options - Normalized localnet options.
+ */
+function runPostgresCommand (command, args, options) {
+  const env = Object.assign({}, process.env);
+  const commandArgs = [
+    '-h',
+    options.dbHost,
+    '-p',
+    String(options.dbPort)
+  ];
+
+  if (options.dbAdminUser) {
+    commandArgs.push('-U', options.dbAdminUser);
+  }
+
+  if (options.dbAdminPassword !== undefined && options.dbAdminPassword !== null) {
+    env.PGPASSWORD = options.dbAdminPassword;
+  }
+
+  return childProcess.spawnSync(command, commandArgs.concat(args), {
+    cwd: options.cwd,
+    env,
+    encoding: 'utf8'
+  });
+}
+
+/**
+ * Formats child process output for user-facing errors.
+ * @param {object} result - spawnSync result object.
+ */
+function formatCommandOutput (result) {
+  return [result.stdout, result.stderr, result.error && result.error.message]
+      .filter(Boolean)
+      .join('\n');
+}
+
+/**
+ * Refuses unsafe localnet starts when the previous manifest is active or unclear.
+ * @param {string} manifestPath - Localnet manifest path.
+ * @param {boolean} force - Whether to replace a stale non-running manifest.
+ */
+function assertNoRunningLocalnet (manifestPath, force) {
+  if (!fs.existsSync(manifestPath)) {
+    return;
+  }
+
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const running = (manifest.nodes || []).filter(function (node) {
+    return node.pid && isProcessRunning(node.pid);
+  });
+
+  if (running.length) {
+    throw Error(
+        'Localnet manifest already contains running nodes: ' +
+        running.map(function (node) {
+          return node.id + ' pid ' + node.pid;
+        }).join(', ') +
+        '. Run npm run stop:localnet first.'
+    );
+  }
+
+  if (manifest.status === 'stopped') {
+    return;
+  }
+
+  if (!force) {
+    throw Error(
+        'Localnet manifest already exists at ' +
+        manifestPath +
+        '. Pass --force to replace the stale manifest.'
+    );
+  }
+}
+
+/**
+ * Checks whether a process exists without sending a real signal.
+ * @param {number} pid - Process ID.
+ */
+function isProcessRunning (pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error.code === 'EPERM';
+  }
+}
+
+/**
+ * Waits until a process exits or a timeout expires.
+ * @param {number} pid - Process ID.
+ * @param {number} timeoutMs - Maximum wait time in milliseconds.
+ */
+function waitForExit (pid, timeoutMs) {
+  const started = Date.now();
+
+  return new Promise(function (resolve) {
+    function check () {
+      if (!isProcessRunning(pid)) {
+        return resolve(true);
+      }
+
+      if (Date.now() - started >= timeoutMs) {
+        return resolve(false);
+      }
+
+      setTimeout(check, 250);
+    }
+
+    check();
+  });
+}
+
+/**
+ * Returns the manifest path for a localnet runtime directory.
+ * @param {object} options - Normalized localnet options.
+ */
+function getManifestPath (options) {
+  return path.join(options.runtimeDir, 'manifest.json');
+}
+
+/**
+ * Writes JSON with stable formatting.
+ * @param {string} filePath - Target file path.
+ * @param {object} data - JSON-serializable data.
+ */
+function writeJsonFile (filePath, data) {
+  ensureDirectory(path.dirname(filePath));
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + '\n');
+}
+
+/**
+ * Creates a directory and its parents when missing.
+ * @param {string} dirPath - Directory path.
+ */
+function ensureDirectory (dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+/**
+ * Returns a Redis URL with a deterministic database index.
+ * @param {string} redisUrl - Base Redis URL.
+ * @param {number} databaseIndex - Redis logical database index.
+ */
+function withRedisDatabase (redisUrl, databaseIndex) {
+  try {
+    const url = new URL(redisUrl);
+    url.pathname = '/' + databaseIndex;
+    return url.toString();
+  } catch (error) {
+    return redisUrl.replace(/\/\d+\/?$/, '') + '/' + databaseIndex;
+  }
+}
+
+/**
+ * Converts a path to cwd-relative form when it is safely inside cwd.
+ * @param {string} cwd - Current working directory.
+ * @param {string} targetPath - Target path.
+ */
+function toRelativePath (cwd, targetPath) {
+  const relativePath = path.relative(cwd, targetPath);
+
+  if (!relativePath || relativePath.indexOf('..') === 0 || path.isAbsolute(relativePath)) {
+    return targetPath;
+  }
+
+  return relativePath;
+}
+
+/**
+ * Normalizes path separators for CLI arguments that should remain relative.
+ * @param {string} value - Path value.
+ */
+function normalizeRelativePath (value) {
+  return String(value).replace(/\\/g, '/');
+}
+
+/**
+ * Normalizes optional path input into an ordered path list.
+ * @param {string|Array<string>} value - Path or paths.
+ */
+function normalizePathList (value) {
+  if (Array.isArray(value)) {
+    return value.map(normalizeRelativePath);
+  }
+
+  if (!value) {
+    return [];
+  }
+
+  return [normalizeRelativePath(value)];
+}
+
+/**
+ * Parses a positive integer option.
+ * @param {*} value - Raw option value.
+ * @param {string} name - Option name for error messages.
+ * @param {number} fallback - Fallback value when the raw value is empty.
+ */
+function parsePositiveInteger (value, name, fallback) {
+  const parsed = value === undefined || value === null ? fallback : Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw Error('Invalid ' + name + ': expected a positive integer');
+  }
+
+  return parsed;
+}
+
+/**
+ * Parses a non-negative integer option.
+ * @param {*} value - Raw option value.
+ * @param {string} name - Option name for error messages.
+ * @param {number} fallback - Fallback value when the raw value is empty.
+ */
+function parseNonNegativeInteger (value, name, fallback) {
+  const parsed = value === undefined || value === null ? fallback : Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw Error('Invalid ' + name + ': expected a non-negative integer');
+  }
+
+  return parsed;
+}
+
+/**
+ * Parses and validates a TCP port option.
+ * @param {*} value - Raw option value.
+ * @param {string} name - Option name for error messages.
+ * @param {number} fallback - Fallback value when the raw value is empty.
+ */
+function parsePort (value, name, fallback) {
+  const parsed = parsePositiveInteger(value, name, fallback);
+
+  if (parsed > 65535) {
+    throw Error('Invalid ' + name + ': expected a TCP port between 1 and 65535');
+  }
+
+  return parsed;
+}
+
+module.exports = {
+  DEFAULTS,
+  normalizeOptions,
+  buildLocalnetPlan,
+  buildNodeOverrides,
+  buildNodeArgs,
+  buildManifest,
+  toManifestNode,
+  loadGenesisDelegateSecrets,
+  distributeDelegateSecrets,
+  withRedisDatabase,
+  startLocalnet,
+  stopLocalnet,
+  dropLocalnet,
+  dropLocalnetDatabases,
+  getLocalnetDatabaseNames,
+  listLocalnetDatabases,
+  isProcessRunning,
+  waitForExit,
+  getManifestPath
+};

--- a/scripts/localnet/localnet.js
+++ b/scripts/localnet/localnet.js
@@ -6,7 +6,7 @@ const path = require('path');
 
 const DEFAULTS = {
   nodes: 3,
-  config: 'config.default.json',
+  config: 'test/config.default.json',
   genesis: 'test/genesisBlock.json',
   genesisPasses: 'test/genesisPasses.json',
   configOverrides: ['test/config.localnet.json'],

--- a/scripts/localnet/start.js
+++ b/scripts/localnet/start.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+'use strict';
+
+const { Command } = require('commander');
+const localnet = require('./localnet.js');
+
+const program = new Command();
+
+program
+    .description('Start an ADAMANT localnet in background/headless mode')
+    .option('--nodes <count>', 'number of localnet nodes', String(localnet.DEFAULTS.nodes))
+    .option('--config <path>', 'base config file', localnet.DEFAULTS.config)
+    .option('--genesis <path>', 'genesis block file', localnet.DEFAULTS.genesis)
+    .option('--genesis-passes <path>', 'genesis delegate passphrase file', localnet.DEFAULTS.genesisPasses)
+    .option('--config-overrides <path>', 'base config override file', collectOption, [])
+    .option('--runtime-dir <path>', 'generated runtime directory', localnet.DEFAULTS.runtimeDir)
+    .option('--logs-dir <path>', 'localnet log directory', localnet.DEFAULTS.logsDir)
+    .option('--bind-address <ip>', 'local bind address', localnet.DEFAULTS.bindAddress)
+    .option('--base-port <port>', 'first node HTTP/peer port', String(localnet.DEFAULTS.basePort))
+    .option('--base-ws-port <port>', 'first node WebSocket client port', String(localnet.DEFAULTS.baseWsPort))
+    .option('--db-host <host>', 'PostgreSQL host', localnet.DEFAULTS.dbHost)
+    .option('--db-port <port>', 'PostgreSQL port', String(localnet.DEFAULTS.dbPort))
+    .option('--db-user <user>', 'PostgreSQL user', localnet.DEFAULTS.dbUser)
+    .option('--db-password <password>', 'PostgreSQL password', localnet.DEFAULTS.dbPassword)
+    .option('--db-admin-user <user>', 'PostgreSQL user for creating localnet databases')
+    .option('--db-admin-password <password>', 'PostgreSQL password for --db-admin-user')
+    .option('--db-name-prefix <prefix>', 'PostgreSQL database name prefix', localnet.DEFAULTS.dbNamePrefix)
+    .option('--redis-url <url>', 'base Redis URL', localnet.DEFAULTS.redisUrl)
+    .option('--redis-db-base <index>', 'first Redis database index', String(localnet.DEFAULTS.redisDbBase))
+    .option('--skip-db-create', 'do not create per-node PostgreSQL databases')
+    .option('--force', 'replace a stale localnet manifest without running PIDs')
+    .addHelpText('after', '\nWhen no --config-overrides is passed, test/config.localnet.json is used.')
+    .parse(process.argv);
+
+/**
+ * Collects repeatable Commander options in declaration order.
+ * @param {string} value - Current option value.
+ * @param {Array<string>} previous - Values collected so far.
+ */
+function collectOption (value, previous) {
+  previous.push(value);
+  return previous;
+}
+
+/**
+ * Starts localnet from parsed CLI options and prints connection metadata.
+ */
+function main () {
+  const options = program.opts();
+
+  if (!options.configOverrides.length) {
+    // Commander cannot display this dynamic default for repeatable options.
+    options.configOverrides = localnet.DEFAULTS.configOverrides;
+  }
+
+  const manifest = localnet.startLocalnet(options);
+
+  console.log('Started ADAMANT localnet with ' + manifest.nodes.length + ' node(s).');
+  console.log('Manifest: ' + manifest.generatedRuntimeDir + '/manifest.json');
+  console.log('Logs: ' + manifest.logsDir + '/node-N/');
+  manifest.nodes.forEach(function (node) {
+    console.log('- ' + node.id + ': pid ' + node.pid + ', API ' + node.apiUrl + ', WS ' + node.wsClientUrl);
+  });
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}

--- a/scripts/localnet/status.js
+++ b/scripts/localnet/status.js
@@ -1,0 +1,356 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const http = require('http');
+const https = require('https');
+const { Command } = require('commander');
+const localnet = require('./localnet.js');
+
+const DEFAULT_TIMEOUT_MS = 3000;
+const FORGED_BLOCK_PATTERN = /^\[[^\]]+\]\s+([0-9TZ:.+-]+)\s+\|\s+delegates\s+\|\s+Forged new block id:/;
+
+const program = new Command();
+
+program
+    .description('Show ADAMANT localnet process, API, delegate, and forging status')
+    .option('--runtime-dir <path>', 'generated runtime directory', localnet.DEFAULTS.runtimeDir)
+    .option('--logs-dir <path>', 'localnet log directory', localnet.DEFAULTS.logsDir)
+    .option('--timeout-ms <ms>', 'HTTP status request timeout per node', String(DEFAULT_TIMEOUT_MS));
+
+/**
+ * Collects manifest, process, API, config, and log status for localnet.
+ * @param {object} input - Partial localnet status options.
+ */
+async function getLocalnetStatus (input) {
+  input = input || {};
+
+  const options = localnet.normalizeOptions(input);
+  const manifestPath = localnet.getManifestPath(options);
+
+  if (!fs.existsSync(manifestPath)) {
+    return {
+      manifestPath,
+      manifestExists: false,
+      nodes: []
+    };
+  }
+
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const timeoutMs = parsePositiveInteger(input.timeoutMs, 'timeoutMs', DEFAULT_TIMEOUT_MS);
+  const nodes = await Promise.all((manifest.nodes || []).map(function (node) {
+    return getNodeStatus(node, timeoutMs);
+  }));
+
+  return {
+    manifestPath,
+    manifestExists: true,
+    manifest,
+    nodes,
+    summary: buildSummary(manifest, nodes)
+  };
+}
+
+/**
+ * Collects status for one manifest node.
+ * @param {object} node - Manifest node entry.
+ * @param {number} timeoutMs - HTTP request timeout in milliseconds.
+ */
+async function getNodeStatus (node, timeoutMs) {
+  const pidRunning = !!(node.pid && localnet.isProcessRunning(node.pid));
+  const api = await fetchNodeApiStatus(node.apiUrl, timeoutMs);
+
+  return {
+    id: node.id,
+    pid: node.pid,
+    pidRunning,
+    apiUrl: node.apiUrl,
+    wsClientUrl: node.wsClientUrl,
+    api,
+    delegateSecretsCount: readDelegateSecretsCount(node),
+    lastForging: findLastForgingEvent(node.generalLogFile)
+  };
+}
+
+/**
+ * Requests `/api/node/status` from one localnet node.
+ * @param {string} apiUrl - Base node API URL from manifest.
+ * @param {number} timeoutMs - HTTP request timeout in milliseconds.
+ */
+function fetchNodeApiStatus (apiUrl, timeoutMs) {
+  return new Promise(function (resolve) {
+    const statusUrl = new URL(apiUrl);
+    statusUrl.pathname = '/api/node/status';
+    statusUrl.search = '';
+
+    const transport = statusUrl.protocol === 'https:' ? https : http;
+    const request = transport.get(statusUrl, function (response) {
+      const chunks = [];
+
+      response.on('data', function (chunk) {
+        chunks.push(chunk);
+      });
+
+      response.on('end', function () {
+        const body = Buffer.concat(chunks).toString('utf8');
+
+        try {
+          const parsedBody = JSON.parse(body);
+          const payload = extractNodeStatusPayload(parsedBody);
+
+          resolve({
+            ok: response.statusCode >= 200 && response.statusCode < 300 && parsedBody.success !== false,
+            statusCode: response.statusCode,
+            payload,
+            error: parsedBody.error || null
+          });
+        } catch (error) {
+          resolve({
+            ok: false,
+            statusCode: response.statusCode,
+            payload: null,
+            error: 'Invalid JSON response: ' + error.message
+          });
+        }
+      });
+    });
+
+    request.setTimeout(timeoutMs, function () {
+      // Destroying the client request does not affect the node process; it only ends this status probe.
+      request.destroy(Error('Request timed out after ' + timeoutMs + ' ms'));
+    });
+
+    request.on('error', function (error) {
+      resolve({
+        ok: false,
+        statusCode: null,
+        payload: null,
+        error: error.message
+      });
+    });
+  });
+}
+
+/**
+ * Normalizes current and possible future API response wrappers.
+ * @param {object} body - Parsed `/api/node/status` response body.
+ */
+function extractNodeStatusPayload (body) {
+  if (!body || typeof body !== 'object') {
+    return null;
+  }
+
+  return body.node || body.status || body.data || body;
+}
+
+/**
+ * Reads configured forging delegate count from a generated node override file.
+ * @param {object} node - Manifest node entry.
+ */
+function readDelegateSecretsCount (node) {
+  if (!node.overrideFile || !fs.existsSync(node.overrideFile)) {
+    return node.delegateSecretsCount || 0;
+  }
+
+  const overrides = JSON.parse(fs.readFileSync(node.overrideFile, 'utf8'));
+  const secrets = overrides.forging && overrides.forging.secret;
+
+  if (Array.isArray(secrets)) {
+    return secrets.length;
+  }
+
+  return secrets ? 1 : 0;
+}
+
+/**
+ * Finds the last successful forging event in a node general log.
+ * @param {string} logFile - Path to a node general log file.
+ */
+function findLastForgingEvent (logFile) {
+  if (!logFile || !fs.existsSync(logFile)) {
+    return null;
+  }
+
+  const lines = fs.readFileSync(logFile, 'utf8').split(/\r?\n/);
+  let lastEvent = null;
+
+  lines.forEach(function (line) {
+    const match = FORGED_BLOCK_PATTERN.exec(line);
+
+    if (!match) {
+      return;
+    }
+
+    const timestampMs = Date.parse(match[1]);
+
+    if (!Number.isNaN(timestampMs)) {
+      lastEvent = {
+        timestamp: new Date(timestampMs).toISOString(),
+        timestampMs,
+        line
+      };
+    }
+  });
+
+  return lastEvent;
+}
+
+/**
+ * Builds aggregate localnet counters from node statuses.
+ * @param {object} manifest - Localnet manifest.
+ * @param {Array<object>} nodes - Per-node status entries.
+ */
+function buildSummary (manifest, nodes) {
+  const apiOkNodes = nodes.filter(function (node) {
+    return node.api.ok;
+  });
+  const heights = apiOkNodes.map(function (node) {
+    return node.api.payload && node.api.payload.network && node.api.payload.network.height;
+  }).filter(function (height) {
+    return Number.isFinite(height);
+  });
+
+  return {
+    status: manifest.status || 'unknown',
+    nodesTotal: nodes.length,
+    processesRunning: nodes.filter(function (node) {
+      return node.pidRunning;
+    }).length,
+    apiReachable: apiOkNodes.length,
+    minHeight: heights.length ? Math.min.apply(null, heights) : null,
+    maxHeight: heights.length ? Math.max.apply(null, heights) : null
+  };
+}
+
+/**
+ * Formats localnet status as a compact terminal report.
+ * @param {object} status - Localnet status returned by `getLocalnetStatus`.
+ */
+function formatStatusReport (status) {
+  if (!status.manifestExists) {
+    return 'No localnet manifest found at ' + status.manifestPath + '.';
+  }
+
+  const lines = [];
+  const summary = status.summary;
+  const heightText = summary.minHeight === null ?
+    'n/a' :
+    summary.minHeight === summary.maxHeight ? String(summary.maxHeight) : summary.minHeight + '..' + summary.maxHeight;
+
+  lines.push('Localnet status: ' + summary.status);
+  lines.push('Manifest: ' + status.manifestPath);
+  lines.push(
+      'Nodes: ' +
+      summary.nodesTotal +
+      ' total, ' +
+      summary.processesRunning +
+      ' process(es) running, ' +
+      summary.apiReachable +
+      ' API reachable, height ' +
+      heightText
+  );
+
+  status.nodes.forEach(function (node) {
+    lines.push(formatNodeStatusLine(node));
+  });
+
+  return lines.join('\n');
+}
+
+/**
+ * Formats one node status line.
+ * @param {object} node - Per-node status entry.
+ */
+function formatNodeStatusLine (node) {
+  const payload = node.api.payload || {};
+  const network = payload.network || {};
+  const loader = payload.loader || {};
+  const apiState = node.api.ok ? 'api ok' : 'api unavailable: ' + (node.api.error || 'unknown error');
+  const processState = node.pidRunning ? 'pid ' + node.pid + ' running' : 'pid ' + (node.pid || 'n/a') + ' not running';
+  const height = Number.isFinite(network.height) ? network.height : 'n/a';
+  const nethash = network.nethash || 'n/a';
+  const consensus = Number.isFinite(loader.consensus) ? loader.consensus + '%' : 'n/a';
+
+  return [
+    '- ' + node.id + ':',
+    processState + ',',
+    apiState + ',',
+    'height ' + height + ',',
+    'loaded ' + formatBoolean(loader.loaded) + ',',
+    'syncing ' + formatBoolean(loader.syncing) + ',',
+    'consensus ' + consensus + ',',
+    'delegates ' + node.delegateSecretsCount + ',',
+    'last forge ' + formatLastForging(node.lastForging) + ',',
+    'nethash ' + nethash
+  ].join(' ');
+}
+
+/**
+ * Formats boolean-like API values for terminal output.
+ * @param {*} value - API value.
+ */
+function formatBoolean (value) {
+  return typeof value === 'boolean' ? String(value) : 'n/a';
+}
+
+/**
+ * Formats a forging event with relative age.
+ * @param {?object} event - Forging event returned by `findLastForgingEvent`.
+ */
+function formatLastForging (event) {
+  if (!event) {
+    return 'never';
+  }
+
+  const secondsAgo = Math.max(0, Math.floor((Date.now() - event.timestampMs) / 1000));
+
+  return event.timestamp + ' (' + secondsAgo + 's ago)';
+}
+
+/**
+ * Parses a positive integer option for standalone status execution.
+ * @param {*} value - Raw option value.
+ * @param {string} name - Option name for error messages.
+ * @param {number} fallback - Fallback value when the raw value is empty.
+ */
+function parsePositiveInteger (value, name, fallback) {
+  const parsed = value === undefined || value === null ? fallback : Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw Error('Invalid ' + name + ': expected a positive integer');
+  }
+
+  return parsed;
+}
+
+/**
+ * Runs status collection from parsed CLI options and prints the report.
+ */
+async function main () {
+  program.parse(process.argv);
+
+  const status = await getLocalnetStatus(program.opts());
+
+  console.log(formatStatusReport(status));
+}
+
+if (require.main === module) {
+  main().catch(function (error) {
+    console.error(error.message);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  getLocalnetStatus,
+  getNodeStatus,
+  fetchNodeApiStatus,
+  extractNodeStatusPayload,
+  readDelegateSecretsCount,
+  findLastForgingEvent,
+  buildSummary,
+  formatStatusReport,
+  formatNodeStatusLine,
+  formatBoolean,
+  formatLastForging
+};

--- a/scripts/localnet/status.js
+++ b/scripts/localnet/status.js
@@ -58,7 +58,12 @@ async function getLocalnetStatus (input) {
  */
 async function getNodeStatus (node, timeoutMs) {
   const pidRunning = !!(node.pid && localnet.isProcessRunning(node.pid));
-  const api = await fetchNodeApiStatus(node.apiUrl, timeoutMs);
+  const results = await Promise.all([
+    fetchNodeApiStatus(node.apiUrl, timeoutMs),
+    fetchNodePeers(node.apiUrl, timeoutMs)
+  ]);
+  const api = results[0];
+  const peers = results[1];
 
   return {
     id: node.id,
@@ -67,6 +72,7 @@ async function getNodeStatus (node, timeoutMs) {
     apiUrl: node.apiUrl,
     wsClientUrl: node.wsClientUrl,
     api,
+    peers,
     delegateSecretsCount: readDelegateSecretsCount(node),
     lastForging: findLastForgingEvent(node.generalLogFile)
   };
@@ -78,10 +84,44 @@ async function getNodeStatus (node, timeoutMs) {
  * @param {number} timeoutMs - HTTP request timeout in milliseconds.
  */
 function fetchNodeApiStatus (apiUrl, timeoutMs) {
+  return fetchNodeJson(apiUrl, '/api/node/status', timeoutMs).then(function (result) {
+    if (!result.ok) {
+      return result;
+    }
+
+    return Object.assign({}, result, {
+      payload: extractNodeStatusPayload(result.body),
+      error: result.body.error || null
+    });
+  });
+}
+
+/**
+ * Requests `/api/peers` from one localnet node.
+ * @param {string} apiUrl - Base node API URL from manifest.
+ * @param {number} timeoutMs - HTTP request timeout in milliseconds.
+ */
+function fetchNodePeers (apiUrl, timeoutMs) {
+  return fetchNodeJson(apiUrl, '/api/peers?limit=100', timeoutMs).then(function (result) {
+    if (!result.ok) {
+      return result;
+    }
+
+    return Object.assign({}, result, {
+      peers: Array.isArray(result.body.peers) ? result.body.peers : []
+    });
+  });
+}
+
+/**
+ * Requests and parses JSON from a localnet node API endpoint.
+ * @param {string} apiUrl - Base node API URL from manifest.
+ * @param {string} endpoint - Absolute API endpoint path and query.
+ * @param {number} timeoutMs - HTTP request timeout in milliseconds.
+ */
+function fetchNodeJson (apiUrl, endpoint, timeoutMs) {
   return new Promise(function (resolve) {
-    const statusUrl = new URL(apiUrl);
-    statusUrl.pathname = '/api/node/status';
-    statusUrl.search = '';
+    const statusUrl = new URL(endpoint, apiUrl);
 
     const transport = statusUrl.protocol === 'https:' ? https : http;
     const request = transport.get(statusUrl, function (response) {
@@ -101,6 +141,7 @@ function fetchNodeApiStatus (apiUrl, timeoutMs) {
           resolve({
             ok: response.statusCode >= 200 && response.statusCode < 300 && parsedBody.success !== false,
             statusCode: response.statusCode,
+            body: parsedBody,
             payload,
             error: parsedBody.error || null
           });
@@ -108,6 +149,7 @@ function fetchNodeApiStatus (apiUrl, timeoutMs) {
           resolve({
             ok: false,
             statusCode: response.statusCode,
+            body: null,
             payload: null,
             error: 'Invalid JSON response: ' + error.message
           });
@@ -124,6 +166,7 @@ function fetchNodeApiStatus (apiUrl, timeoutMs) {
       resolve({
         ok: false,
         statusCode: null,
+        body: null,
         payload: null,
         error: error.message
       });
@@ -223,6 +266,27 @@ function buildSummary (manifest, nodes) {
 }
 
 /**
+ * Calculates current broadhash consensus from peer records.
+ * @param {string} broadhash - Local node broadhash.
+ * @param {Array<object>} peers - Current peer records from `/api/peers`.
+ */
+function calculateBroadhashConsensus (broadhash, peers) {
+  const connectedPeers = (peers || []).filter(function (peer) {
+    return peer.state === 2;
+  });
+
+  if (!broadhash || !connectedPeers.length) {
+    return null;
+  }
+
+  const matchedPeers = connectedPeers.filter(function (peer) {
+    return peer.broadhash === broadhash;
+  });
+
+  return Math.round(matchedPeers.length / connectedPeers.length * 100 * 1e2) / 1e2;
+}
+
+/**
  * Formats localnet status as a compact terminal report.
  * @param {object} status - Localnet status returned by `getLocalnetStatus`.
  */
@@ -269,7 +333,11 @@ function formatNodeStatusLine (node) {
   const processState = node.pidRunning ? 'pid ' + node.pid + ' running' : 'pid ' + (node.pid || 'n/a') + ' not running';
   const height = Number.isFinite(network.height) ? network.height : 'n/a';
   const nethash = network.nethash || 'n/a';
-  const consensus = Number.isFinite(loader.consensus) ? loader.consensus + '%' : 'n/a';
+  const broadhash = network.broadhash || 'n/a';
+  const cachedConsensus = Number.isFinite(loader.consensus) ? loader.consensus : null;
+  const liveConsensus = node.peers && node.peers.ok ?
+    calculateBroadhashConsensus(network.broadhash, node.peers.peers) :
+    null;
 
   return [
     '- ' + node.id + ':',
@@ -278,11 +346,33 @@ function formatNodeStatusLine (node) {
     'height ' + height + ',',
     'loaded ' + formatBoolean(loader.loaded) + ',',
     'syncing ' + formatBoolean(loader.syncing) + ',',
-    'consensus ' + consensus + ',',
+    'broadhash consensus ' + formatConsensus(liveConsensus, cachedConsensus) + ',',
+    'broadhash ' + broadhash + ',',
     'delegates ' + node.delegateSecretsCount + ',',
     'last forge ' + formatLastForging(node.lastForging) + ',',
     'nethash ' + nethash
   ].join(' ');
+}
+
+/**
+ * Formats live and cached consensus values for terminal output.
+ * @param {?number} liveConsensus - Consensus calculated from current peer records.
+ * @param {?number} cachedConsensus - Cached consensus returned by `/api/node/status`.
+ */
+function formatConsensus (liveConsensus, cachedConsensus) {
+  if (liveConsensus === null && cachedConsensus === null) {
+    return 'n/a';
+  }
+
+  if (liveConsensus === null) {
+    return cachedConsensus + '% cached';
+  }
+
+  if (cachedConsensus !== null && cachedConsensus !== liveConsensus) {
+    return liveConsensus + '% (cached ' + cachedConsensus + '%)';
+  }
+
+  return liveConsensus + '%';
 }
 
 /**
@@ -345,12 +435,16 @@ module.exports = {
   getLocalnetStatus,
   getNodeStatus,
   fetchNodeApiStatus,
+  fetchNodePeers,
+  fetchNodeJson,
   extractNodeStatusPayload,
   readDelegateSecretsCount,
   findLastForgingEvent,
   buildSummary,
+  calculateBroadhashConsensus,
   formatStatusReport,
   formatNodeStatusLine,
   formatBoolean,
+  formatConsensus,
   formatLastForging
 };

--- a/scripts/localnet/stop.js
+++ b/scripts/localnet/stop.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+'use strict';
+
+const { Command } = require('commander');
+const localnet = require('./localnet.js');
+
+const program = new Command();
+
+program
+    .description('Gracefully stop an ADAMANT localnet started by start:localnet')
+    .option('--runtime-dir <path>', 'generated runtime directory', localnet.DEFAULTS.runtimeDir)
+    .option('--logs-dir <path>', 'localnet log directory', localnet.DEFAULTS.logsDir)
+    .option('--timeout-ms <ms>', 'graceful shutdown timeout per node', String(localnet.DEFAULTS.stopTimeoutMs))
+    .option('--drop-on-stop', 'drop localnet PostgreSQL databases after graceful stop')
+    .option('--dropOnStop', 'alias for --drop-on-stop')
+    .option('--nodes <count>', 'fallback number of localnet databases', String(localnet.DEFAULTS.nodes))
+    .option('--db-host <host>', 'PostgreSQL host', localnet.DEFAULTS.dbHost)
+    .option('--db-port <port>', 'PostgreSQL port', String(localnet.DEFAULTS.dbPort))
+    .option('--db-user <user>', 'node PostgreSQL owner/user', localnet.DEFAULTS.dbUser)
+    .option('--db-admin-user <user>', 'PostgreSQL user for dropping localnet databases')
+    .option('--db-admin-password <password>', 'PostgreSQL password for --db-admin-user')
+    .option('--db-name-prefix <prefix>', 'PostgreSQL database name prefix', localnet.DEFAULTS.dbNamePrefix)
+    .parse(process.argv);
+
+/**
+ * Stops localnet from parsed CLI options and reports graceful shutdown status.
+ */
+async function main () {
+  const options = program.opts();
+
+  options.stopTimeoutMs = options.timeoutMs;
+
+  const result = await localnet.stopLocalnet(options);
+
+  if (result.message) {
+    console.log(result.message);
+    console.log('Manifest: ' + result.manifestPath);
+    return;
+  }
+
+  result.stopped.forEach(function (node) {
+    console.log('Stopped ' + node.id + ' pid ' + node.pid + '.');
+  });
+
+  result.missing.forEach(function (node) {
+    console.log('Already stopped or missing: ' + node.id + ' pid ' + node.pid + '.');
+  });
+
+  if (result.timedOut.length) {
+    result.timedOut.forEach(function (node) {
+      console.error('Timed out waiting for graceful shutdown: ' + node.id + ' pid ' + node.pid + '.');
+    });
+    process.exit(1);
+  }
+
+  if (result.dropResult) {
+    result.dropResult.dropped.forEach(function (databaseName) {
+      console.log('Dropped database ' + databaseName + '.');
+    });
+
+    result.dropResult.skipped.forEach(function (databaseName) {
+      console.log('Database already absent: ' + databaseName + '.');
+    });
+
+    result.dropResult.failed.forEach(function (failure) {
+      console.error('Failed to drop database ' + failure.database + ': ' + failure.error);
+    });
+
+    if (result.dropResult.failed.length) {
+      process.exit(1);
+    }
+  }
+
+  console.log('Localnet stopped gracefully.');
+}
+
+main().catch(function (error) {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/test/config.localnet.json
+++ b/test/config.localnet.json
@@ -1,0 +1,84 @@
+{
+  "address": "127.0.0.1",
+  "generalLog": {
+    "enabled": true,
+    "fileName": "logs-localnet/node-1/adamant_localnet.log",
+    "level": "info",
+    "rotate": {
+      "enabled": true,
+      "maxSize": "300M",
+      "retain": 5,
+      "rotateInterval": "0 0 0 1 *",
+      "rotateOnRestart": true
+    }
+  },
+  "debugLog": {
+    "enabled": true,
+    "fileName": "logs-localnet/node-1/adamant_localnet_debug.log",
+    "level": "trace",
+    "rotate": {
+      "enabled": true,
+      "maxSize": "300M",
+      "retain": 7,
+      "rotateInterval": "0 0 * * *",
+      "rotateOnRestart": true
+    }
+  },
+  "consoleLog": {
+    "enabled": false,
+    "level": "info"
+  },
+  "topAccounts": true,
+  "cacheEnabled": true,
+  "db": {
+    "host": "localhost",
+    "port": 5432,
+    "database": "adamant_localnet_node_1",
+    "user": "adamanttest",
+    "password": "password",
+    "poolSize": 25,
+    "poolIdleTimeout": 30000,
+    "reapIntervalMillis": 1000,
+    "logEvents": [
+      "error"
+    ]
+  },
+  "redis": {
+    "url": "redis://127.0.0.1:6379/10",
+    "password": null
+  },
+  "api": {
+    "access": {
+      "public": false,
+      "whiteList": [
+        "127.0.0.1"
+      ]
+    }
+  },
+  "peers": {
+    "list": [],
+    "options": {
+      "allowPrivatePeers": true
+    },
+    "access": {
+      "blackList": []
+    }
+  },
+  "forging": {
+    "force": false,
+    "secret": [],
+    "access": {
+      "whiteList": [
+        "127.0.0.1"
+      ]
+    }
+  },
+  "ssl": {
+    "enabled": false
+  },
+  "dapp": {
+    "masterrequired": false,
+    "masterpassword": "",
+    "autoexec": []
+  }
+}

--- a/test/unit/helpers/configOverrides.js
+++ b/test/unit/helpers/configOverrides.js
@@ -320,6 +320,29 @@ describe('configOverrides', () => {
       expect(config.consensusActivationHeights.fairSystem).to.equal(4359465);
     });
 
+    it('should apply multiple config override files in order', () => {
+      const firstOverrideFile = writeTempFile('first.json', JSON.stringify({
+        port: 36668,
+        redis: {
+          url: 'redis://127.0.0.1:6379/2'
+        }
+      }));
+      const secondOverrideFile = writeTempFile('second.json', JSON.stringify({
+        port: 36669
+      }));
+      const config = Config(testConfigPath, {
+        file: [firstOverrideFile, secondOverrideFile]
+      });
+
+      expect(config.port).to.equal(36669);
+      expect(config.redis.url).to.equal('redis://127.0.0.1:6379/2');
+      expect(config.__configEvents.map((event) => event.source)).to.deep.equal([
+        '--config-overrides ' + firstOverrideFile,
+        '--config-overrides ' + firstOverrideFile,
+        '--config-overrides ' + secondOverrideFile
+      ]);
+    });
+
     it('should fail during schema validation for invalid override value types', () => {
       sinon.stub(console, 'error');
       sinon.stub(process, 'exit').throws(new Error('process.exit'));

--- a/test/unit/localnet.js
+++ b/test/unit/localnet.js
@@ -305,6 +305,55 @@ describe('localnet scripts', () => {
     });
   });
 
+  it('should mark processes missing when they exit before SIGTERM', async () => {
+    const options = localnet.normalizeOptions({
+      cwd: tempDir,
+      runtimeDir: '.localnet-test',
+      logsDir: 'logs-localnet-test'
+    });
+    const manifestPath = localnet.getManifestPath(options);
+    const kill = sinon.stub(process, 'kill').callsFake((pid, signal) => {
+      if (pid === 4321 && signal === 0) {
+        return true;
+      }
+
+      if (pid === 4321 && signal === 'SIGTERM') {
+        const error = Error('No such process');
+
+        error.code = 'ESRCH';
+        throw error;
+      }
+
+      return true;
+    });
+
+    fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      status: 'running',
+      nodes: [
+        {
+          id: 'node-1',
+          pid: 4321
+        }
+      ]
+    }, null, 2));
+
+    const result = await localnet.stopLocalnet({
+      cwd: tempDir,
+      runtimeDir: '.localnet-test',
+      logsDir: 'logs-localnet-test',
+      stopTimeoutMs: 1
+    });
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+
+    expect(result.stopped).to.be.empty;
+    expect(result.timedOut).to.be.empty;
+    expect(result.missing.map((node) => node.id)).to.deep.equal(['node-1']);
+    expect(manifest.stopResult.missing).to.deep.equal(['node-1']);
+    expect(kill.calledWith(4321, 0)).to.equal(true);
+    expect(kill.calledWith(4321, 'SIGTERM')).to.equal(true);
+  });
+
   it('should drop localnet databases on stop when requested', async () => {
     const options = localnet.normalizeOptions({
       cwd: tempDir,
@@ -385,5 +434,24 @@ describe('localnet scripts', () => {
       '--if-exists',
       'adamant_localnet_node_1'
     ]);
+  });
+
+  it('should escape localnet database prefix before listing databases', () => {
+    const spawnSync = sinon.stub(childProcess, 'spawnSync').returns({
+      status: 0,
+      stdout: 'adamant%_local\\net_node_1\n',
+      stderr: ''
+    });
+    const result = localnet.listLocalnetDatabases(localnet.normalizeOptions({
+      cwd: tempDir,
+      dbNamePrefix: 'adamant%_local\\net\'node_'
+    }));
+    const query = spawnSync.firstCall.args[1][8];
+
+    expect(result).to.deep.equal(['adamant%_local\\net_node_1']);
+    expect(query).to.equal(
+        'SELECT datname FROM pg_database WHERE datname LIKE ' +
+        '\'adamant\\%\\_local\\\\net\'\'node\\_%\' ESCAPE E\'\\\\\' ORDER BY datname'
+    );
   });
 });

--- a/test/unit/localnet.js
+++ b/test/unit/localnet.js
@@ -1,0 +1,327 @@
+'use strict';
+
+const { expect } = require('chai');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const childProcess = require('child_process');
+const sinon = require('sinon');
+
+const localnet = require('../../scripts/localnet/localnet.js');
+const localnetStatus = require('../../scripts/localnet/status.js');
+
+describe('localnet scripts', () => {
+  let tempDir;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'adamant-localnet-'));
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should build isolated node overrides and startup args', () => {
+    const options = localnet.normalizeOptions({
+      cwd: tempDir,
+      nodes: 3,
+      delegateSecrets: ['secret-1', 'secret-2', 'secret-3', 'secret-4', 'secret-5'],
+      runtimeDir: '.localnet-test',
+      logsDir: 'logs-localnet-test',
+      basePort: 4100,
+      baseWsPort: 5100,
+      redisDbBase: 20,
+      configOverrides: ['test/config.localnet.json', 'test/custom.json']
+    });
+    const plan = localnet.buildLocalnetPlan(options);
+
+    expect(plan.manifestPath).to.equal(path.join(tempDir, '.localnet-test', 'manifest.json'));
+    expect(plan.nodes).to.have.length(3);
+    expect(plan.nodes.map((node) => node.port)).to.deep.equal([4100, 4101, 4102]);
+    expect(plan.nodes.map((node) => node.wsClientPort)).to.deep.equal([5100, 5101, 5102]);
+    expect(plan.nodes.map((node) => node.db.database)).to.deep.equal([
+      'adamant_localnet_node_1',
+      'adamant_localnet_node_2',
+      'adamant_localnet_node_3'
+    ]);
+    expect(plan.nodes.map((node) => node.redis.url)).to.deep.equal([
+      'redis://127.0.0.1:6379/20',
+      'redis://127.0.0.1:6379/21',
+      'redis://127.0.0.1:6379/22'
+    ]);
+
+    expect(plan.nodes[0].peers).to.deep.equal([
+      { ip: '127.0.0.1', port: 4101 },
+      { ip: '127.0.0.1', port: 4102 }
+    ]);
+    expect(plan.nodes[1].overrides).to.include({
+      port: 4101,
+      address: '127.0.0.1'
+    });
+    expect(plan.nodes[1].overrides.wsClient.portWS).to.equal(5101);
+    expect(plan.nodes[1].overrides.generalLog.fileName)
+        .to.equal('logs-localnet-test/node-2/adamant_localnet.log');
+    expect(plan.nodes[1].overrides.debugLog.fileName)
+        .to.equal('logs-localnet-test/node-2/adamant_localnet_debug.log');
+    expect(plan.nodes.map((node) => node.delegateSecretsCount)).to.deep.equal([2, 2, 1]);
+    expect(plan.nodes[1].overrides.forging.secret).to.deep.equal(['secret-2', 'secret-5']);
+    expect(plan.nodes[1].overrides.peers.list).to.deep.equal([
+      { ip: '127.0.0.1', port: 4100 },
+      { ip: '127.0.0.1', port: 4102 }
+    ]);
+    expect(plan.nodes[1].overrides.peers.options.allowPrivatePeers).to.equal(true);
+
+    expect(plan.nodes[2].args).to.deep.equal([
+      'app.js',
+      '--config',
+      'config.default.json',
+      '--genesis',
+      'test/genesisBlock.json',
+      '--config-overrides',
+      'test/config.localnet.json',
+      '--config-overrides',
+      'test/custom.json',
+      '--config-overrides',
+      '.localnet-test/node-3/config.overrides.json'
+    ]);
+  });
+
+  it('should write manifest and generated config files without starting databases when skipped', () => {
+    sinon.stub(childProcess, 'spawn').returns({
+      pid: 12345,
+      unref: sinon.stub()
+    });
+
+    const manifest = localnet.startLocalnet({
+      cwd: tempDir,
+      nodes: 1,
+      delegateSecrets: ['secret-1'],
+      runtimeDir: '.localnet-test',
+      logsDir: 'logs-localnet-test',
+      basePort: 4200,
+      baseWsPort: 5200,
+      skipDbCreate: true
+    });
+    const manifestPath = path.join(tempDir, '.localnet-test', 'manifest.json');
+    const overridePath = path.join(tempDir, '.localnet-test', 'node-1', 'config.overrides.json');
+
+    expect(fs.existsSync(manifestPath)).to.equal(true);
+    expect(fs.existsSync(overridePath)).to.equal(true);
+    expect(manifest.status).to.equal('running');
+    expect(manifest.nodes).to.have.length(1);
+    expect(manifest.nodes[0].pid).to.equal(12345);
+    expect(manifest.nodes[0].port).to.equal(4200);
+    expect(manifest.nodes[0].logDir).to.equal(path.join(tempDir, 'logs-localnet-test', 'node-1'));
+
+    const overrides = JSON.parse(fs.readFileSync(overridePath, 'utf8'));
+
+    expect(overrides.port).to.equal(4200);
+    expect(overrides.wsClient.portWS).to.equal(5200);
+    expect(overrides.db.database).to.equal('adamant_localnet_node_1');
+    expect(overrides.redis.url).to.equal('redis://127.0.0.1:6379/10');
+    expect(overrides.forging.secret).to.deep.equal(['secret-1']);
+  });
+
+  it('should keep the last node non-forging when more than three nodes are started', () => {
+    const options = localnet.normalizeOptions({
+      cwd: tempDir,
+      nodes: 4,
+      delegateSecrets: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
+      runtimeDir: '.localnet-test',
+      logsDir: 'logs-localnet-test'
+    });
+    const plan = localnet.buildLocalnetPlan(options);
+
+    expect(plan.nodes.map((node) => node.delegateSecretsCount)).to.deep.equal([3, 3, 2, 0]);
+    expect(plan.nodes[3].overrides.forging.secret).to.deep.equal([]);
+  });
+
+  it('should create localnet databases with the configured node database owner', () => {
+    sinon.stub(childProcess, 'spawn').returns({
+      pid: 12345,
+      unref: sinon.stub()
+    });
+    const spawnSync = sinon.stub(childProcess, 'spawnSync').returns({
+      status: 0,
+      stdout: '',
+      stderr: ''
+    });
+
+    localnet.startLocalnet({
+      cwd: tempDir,
+      nodes: 1,
+      delegateSecrets: ['secret-1'],
+      runtimeDir: '.localnet-test',
+      logsDir: 'logs-localnet-test',
+      dbAdminUser: 'postgres_admin'
+    });
+
+    expect(spawnSync.calledOnce).to.equal(true);
+    expect(spawnSync.firstCall.args[0]).to.equal('createdb');
+    expect(spawnSync.firstCall.args[1]).to.deep.equal([
+      '-h',
+      'localhost',
+      '-p',
+      '5432',
+      '-U',
+      'postgres_admin',
+      '-O',
+      'adamanttest',
+      'adamant_localnet_node_1'
+    ]);
+  });
+
+  it('should assign Redis database indexes for URLs without an existing path', () => {
+    expect(localnet.withRedisDatabase('redis://127.0.0.1:6379', 15))
+        .to.equal('redis://127.0.0.1:6379/15');
+  });
+
+  it('should read delegate count and last forging time for localnet status', () => {
+    const nodeDir = path.join(tempDir, '.localnet-test', 'node-1');
+    const logDir = path.join(tempDir, 'logs-localnet-test', 'node-1');
+    const overrideFile = path.join(nodeDir, 'config.overrides.json');
+    const generalLogFile = path.join(logDir, 'adamant_localnet.log');
+
+    fs.mkdirSync(nodeDir, { recursive: true });
+    fs.mkdirSync(logDir, { recursive: true });
+    fs.writeFileSync(overrideFile, JSON.stringify({
+      forging: {
+        secret: ['secret-1', 'secret-2']
+      }
+    }));
+    fs.writeFileSync(generalLogFile, [
+      '[inf] 2026-06-04T12:00:01.000Z | delegates | Forged new block id: 1 height: 2',
+      '[inf] 2026-06-04T12:00:05.000Z | delegates | Forged new block id: 2 height: 3'
+    ].join('\n'));
+
+    const node = {
+      overrideFile,
+      generalLogFile
+    };
+    const lastForging = localnetStatus.findLastForgingEvent(generalLogFile);
+
+    expect(localnetStatus.readDelegateSecretsCount(node)).to.equal(2);
+    expect(lastForging.timestamp).to.equal('2026-06-04T12:00:05.000Z');
+  });
+
+  it('should mark missing localnet processes as stopped', async () => {
+    const options = localnet.normalizeOptions({
+      cwd: tempDir,
+      runtimeDir: '.localnet-test',
+      logsDir: 'logs-localnet-test'
+    });
+    const manifestPath = localnet.getManifestPath(options);
+
+    fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      status: 'running',
+      nodes: [
+        {
+          id: 'node-1',
+          pid: 999999999
+        }
+      ]
+    }, null, 2));
+
+    const result = await localnet.stopLocalnet({
+      cwd: tempDir,
+      runtimeDir: '.localnet-test',
+      logsDir: 'logs-localnet-test',
+      stopTimeoutMs: 1
+    });
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+
+    expect(result.stopped).to.be.empty;
+    expect(result.timedOut).to.be.empty;
+    expect(result.missing.map((node) => node.id)).to.deep.equal(['node-1']);
+    expect(manifest.status).to.equal('stopped');
+    expect(manifest.stopResult).to.deep.equal({
+      stopped: [],
+      missing: ['node-1'],
+      timedOut: []
+    });
+  });
+
+  it('should drop localnet databases on stop when requested', async () => {
+    const options = localnet.normalizeOptions({
+      cwd: tempDir,
+      runtimeDir: '.localnet-test',
+      logsDir: 'logs-localnet-test'
+    });
+    const manifestPath = localnet.getManifestPath(options);
+    const spawnSync = sinon.stub(childProcess, 'spawnSync');
+
+    spawnSync.withArgs('psql').returns({
+      status: 0,
+      stdout: 'adamant_localnet_node_1\nadamant_localnet_node_2\n',
+      stderr: ''
+    });
+    spawnSync.withArgs('dropdb').returns({
+      status: 0,
+      stdout: '',
+      stderr: ''
+    });
+
+    fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      status: 'running',
+      nodes: [
+        {
+          id: 'node-1',
+          pid: 999999999,
+          db: {
+            database: 'adamant_localnet_node_1'
+          }
+        }
+      ]
+    }, null, 2));
+
+    const result = await localnet.stopLocalnet({
+      cwd: tempDir,
+      runtimeDir: '.localnet-test',
+      logsDir: 'logs-localnet-test',
+      dropOnStop: true
+    });
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+
+    expect(result.dropResult.dropped).to.deep.equal([
+      'adamant_localnet_node_1',
+      'adamant_localnet_node_2'
+    ]);
+    expect(manifest.dropResult.dropped).to.deep.equal(result.dropResult.dropped);
+    expect(spawnSync.withArgs('dropdb').callCount).to.equal(2);
+  });
+
+  it('should stop and drop localnet databases with dropLocalnet', async () => {
+    const spawnSync = sinon.stub(childProcess, 'spawnSync');
+
+    spawnSync.withArgs('psql').returns({
+      status: 0,
+      stdout: 'adamant_localnet_node_1\n',
+      stderr: ''
+    });
+    spawnSync.withArgs('dropdb').returns({
+      status: 0,
+      stdout: '',
+      stderr: ''
+    });
+
+    const result = await localnet.dropLocalnet({
+      cwd: tempDir,
+      runtimeDir: '.localnet-test',
+      logsDir: 'logs-localnet-test'
+    });
+
+    expect(result.stopResult.message).to.equal('No localnet manifest found.');
+    expect(result.dropResult.dropped).to.deep.equal(['adamant_localnet_node_1']);
+    expect(spawnSync.withArgs('dropdb').firstCall.args[1]).to.deep.equal([
+      '-h',
+      'localhost',
+      '-p',
+      '5432',
+      '--if-exists',
+      'adamant_localnet_node_1'
+    ]);
+  });
+});

--- a/test/unit/localnet.js
+++ b/test/unit/localnet.js
@@ -75,7 +75,7 @@ describe('localnet scripts', () => {
     expect(plan.nodes[2].args).to.deep.equal([
       'app.js',
       '--config',
-      'config.default.json',
+      'test/config.default.json',
       '--genesis',
       'test/genesisBlock.json',
       '--config-overrides',
@@ -203,6 +203,68 @@ describe('localnet scripts', () => {
 
     expect(localnetStatus.readDelegateSecretsCount(node)).to.equal(2);
     expect(lastForging.timestamp).to.equal('2026-06-04T12:00:05.000Z');
+  });
+
+  it('should format status consensus as broadhash consensus', () => {
+    const line = localnetStatus.formatNodeStatusLine({
+      id: 'node-1',
+      pid: 12345,
+      pidRunning: true,
+      api: {
+        ok: true,
+        payload: {
+          loader: {
+            loaded: true,
+            syncing: false,
+            consensus: 50
+          },
+          network: {
+            height: 10,
+            broadhash: 'broadhash-value',
+            nethash: 'nethash-value'
+          }
+        }
+      },
+      peers: {
+        ok: true,
+        peers: [
+          {
+            state: 2,
+            broadhash: 'broadhash-value'
+          },
+          {
+            state: 2,
+            broadhash: 'broadhash-value'
+          }
+        ]
+      },
+      delegateSecretsCount: 34,
+      lastForging: null
+    });
+
+    expect(line).to.include('broadhash consensus 100% (cached 50%)');
+    expect(line).to.include('broadhash broadhash-value');
+    expect(line).to.include('nethash nethash-value');
+  });
+
+  it('should calculate live broadhash consensus from connected peer records', () => {
+    const consensus = localnetStatus.calculateBroadhashConsensus('broadhash-a', [
+      {
+        state: 2,
+        broadhash: 'broadhash-a'
+      },
+      {
+        state: 2,
+        broadhash: 'broadhash-b'
+      },
+      {
+        state: 1,
+        broadhash: 'broadhash-a'
+      }
+    ]);
+
+    expect(consensus).to.equal(50);
+    expect(localnetStatus.formatConsensus(100, 50)).to.equal('100% (cached 50%)');
   });
 
   it('should mark missing localnet processes as stopped', async () => {

--- a/test/unit/modules/peers.js
+++ b/test/unit/modules/peers.js
@@ -322,6 +322,20 @@ describe('peers', function () {
       expect(peers.acceptable([privatePeer])).that.is.an('array').and.to.be.empty;
     });
 
+    it('should accept peer with private ip when explicitly configured', function () {
+      var previousValue = config.peers.options.allowPrivatePeers;
+      var privatePeer = _.clone(validPeer);
+      privatePeer.ip = '127.0.0.1';
+
+      config.peers.options.allowPrivatePeers = true;
+
+      try {
+        expect(peers.acceptable([privatePeer])).that.is.an('array').and.to.deep.equal([privatePeer]);
+      } finally {
+        config.peers.options.allowPrivatePeers = previousValue;
+      }
+    });
+
     it('should not accept peer with adm-js-api os', function () {
       var privatePeer = _.clone(validPeer);
       privatePeer.os = 'adm-js-api';


### PR DESCRIPTION
## Description

Adds a maintained localnet lifecycle for running multiple isolated ADAMANT nodes on one machine.

- Adds `start:localnet`, `stop:localnet`, `status:localnet`, and `drop:localnet` npm scripts.
- Generates per-node localnet configs, manifests, runtime state, PID files, and per-node log folders.
- Uses `test/config.default.json` as the localnet base config and `test/genesisBlock.json` as the localnet genesis block source.
- Applies `test/config.localnet.json` by default through config overrides.
- Distributes testnet forging secrets across localnet nodes, leaving the last node non-forging when more than three nodes are requested.
- Adds live localnet status reporting, including per-node API status, delegate counts, last forging time, nethash, and live broadhash consensus.
- Adds `--dropOnStop` support and a dedicated `drop:localnet` script for removing persisted localnet databases after graceful shutdown.
- Allows localnet/private peer records only through an explicit peer configuration option.
- Documents localnet usage and keeps generated localnet runtime files out of git.

## Related issue

Closes #229

## How to test

- `node -c scripts/localnet/localnet.js && node -c scripts/localnet/start.js && node -c scripts/localnet/stop.js && node -c scripts/localnet/drop.js && node -c scripts/localnet/status.js`
- `npm run test:single -- test/unit/localnet.js`
- `npm run test:single -- test/unit/localnet.js test/unit/helpers/configOverrides.js test/unit/modules/node.js test/unit/modules/peers.js`
- `npm run test:unit:fast`
- `ESLINT_USE_FLAT_CONFIG=false npx eslint scripts/localnet/localnet.js scripts/localnet/start.js scripts/localnet/stop.js scripts/localnet/drop.js scripts/localnet/status.js test/unit/localnet.js test/unit/helpers/configOverrides.js test/unit/modules/peers.js`
- `git diff --check origin/dev...HEAD`
- Local smoke run with a 3-node localnet: start, poll `status:localnet`, confirm live broadhash consensus reaches 100% on all nodes, then stop and drop the localnet databases.

## Checklist

- [x] Repository artifacts are in English.
- [x] The PR title follows the repository PR title taxonomy.
- [x] No production consensus rules, block bytes, transaction bytes, delegate order, rewards, fees, or signature checks are intentionally changed.
- [x] Private/local peer acceptance is gated by explicit localnet peer configuration.
- [x] Generated runtime files are ignored by git.
- [x] Tests and lint checks for touched files were run.

## Risk and operator notes

- Localnet PostgreSQL databases are persistent by default. Use `npm run drop:localnet` or `--dropOnStop` when a full cleanup is needed.
- Automatic database creation still depends on the local PostgreSQL role having `CREATEDB` permission; otherwise use an existing database setup or pass the skip/create flags documented in the README.
- `status:localnet` reports live broadhash consensus separately from the node's cached `/api/node/status` consensus value, because the cached value can lag behind peer records immediately after startup.
