### PR TITLE
Fix: Improve WebSocket peer logging visibility

### DIFF
--- a/api/ws/server.js
+++ b/api/ws/server.js
@@ -5,14 +5,16 @@ const Peer = require('../../logic/peer');
  * Creates a WebSocket server to broadcast transactions/blocks/signature changes
  */
 class WebSocketServer {
-  constructor(server, appConfig, logger) {
+  constructor (server, appConfig, logger) {
     this.io = new Server(server, {
       allowEIO3: true,
-      cors: appConfig.cors,
+      cors: appConfig.cors
     });
 
     this.enabled = appConfig.wsNode.enabled;
     this.max = appConfig.wsNode.maxBroadcastConnections;
+    this.address = appConfig.address;
+    this.port = appConfig.port;
 
     this.logger = logger;
 
@@ -24,17 +26,19 @@ class WebSocketServer {
    * Initializes the server and authorizes connections
    * @param {{ peers: Peers }} logic logic modules
    */
-  initialize(logic) {
+  initialize (logic) {
     const self = this;
 
     if (!this.enabled) {
       return;
     }
 
+    self.logger.info('ws-node-server', `WebSocketServer is listening for inbound peers on ${this.address}:${this.port}…`);
+
     this.io.on('connection', (socket) => {
       const peerIp = socket.handshake.address || socket.request.socket.remoteAddress;
 
-      self.logger.debug('ws-node-server', `WebSocket peer ${peerIp} is connecting…`);
+      self.logger.debug('ws-node-server', `WebSocket peer ${peerIp} is connecting…`, { direction: 'inbound' });
 
       const { nonce } = socket.handshake.auth;
 
@@ -73,7 +77,7 @@ class WebSocketServer {
 
       existingPeer.isBroadcastingViaSocket = true;
 
-      self.logger.info('ws-node-server', `WebSocket peer ${peerIp} is connected to the node`);
+      self.logger.info('ws-node-server', `WebSocket peer ${peerIp} is connected to the node`, { direction: 'inbound' });
 
       socket.on('disconnect', () => {
         const disconnectedPeer = logic.peers.getByNonce(nonce);
@@ -92,7 +96,7 @@ class WebSocketServer {
    * @param {string} eventName emitting event name
    * @param {any} data data to emit
    */
-  emit(eventName, data) {
+  emit (eventName, data) {
     if (this.enabled) {
       this.io.sockets.emit(eventName, data);
     }

--- a/api/ws/server.js
+++ b/api/ws/server.js
@@ -33,7 +33,7 @@ class WebSocketServer {
       return;
     }
 
-    self.logger.info('ws-node-server', `WebSocketServer is listening for inbound peers on ${this.address}:${this.port}…`);
+    self.logger.info('ws-node-server', `WebSocketServer enabled; awaiting inbound peers on ${this.address}:${this.port}…`);
 
     this.io.on('connection', (socket) => {
       const peerIp = socket.handshake.address || socket.request.socket.remoteAddress;

--- a/api/ws/transport.js
+++ b/api/ws/transport.js
@@ -82,7 +82,7 @@ class TransportWsApi {
       return;
     }
 
-    self.logger.debug('ws-node-client', `Connecting to WebSocket peer ${peerUrl}…`);
+    self.logger.debug('ws-node-client', `Connecting to WebSocket peer ${peerUrl}…`, { direction: 'outbound' });
 
     const socket = io(peerUrl, {
       reconnection: false,
@@ -108,7 +108,9 @@ class TransportWsApi {
    * @param {Peer} peer target peer
    */
   handleConnect (socket, peer) {
-    this.logger.info('ws-node-client', `Connected to peer WebSocket at ${peer.ip}:${peer.port}`);
+    this.logger.info('ws-node-client', `Connected to WebSocket peer at ${peer.ip}:${peer.port}`, {
+      direction: 'outbound'
+    });
 
     this.peers.switchToWs(peer);
     this.peers.recordRequest(peer.ip, peer.port, null);


### PR DESCRIPTION
## Description

Improve WebSocket peer logging visibility for both inbound and outbound connection flows.

The change keeps `ws-node-server` logging for real inbound socket connections and adds clearer operator-visible lifecycle logs for the outbound `ws-node-client` path that is typically observed during `npm run start:testnet`.

## Related issue

Closes #146

## How to test

1. Run `npm run start:testnet`.
2. Check `logs-testnet/adamant_testnet_debug.log`.
3. Verify that outbound WebSocket lifecycle logs are present, including `is connecting…` and `is connected to the node`.
4. Verify that the server logs its inbound readiness state.

## Verification

- `npm run start:testnet`
- `ESLINT_USE_FLAT_CONFIG=false npx eslint api/ws/server.js api/ws/transport.js`

## Checklist

- [x] Change is scoped to WebSocket logging only.
- [x] No consensus or protocol behavior changed.
- [x] Validation commands were executed.
