### PR TITLE
Fix: Limit past-timestamp admission to chat and state transactions

### DIFF
--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -9,6 +9,7 @@ var exceptions = require('../helpers/exceptions.js');
 var extend = require('extend');
 var slots = require('../helpers/slots.js');
 var sql = require('../sql/transactions.js');
+var transactionTypes = require('../helpers/transactionTypes.js');
 const Consensus = require('./consensus/consensus.js');
 // Private fields
 var self, modules, __private = {};
@@ -121,7 +122,8 @@ Transaction.prototype.create = function (data) {
 
 /**
  * Modifies a transaction by adding the calculated fee and transaction ID,
- * and validates that the timestamp is recent.
+ * and validates public-API admission timestamps.
+ * Chat and state transactions must not be more than `maxTransactionAgeSec` in the past.
  * This should be called for freshly created transactions received from the Public API
  * @param {object} data - The transaction object
  * @throws {Error} If an invalid transaction is passed
@@ -152,11 +154,13 @@ Transaction.prototype.publish = function (data) {
     throw 'Transaction timestamp is in the future';
   }
 
-  const earliestValidTime = currentTime - constants.maxTransactionAgeSec;
-  const earliestValidSlotNumber = slots.getSlotNumber(earliestValidTime);
+  if (data.type === transactionTypes.CHAT_MESSAGE || data.type === transactionTypes.STATE) {
+    const earliestValidTime = currentTime - constants.maxTransactionAgeSec;
+    const earliestValidSlotNumber = slots.getSlotNumber(earliestValidTime);
 
-  if (transactionSlotNumber < earliestValidSlotNumber) {
-    throw `Transaction timestamp is more than ${constants.maxTransactionAgeSec} seconds in the past`;
+    if (transactionSlotNumber < earliestValidSlotNumber) {
+      throw `Transaction timestamp is more than ${constants.maxTransactionAgeSec} seconds in the past`;
+    }
   }
 
   var trs = data;

--- a/test/unit/logic/transaction.js
+++ b/test/unit/logic/transaction.js
@@ -880,8 +880,50 @@ describe('transaction', () => {
       );
     });
 
-    it('should return error on timestamp that is 16 seconds in the past', () => {
+    it('should accept timestamp that is 16 seconds in the past for transfer transactions', () => {
       const trs = _.cloneDeep(validUnconfirmedTransaction);
+      trs.timestamp = slots.getTime() - 100;
+      trs.timestampMs = trs.timestamp * 1000;
+      delete trs.signature;
+      trs.signature = transaction.sign(testSenderKeypair, trs);
+      expect(() => transaction.publish(trs)).to.not.throw();
+    });
+
+    it('should return error on timestamp that is 16 seconds in the past for chat messages', () => {
+      transaction.attachAssetType(transactionTypes.CHAT_MESSAGE, new Chat());
+      const trs = _.cloneDeep(validUnconfirmedTransaction);
+      trs.type = transactionTypes.CHAT_MESSAGE;
+      trs.amount = 0;
+      trs.recipientId = 'U810656636599221322';
+      trs.asset = {
+        chat: {
+          message: '75582d940f2c4093929c99a6c1911b4753',
+          own_message: '58dceaa227b3fb1dd1c7d3fbf3eb5db6aeb6a03cb7e2ec91',
+          type: 1,
+        },
+      };
+      trs.timestamp = slots.getTime() - 100;
+      trs.timestampMs = trs.timestamp * 1000;
+      delete trs.signature;
+      trs.signature = transaction.sign(testSenderKeypair, trs);
+      expect(() => transaction.publish(trs)).to.throw(
+        'Transaction timestamp is more than 5 seconds in the past',
+      );
+    });
+
+    it('should return error on timestamp that is 16 seconds in the past for state transactions', () => {
+      transaction.attachAssetType(transactionTypes.STATE, new State());
+      const trs = _.cloneDeep(validUnconfirmedTransaction);
+      trs.type = transactionTypes.STATE;
+      trs.amount = 0;
+      trs.recipientId = null;
+      trs.asset = {
+        state: {
+          key: 'test:key',
+          value: '74657374',
+          type: 0,
+        },
+      };
       trs.timestamp = slots.getTime() - 100;
       trs.timestampMs = trs.timestamp * 1000;
       delete trs.signature;

--- a/test/unit/logic/transaction.js
+++ b/test/unit/logic/transaction.js
@@ -882,7 +882,7 @@ describe('transaction', () => {
 
     it('should accept timestamp that is 16 seconds in the past for transfer transactions', () => {
       const trs = _.cloneDeep(validUnconfirmedTransaction);
-      trs.timestamp = slots.getTime() - 100;
+      trs.timestamp = slots.getTime() - 16;
       trs.timestampMs = trs.timestamp * 1000;
       delete trs.signature;
       trs.signature = transaction.sign(testSenderKeypair, trs);
@@ -902,7 +902,7 @@ describe('transaction', () => {
           type: 1,
         },
       };
-      trs.timestamp = slots.getTime() - 100;
+      trs.timestamp = slots.getTime() - 16;
       trs.timestampMs = trs.timestamp * 1000;
       delete trs.signature;
       trs.signature = transaction.sign(testSenderKeypair, trs);
@@ -924,7 +924,7 @@ describe('transaction', () => {
           type: 0,
         },
       };
-      trs.timestamp = slots.getTime() - 100;
+      trs.timestamp = slots.getTime() - 16;
       trs.timestampMs = trs.timestamp * 1000;
       delete trs.signature;
       trs.signature = transaction.sign(testSenderKeypair, trs);


### PR DESCRIPTION
## Description

Limit the public-API `maxTransactionAgeSec` admission check in `Transaction.prototype.publish()` to chat message transactions (type 8) and state/KVS transactions (type 9).

Transfers and other non-messaging transaction types can now be submitted through the public API with a signed timestamp older than five seconds, as long as they pass the existing future-timestamp grace and normal `verify()` rules.

Messaging types still enforce the 5-second past window at admission time.

**Offline wallet note:** this is `publish()` admission policy only, not consensus validation. Relaxing the check for non-messaging types unblocks offline signing for transfers and account operations, but types 8 and 9 still reject stale timestamps and therefore continue to block a future offline wallet for chat messages and KVS updates unless clients re-sign before submission or admission policy is extended further.

## Related issue

Closes #235

Related:

- #209 — `timestampMs` tracking issue
- #93 — introduced `maxTransactionAgeSec` and scoped freshness checks to `publish()`
- #210 — completed `timestampMs` response and activation handling
- [AIPs#64](https://github.com/Adamant-im/AIPs/issues/64) / [AIP-21](https://github.com/Adamant-im/AIPs/blob/master/AIPS/aip-21.md)

## How to test

```bash
PATH=/opt/homebrew/opt/node@22/bin:$PATH PG_NATIVE=false npm run test:single -- test/unit/logic/transaction.js
ESLINT_USE_FLAT_CONFIG=false npx eslint logic/transaction.js test/unit/logic/transaction.js
```

Results:

- `test/unit/logic/transaction.js`: 109 passing

## Checklist

- [x] English-only repository output
- [x] No consensus-breaking nondeterminism introduced (change is limited to `publish()` admission)
- [x] No security checks weakened in `verify()`, sync, or block processing paths
- [x] Tests added/updated and run
- [x] Issue linked with closing keyword
