### PR TITLE
Chore: Modernize node installation and repair scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Ubuntu 20.04 is supported by the script, but its standard security maintenance h
 Run an installer as root from the official download URL and select the network, Git branch, and Node.js major version as needed:
 
 ```sh
-curl -fsSL https://adamant.im/install_node.sh | sudo bash -s -- -n mainnet -b master -j 24
-curl -fsSL https://adamant.im/install_node_centos.sh | sudo bash -s -- -n testnet -b dev -j 24
+sudo bash -c "$(wget -O - https://adamant.im/install_node.sh)" -O -b dev -n mainnet -j 24
+sudo bash -c "$(wget -O - https://adamant.im/install_node_centos.sh)" -O -b dev -n mainnet -j 24
 ```
 
 Both installers update system packages, preserve existing ADAMANT configuration files and local Git changes, and reuse existing users and databases. A blockchain image is skipped when the selected database already contains tables. Installation logs are written to `/var/log/adamant_<network>_install.log`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ADAMANT
 
-ADAMANT is a **decentralized blockchain-based messaging platform**. Applications use ADAMANT as an anonymous and encrypted relay and storage layer to enable secure messaging features. Examples include the [Messenger app](https://github.com/Adamant-im/adamant-im), [Blockchain 2FA](https://github.com/Adamant-im/adamant-2fa), and [Exchange bot](https://github.com/Adamant-im/adamant-exchangebot).
+ADAMANT is a **decentralized, blockchain-based messaging platform**. Applications use ADAMANT as an anonymous, encrypted relay and storage layer for secure communication. Examples include the [Messenger app](https://github.com/Adamant-im/adamant-im), [Blockchain 2FA](https://github.com/Adamant-im/adamant-2fa), and [Exchange bot](https://github.com/Adamant-im/adamant-exchangebot).
 
 For more information, refer to the ADAMANT website:
 
@@ -18,23 +18,49 @@ Additional information:
 
 ## Node and API Documentation
 
-Comprehensive [Node specification](https://docs.adamant.im) is available.
+Comprehensive [node documentation](https://docs.adamant.im) is available.
 
-It covers the Fair dPoS consensus algorithm, decentralization principles, node installation and configuration, and other core concepts. The documentation also details API endpoints for managing accounts, transactions, chats, and key-value storage (KVS). Additionally, it provides guidance on creating new accounts and encrypting or decrypting messages, and data types.
+It covers the Fair dPoS consensus algorithm, decentralization principles, node installation and configuration, and other core concepts. The documentation also describes API endpoints for managing accounts, transactions, chats, and key-value storage (KVS), along with account creation, message encryption and decryption, and API data types.
 
 See also:
 
 - [ADAMANT Improvement Proposals (AIPs)](https://aips.adamant.im)
 
-## Installation, Configuration and Running ADM node
+## Installing, Configuring, and Running an ADAMANT Node
 
-ADAMANT Node requires Node.js 22.13.0 or newer.
+ADAMANT Node requires Node.js 22.13.0 or newer. The installation scripts support Node.js 22, 24, and 26, with Node.js 24 selected by default.
 
-Refer to [ADAMANT Node documentation](https://docs.adamant.im/own-node/installation.html) for complete installation instructions. It includes hardware requirements, installation scripts, and step-by-step guides for setting up an ADM blockchain node on various operating systems, including Linux, macOS, and Windows.
+Refer to the [ADAMANT Node installation documentation](https://docs.adamant.im/own-node/installation.html) for hardware requirements and complete setup instructions for Linux, macOS, and Windows.
+
+### Linux Installation Scripts
+
+The bundled installers support:
+
+- Ubuntu 20.04, 22.04, 24.04, and 26.04 LTS: `tools/install_node.sh`
+- RHEL-compatible releases 8-10, including CentOS Stream, Rocky Linux, AlmaLinux, and RHEL: `tools/install_node_centos.sh`
+
+Ubuntu 20.04 is supported by the script, but its standard security maintenance has ended. Use Ubuntu Pro or upgrade the operating system for continued security updates.
+
+Run an installer as root and select the network, Git branch, and Node.js major version as needed:
+
+```sh
+sudo bash tools/install_node.sh -n mainnet -b master -j 24
+sudo bash tools/install_node_centos.sh -n testnet -b dev -j 24
+```
+
+Both installers update system packages, preserve existing ADAMANT configuration files and local Git changes, and reuse existing users and databases. A blockchain image is skipped when the selected database already contains tables. Installation logs are written to `/var/log/adamant_<network>_install.log`.
+
+To replace an Ubuntu node database with a newly downloaded blockchain image, use:
+
+```sh
+sudo bash tools/fix_node.sh -n mainnet
+```
+
+The repair tool validates the downloaded image before dropping the database, but the database replacement itself is destructive. Back up any required data first. Repair logs are written to `/var/log/adamant_<network>_fix.log`.
 
 ### Critical Shutdown Notice
 
-Stop the node with graceful shutdown. When running in the foreground, press `Ctrl+C` and wait until cleanup finishes. Do not use `kill -9`, forced terminal termination, or any other uncatchable process kill unless the process is already unrecoverably stuck.
+Always stop the node gracefully. When running it in the foreground, press `Ctrl+C` and wait for cleanup to finish. Do not use `kill -9`, forced terminal termination, or any other uncatchable process kill unless the process is already unrecoverably stuck.
 
 The node stores derived consensus state in memory mirror tables such as `mem_accounts` and `mem_round`. A forced kill can interrupt block, transaction, or round writes and leave those tables inconsistent with the persisted blockchain. On the next startup this may force a full memory-state rebuild from the beginning of the chain:
 
@@ -48,7 +74,7 @@ If this happens, do not try to repair `mem_*` tables with manual SQL edits. The 
 
 ## Development and Tests
 
-Refer to [CONTRIBUTING.md](./.github/CONTRIBUTING.md)
+Refer to [CONTRIBUTING.md](./.github/CONTRIBUTING.md).
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ The bundled installers support:
 
 Ubuntu 20.04 is supported by the script, but its standard security maintenance has ended. Use Ubuntu Pro or upgrade the operating system for continued security updates.
 
-Run an installer as root and select the network, Git branch, and Node.js major version as needed:
+Run an installer as root from the official download URL and select the network, Git branch, and Node.js major version as needed:
 
 ```sh
-sudo bash tools/install_node.sh -n mainnet -b master -j 24
-sudo bash tools/install_node_centos.sh -n testnet -b dev -j 24
+curl -fsSL https://adamant.im/install_node.sh | sudo bash -s -- -n mainnet -b master -j 24
+curl -fsSL https://adamant.im/install_node_centos.sh | sudo bash -s -- -n testnet -b dev -j 24
 ```
 
 Both installers update system packages, preserve existing ADAMANT configuration files and local Git changes, and reuse existing users and databases. A blockchain image is skipped when the selected database already contains tables. Installation logs are written to `/var/log/adamant_<network>_install.log`.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To replace an Ubuntu node database with a newly downloaded blockchain image, use
 sudo bash tools/fix_node.sh -n mainnet
 ```
 
-The repair tool validates the downloaded image before dropping the database, but the database replacement itself is destructive. Back up any required data first. Repair logs are written to `/var/log/adamant_<network>_fix.log`.
+The repair tool drops the database to free disk space, downloads and validates the replacement image, then recreates the database and restores it from the snapshot. Back up any required data first. Repair logs are written to `/var/log/adamant_<network>_fix.log`.
 
 ### Critical Shutdown Notice
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adamant",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adamant",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "GPL-3.0",
       "dependencies": {
         "async": "=3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adamant",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "ADAMANT Blockchain Node",
   "private": true,
   "engines": {
@@ -42,7 +42,7 @@
     "cryptocurrency",
     "dpos"
   ],
-  "author": "ADAMANT Foundation <devs@adamant.im>, ADAMANT Tech Labs <devs@adamant.im>, Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+  "author": "ADAMANT community developers <devs@adamant.im>, ADAMANT Foundation <devs@adamant.im>, ADAMANT Tech Labs <devs@adamant.im>, Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
   "license": "GPL-3.0",
   "dependencies": {
     "async": "=3.2.6",

--- a/tools/fix_node.sh
+++ b/tools/fix_node.sh
@@ -22,6 +22,24 @@ usage() {
   printf "Usage: %s [-h] [-n mainnet|testnet]\n" "${0##*/}"
 }
 
+require_interactive_tty() {
+  if [[ ! -r /dev/tty || ! -w /dev/tty ]]; then
+    printf "\nThis repair tool requires an interactive terminal for confirmation.\n" >&2
+    printf "Run it from a normal shell session, for example:\n" >&2
+    printf "    curl -fsSL https://adamant.im/fix_node.sh | sudo bash -s -- -n mainnet\n\n" >&2
+    exit 1
+  fi
+}
+
+read_from_tty() {
+  local prompt_text="$1"
+  local response
+
+  printf "%s" "$prompt_text" > /dev/tty
+  IFS= read -r response < /dev/tty
+  printf "%s" "$response"
+}
+
 while getopts ":n:h" OPTION; do
   case "$OPTION" in
     n)
@@ -116,7 +134,8 @@ printf "Node user:        %s\n" "$username"
 printf "Database:         %s\n" "$databasename"
 printf "PM2 process:      %s\n\n" "$processname"
 
-read -r -p "WARNING: This will permanently replace database '$databasename'. Type \"yes\" to continue: " agreement
+require_interactive_tty
+agreement="$(read_from_tty "WARNING: This will permanently replace database '$databasename'. Type \"yes\" to continue: ")"
 if [[ "$agreement" != "yes" ]]; then
   printf "\nRepair cancelled.\n\n"
   exit 1

--- a/tools/fix_node.sh
+++ b/tools/fix_node.sh
@@ -1,18 +1,28 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
-trap 'echo -e "\n[ERROR] Line $LINENO failed. Aborting.\n\n" >&2' ERR
 
-# Defaults for mainnet
+on_error() {
+  local exit_status=$?
+  printf "\n[ERROR] Line %s failed. Repair stopped.\n\n" "${BASH_LINENO[0]}" >&2
+  exit "$exit_status"
+}
+trap on_error ERR
+
+readonly TOOL_VERSION="1.4.0"
+
 network="mainnet"
 username="adamant"
 databasename="adamant_main"
 configfile="config.json"
 processname="adamant"
-port="36666" # Default mainnet REST port; later re-read from config
+port="36666"
 image_url="https://explorer.adamant.im/db_backup.sql.gz"
 
-# Options
-while getopts ":n:" OPTION; do
+usage() {
+  printf "Usage: %s [-n mainnet|testnet]\n" "${0##*/}"
+}
+
+while getopts ":n:h" OPTION; do
   case "$OPTION" in
     n)
       case "$OPTARG" in
@@ -22,200 +32,231 @@ while getopts ":n:" OPTION; do
           databasename="adamant_test"
           configfile="test/config.json"
           processname="adamanttest"
-          port="36667" # Default testnet REST port; later re-read from config
+          port="36667"
           image_url="https://testnet.adamant.im/db_test_backup.sql.gz"
           ;;
-        mainnet) : ;; # keep defaults
+        mainnet) : ;;
         *)
-          printf "\nNetwork should be 'mainnet' or 'testnet'.\n\n"
-          trap - ERR; exit 2
+          printf "\nNetwork must be 'mainnet' or 'testnet'.\n\n" >&2
+          usage
+          trap - ERR
+          exit 2
           ;;
       esac
       ;;
+    h)
+      usage
+      exit 0
+      ;;
+    :)
+      printf "\nOption '-%s' requires an argument.\n\n" "$OPTARG" >&2
+      usage
+      trap - ERR
+      exit 2
+      ;;
     \?)
-      printf "\nWrong parameters. Use '-n' to choose 'mainnet' or 'testnet'.\n\n"
-      trap - ERR; exit 2
+      printf "\nUnknown option: '-%s'.\n\n" "$OPTARG" >&2
+      usage
+      trap - ERR
+      exit 2
       ;;
   esac
 done
 
-image_filename="$(basename "$image_url")"        # db_backup.sql.gz
-image_unzipped_filename="${image_filename%.gz}"  # db_backup.sql
-
-# Logging: Everything goes both to screen and logfile
-# This must work even if the script is executed via `bash -c` or from stdin (no BASH_SOURCE path)
-script_path=""
-if [[ -n "${BASH_SOURCE[0]:-}" && "${BASH_SOURCE[0]}" != "bash" && "${BASH_SOURCE[0]}" != "-bash" ]]; then
-  script_path="${BASH_SOURCE[0]}"
-elif [[ -n "${0:-}" && "${0}" != "bash" && "${0}" != "-bash" ]]; then
-  script_path="${0}"
+if [[ "$(id -u)" -ne 0 ]]; then
+  printf "\nRun this repair tool as root, for example: sudo bash %s\n\n" "${0##*/}" >&2
+  trap - ERR
+  exit 1
 fi
 
-if [[ -n "$script_path" && -e "$script_path" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "$script_path")" && pwd)"
-else
-  SCRIPT_DIR="/tmp"
+if [[ ! -r /etc/os-release ]]; then
+  printf "\nCannot identify the operating system: /etc/os-release is missing.\n\n" >&2
+  trap - ERR
+  exit 1
 fi
 
-LOGFILE="${SCRIPT_DIR}/adamant_${network}_fix.log"
-
-# If /var/log is writable, prefer it (more expected for root-run repair scripts)
-if [[ "$SCRIPT_DIR" == "/tmp" && -w /var/log ]]; then
-  LOGFILE="/var/log/adamant_${network}_fix.log"
+# shellcheck disable=SC1091
+. /etc/os-release
+if [[ "${ID:-}" != "ubuntu" ]]; then
+  printf "\nThis repair tool supports Ubuntu. Detected: %s.\n\n" \
+    "${PRETTY_NAME:-unknown OS}" >&2
+  trap - ERR
+  exit 1
 fi
+case "${VERSION_ID:-}" in
+  20.04|22.04|24.04|26.04) ;;
+  *)
+    printf "\nUnsupported Ubuntu release '%s'. Supported releases: 20.04, 22.04, 24.04, and 26.04.\n\n" \
+      "${VERSION_ID:-unknown}" >&2
+    trap - ERR
+    exit 1
+    ;;
+esac
+
+image_filename="$(basename "$image_url")"
+image_unzipped_filename="${image_filename%.gz}"
+LOGFILE="/var/log/adamant_${network}_fix.log"
 
 exec > >(tee -a "$LOGFILE") 2>&1
-if [ -s "$LOGFILE" ]; then
-  printf "\n\n\n===========================\n" >> "$LOGFILE"
+if [[ -s "$LOGFILE" ]]; then
+  printf "\n\n\n===========================\n"
 fi
-printf "%s ADAMANT %s Node Repair/Bootstrap started…\n" \
-  "$(date -u '+%Y-%m-%d %H:%M UTC+0')" "$network" >> "$LOGFILE"
+printf "%s ADAMANT %s node repair started\n" \
+  "$(date -u '+%Y-%m-%d %H:%M UTC')" "$network"
 
-SECONDS=0
+printf "\nADAMANT Node Repair and Bootstrap Tool v%s for Ubuntu 20.04-26.04 LTS.\n" \
+  "$TOOL_VERSION"
+printf "Make sure you obtained this script from adamant.im or the official GitHub repository.\n"
+printf "This tool downloads and validates a trusted blockchain image, resets the selected database, and restarts the node.\n"
+printf "Installation and recovery guide: https://docs.adamant.im/own-node/installation.html\n\n"
 
-printf "\nADAMANT mainnet/testnet Node Repair/bootstrap Tool v1.3.7 for Ubuntu 20–24.\n"
-printf "Make sure you obtained this file from the adamant.im website or GitHub.\n"
-printf "This tool resets the ADM mainnet/testnet blockchain DB, loads a fresh image, and restarts your node.\n"
-printf "Alternatively, follow the step-by-step manual guide: https://news.adamant.im/how-to-run-your-adamant-node-on-ubuntu-990e391e8fcc\n"
-printf "If you prefer full validation from height 0, syncing may take days.\n\n"
+printf "Operating system: %s\n" "$PRETTY_NAME"
+printf "Selected network: %s\n" "$network"
+printf "Node user:        %s\n" "$username"
+printf "Database:         %s\n" "$databasename"
+printf "PM2 process:      %s\n\n" "$processname"
 
-printf "Selected network: '%s'\n" "$network"
-printf "ADM Node user:    '%s'\n" "$username"
-printf "Database:         '%s'\n" "$databasename"
-printf "Process name:     '%s'\n\n" "$processname"
-
-read -r -p "WARNING! Intended for ADM nodes installed via the ADAMANT installer or with default setup. Type \"yes\" to proceed: " agreement
-if [[ $agreement != "yes" ]]; then
-  printf "\nExecution cancelled.\n\n"; exit 1
-fi
-
-# Pre-flight
-if [ "$(id -u)" -ne 0 ]; then
-  printf "\n\nRun the script as a user with sudo privileges as it modifies PostgreSQL and installs missing packages."
-  printf "\nExecution cancelled.\n\n"
-  trap - ERR; exit 1
+read -r -p "WARNING: This will permanently replace database '$databasename'. Type \"yes\" to continue: " agreement
+if [[ "$agreement" != "yes" ]]; then
+  printf "\nRepair cancelled.\n\n"
+  exit 1
 fi
 
 if ! id -u "$username" >/dev/null 2>&1; then
-  printf "\n\nSystem user '%s' not found. This tool expects the environment created by the ADAMANT installer or with default setup." "$username"
-  printf "\nExecution cancelled.\n\n"
-  trap - ERR; exit 1
+  printf "\nSystem user '%s' was not found. This tool expects a standard ADAMANT installation.\n\n" \
+    "$username" >&2
+  exit 1
 fi
 
-# Ensure tools are present (jq/wget/gzip/psql)
-printf "\n\nChecking required packages (jq, wget, gzip, psql)…\n"
-if ! command -v jq >/dev/null 2>&1 || ! command -v wget >/dev/null 2>&1 || ! command -v gunzip >/dev/null 2>&1 || ! command -v psql >/dev/null 2>&1; then
-  printf "Installing missing packages…\n"
-  apt update
-  DEBIAN_FRONTEND=noninteractive apt install -y jq wget gzip postgresql-client || true
-fi
-
-# Stop node process under the ADM node user
-printf "\n\nStopping ADAMANT '%s' node process '%s' via pm2…\n\n" "$network" "$processname"
-su - "$username" -c "source ~/.nvm/nvm.sh >/dev/null 2>&1 || true; pm2 stop '$processname' || true"
-su - "$username" -c "source ~/.nvm/nvm.sh >/dev/null 2>&1 || true; pm2 save || true"
-
-# PostgreSQL: Terminate sessions, drop & recreate DB
-printf "\n\nResetting '%s' database. Terminating active '%s' DB connections…\n\n" "$network" "$databasename"
-systemctl is-active --quiet postgresql || service postgresql start || true
-sudo -u postgres psql -v ON_ERROR_STOP=1 -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='${databasename}' AND pid <> pg_backend_pid();" || true
-
-printf "\nDropping '%s' database…\n\n" "$databasename"
-sudo -u postgres psql -v ON_ERROR_STOP=1 -c "DROP DATABASE IF EXISTS ${databasename} WITH (FORCE);" || \
-sudo -u postgres psql -v ON_ERROR_STOP=1 -c "DROP DATABASE IF EXISTS ${databasename};"
-
-printf "\n\nRecreating '%s' database owned by '%s'…\n\n" "$databasename" "$username"
-sudo -u postgres psql -v ON_ERROR_STOP=1 -c "CREATE DATABASE ${databasename} OWNER ${username};"
-sudo -u postgres psql -v ON_ERROR_STOP=1 -c "ALTER DATABASE ${databasename} OWNER TO ${username};"
-
-# Heavy lifting under node user
-NODE_HOME="$(eval echo "~$username")"
+NODE_HOME="$(getent passwd "$username" | cut -d: -f6)"
 REPO_DIR="${NODE_HOME}/adamant"
-
-su - "$username" -s /bin/bash <<EOSU
-set -Eeuo pipefail
-trap 'echo -e "\n[ERROR] (user:\$USER) failed at line \$LINENO: \$BASH_COMMAND\n" >&2' ERR
-
-# Inject values from parent (root) shell
-REPO_DIR="${REPO_DIR}"
-network="${network}"
-databasename="${databasename}"
-processname="${processname}"
-image_url="${image_url}"
-image_filename="${image_filename}"
-image_unzipped_filename="${image_unzipped_filename}"
-
-echo
-echo
-echo "Entering ADM node directory…"
-cd "\$REPO_DIR" || { printf "\nCannot enter '%s'. Aborting.\n\n" "\$REPO_DIR"; exit 1; }
-
-source ~/.nvm/nvm.sh >/dev/null 2>&1 || true
-
-echo
-echo "Downloading '\$network' blockchain image…"
-rm -f "\$image_unzipped_filename" "\$image_filename" || true
-
-wget --progress=bar:force:noscroll "\$image_url" -O "\$image_filename" 2>/dev/tty
-
-echo
-echo "Unzipping blockchain image (may take minutes)…"
-gunzip -f "\$image_filename"
-
-echo
-echo "Loading image into database '\$databasename'…"
-echo
-psql "\$databasename" < "\$image_unzipped_filename"
-
-echo
-echo
-echo "Cleaning up temp files…"
-rm -f "\$image_unzipped_filename"
-
-echo
-if pm2 show "\$processname" >/dev/null 2>&1; then
-  echo "Restarting existing pm2 process '\$processname'…"
-  echo
-  pm2 restart "\$processname"
-else
-  echo "Starting new pm2 process '\$processname'…"
-  echo
-  if [[ "\$network" == "mainnet" ]]; then
-    pm2 start --name "\$processname" app.js
-  else
-    pm2 start --name "\$processname" app.js -- --config "test/config.json" --genesis "test/genesisBlock.json"
-  fi
+CFG_PATH="${REPO_DIR}/${configfile}"
+if [[ -z "$NODE_HOME" || ! -d "$REPO_DIR/.git" ]]; then
+  printf "\nADAMANT repository '%s' was not found.\n\n" "$REPO_DIR" >&2
+  exit 1
 fi
-pm2 save || true
+if [[ ! -f "$CFG_PATH" ]]; then
+  printf "\nADAMANT configuration '%s' was not found.\n\n" "$CFG_PATH" >&2
+  exit 1
+fi
+if [[ ! -s "${NODE_HOME}/.nvm/nvm.sh" ]]; then
+  printf "\nnvm was not found for user '%s'.\n\n" "$username" >&2
+  exit 1
+fi
+
+# Install or update the required repair tools while preserving local package
+# configuration files. Do not hide failures: continuing without these tools
+# could leave an empty database.
+printf "\nUpdating required repair packages.\n"
+export DEBIAN_FRONTEND=noninteractive
+export NEEDRESTART_MODE=a
+APT_OPTIONS=(-y -o Dpkg::Options::=--force-confold)
+apt-get update
+apt-get "${APT_OPTIONS[@]}" install gzip jq postgresql-client wget
+
+if command -v systemctl >/dev/null 2>&1 && systemctl list-unit-files postgresql.service >/dev/null 2>&1; then
+  systemctl start postgresql
+else
+  service postgresql start
+fi
+
+role_exists="$(runuser -u postgres -- psql -XAtqc \
+  "SELECT 1 FROM pg_roles WHERE rolname = '${username}'" postgres)"
+if [[ "$role_exists" != "1" ]]; then
+  printf "\nPostgreSQL role '%s' was not found. Refusing to recreate the database without its owner.\n\n" \
+    "$username" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC2016
+runuser -u "$username" -- env HOME="$NODE_HOME" PROCESS_NAME="$processname" bash -c '
+  set -Eeuo pipefail
+  source "$HOME/.nvm/nvm.sh"
+  command -v pm2 >/dev/null
+  pm2 describe "$PROCESS_NAME" >/dev/null
+'
+
+# Download to a partial file and validate gzip before touching the database.
+printf "\nDownloading and validating the %s blockchain image before database reset.\n" "$network"
+runuser -u "$username" -- env \
+  HOME="$NODE_HOME" \
+  REPO_DIR="$REPO_DIR" \
+  IMAGE_URL="$image_url" \
+  IMAGE_FILENAME="$image_filename" \
+  IMAGE_UNZIPPED_FILENAME="$image_unzipped_filename" \
+  bash <<'EOSU'
+set -Eeuo pipefail
+cd "$REPO_DIR"
+rm -f "${IMAGE_FILENAME}.part" "$IMAGE_FILENAME" "$IMAGE_UNZIPPED_FILENAME"
+wget --progress=dot:giga "$IMAGE_URL" -O "${IMAGE_FILENAME}.part"
+mv "${IMAGE_FILENAME}.part" "$IMAGE_FILENAME"
+gzip --test "$IMAGE_FILENAME"
 EOSU
 
-# Read port from config file for curl hint
-CFG_PATH="${REPO_DIR}/${configfile}"
-if [ -f "$CFG_PATH" ]; then
-  port_read="$(jq -r '.port // empty' "$CFG_PATH" 2>/dev/null || true)"
-  if [[ -n "${port_read:-}" ]]; then
-    port="$port_read"
-  fi
+# PM2 sends a catchable signal and allows the node to run its graceful shutdown
+# handlers before the database is replaced.
+printf "\nStopping ADAMANT %s process '%s' through pm2.\n" "$network" "$processname"
+# shellcheck disable=SC2016
+runuser -u "$username" -- env HOME="$NODE_HOME" PROCESS_NAME="$processname" bash -c '
+  set -Eeuo pipefail
+  source "$HOME/.nvm/nvm.sh"
+  pm2 stop "$PROCESS_NAME"
+  pm2 save
+'
+
+printf "\nTerminating active connections to database '%s'.\n" "$databasename"
+runuser -u postgres -- psql -Xv ON_ERROR_STOP=1 -c \
+  "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='${databasename}' AND pid <> pg_backend_pid();" \
+  postgres
+
+printf "Dropping and recreating database '%s'.\n" "$databasename"
+runuser -u postgres -- psql -Xv ON_ERROR_STOP=1 -c \
+  "DROP DATABASE IF EXISTS ${databasename} WITH (FORCE);" postgres || \
+runuser -u postgres -- psql -Xv ON_ERROR_STOP=1 -c \
+  "DROP DATABASE IF EXISTS ${databasename};" postgres
+runuser -u postgres -- createdb -O "$username" "$databasename"
+
+printf "\nExtracting and loading the validated blockchain image.\n"
+runuser -u "$username" -- env \
+  HOME="$NODE_HOME" \
+  REPO_DIR="$REPO_DIR" \
+  DATABASE_NAME="$databasename" \
+  IMAGE_FILENAME="$image_filename" \
+  IMAGE_UNZIPPED_FILENAME="$image_unzipped_filename" \
+  bash <<'EOSU'
+set -Eeuo pipefail
+cd "$REPO_DIR"
+gunzip "$IMAGE_FILENAME"
+psql -Xv ON_ERROR_STOP=1 "$DATABASE_NAME" < "$IMAGE_UNZIPPED_FILENAME"
+rm -f "$IMAGE_UNZIPPED_FILENAME"
+EOSU
+
+printf "\nRestarting ADAMANT %s process '%s'.\n" "$network" "$processname"
+# shellcheck disable=SC2016
+runuser -u "$username" -- env HOME="$NODE_HOME" PROCESS_NAME="$processname" bash -c '
+  set -Eeuo pipefail
+  source "$HOME/.nvm/nvm.sh"
+  pm2 restart "$PROCESS_NAME" --update-env
+  pm2 save
+'
+
+port_read="$(jq -r '.port // empty' "$CFG_PATH" 2>/dev/null || true)"
+if [[ -n "$port_read" ]]; then
+  port="$port_read"
 fi
 
-# Done
 minutes=$(( (SECONDS + 59) / 60 ))
-printf "\n\nADAMANT '%s' node repair/bootstrap completed successfully.\n" "$network"
-printf "Total execution time: %d minutes.\n" "$minutes"
-printf "See repair logs in: %s\n\n" "$LOGFILE"
-
-printf "To check your node status:\n"
-printf "    su - %s    # Use pm2 while logged in as '%s'\n" "$username" "$username"
-printf "    pm2 list\n"
+printf "\nADAMANT %s node repair completed successfully.\n" "$network"
+printf "Total repair time: %d minutes.\n" "$minutes"
+printf "Repair log: %s\n\n" "$LOGFILE"
+printf "Check the node as user '%s':\n" "$username"
+printf "    su - %s\n" "$username"
 printf "    pm2 show %s\n" "$processname"
 printf "    pm2 logs %s\n\n" "$processname"
-printf "To query current blockchain height:\n    curl http://localhost:%s/api/blocks/getHeight\n\n" "$port"
+printf "Query the current blockchain height:\n"
+printf "    curl http://localhost:%s/api/blocks/getHeight\n\n" "$port"
 
-printf "Thank you for supporting the truly decentralized ADAMANT Messenger! 🚀\n\n"
-
-# Remind the user that a 'screen' session is currently running
-if [[ -n ${STY:-} ]]; then
-  printf "You are running inside a 'screen' session (%s). To finish cleanly,\n" "$STY"
-  printf "    Detach:    Press Ctrl-A D (screen keeps running in background)\n"
-  printf "    Exit:      Type 'exit' or press Ctrl-D (screen will terminate)\n\n\n"
+if [[ -n "${STY:-}" ]]; then
+  printf "This command is running inside screen session '%s'.\n" "$STY"
+  printf "Detach with Ctrl-A D, or exit the shell to close the session.\n"
 fi

--- a/tools/fix_node.sh
+++ b/tools/fix_node.sh
@@ -8,7 +8,7 @@ on_error() {
 }
 trap on_error ERR
 
-readonly TOOL_VERSION="1.4.3"
+readonly TOOL_VERSION="1.4.5"
 
 network="mainnet"
 username="adamant"
@@ -121,7 +121,6 @@ case "${VERSION_ID:-}" in
 esac
 
 image_filename="$(basename "$image_url")"
-image_unzipped_filename="${image_filename%.gz}"
 LOGFILE="/var/log/adamant_${network}_fix.log"
 
 exec > >(tee -a "$LOGFILE") 2>&1
@@ -134,7 +133,7 @@ printf "%s ADAMANT %s node repair started\n" \
 printf "\nADAMANT Node Repair and Bootstrap Tool v%s for Ubuntu 20.04-26.04 LTS.\n" \
   "$TOOL_VERSION"
 printf "Make sure you obtained this script from adamant.im or the official GitHub repository.\n"
-printf "This tool downloads and validates a trusted blockchain image, resets the selected database, and restarts the node.\n"
+printf "This tool drops the selected database first to free disk space, downloads a trusted blockchain image, and restarts the node.\n"
 printf "Installation and recovery guide: https://docs.adamant.im/own-node/installation.html\n\n"
 
 printf "Operating system: %s\n" "$PRETTY_NAME"
@@ -144,7 +143,7 @@ printf "Database:         %s\n" "$databasename"
 printf "PM2 process:      %s\n\n" "$processname"
 
 require_interactive_tty
-agreement="$(read_from_tty "WARNING: This will permanently replace database '$databasename'. Type \"yes\" to continue: ")"
+agreement="$(read_from_tty "WARNING: This will stop the node and drop database '$databasename' before downloading the replacement image. Type \"yes\" to continue: ")"
 if [[ "$agreement" != "yes" ]]; then
   printf "\nRepair cancelled.\n\n"
   exit 1
@@ -179,6 +178,9 @@ fi
 printf "\nUpdating required repair packages.\n"
 export DEBIAN_FRONTEND=noninteractive
 export NEEDRESTART_MODE=a
+# Skip needrestart hooks during repair-managed apt runs. Some VPS images ship
+# a broken needrestart.conf, which can print scary Perl parse errors after dpkg.
+export NEEDRESTART_SUSPEND=1
 APT_OPTIONS=(-y -o Dpkg::Options::=--force-confold)
 apt-get update
 apt-get "${APT_OPTIONS[@]}" install gzip jq postgresql-client wget
@@ -251,23 +253,6 @@ runuser -u "$username" -- env HOME="$NODE_HOME" PROCESS_NAME="$processname" bash
   fi
 '
 
-# Download to a partial file and validate gzip before touching the database.
-printf "\nDownloading and validating the %s blockchain image before database reset.\n" "$network"
-runuser -u "$username" -- env \
-  HOME="$NODE_HOME" \
-  REPO_DIR="$REPO_DIR" \
-  IMAGE_URL="$image_url" \
-  IMAGE_FILENAME="$image_filename" \
-  IMAGE_UNZIPPED_FILENAME="$image_unzipped_filename" \
-  bash <<'EOSU'
-set -Eeuo pipefail
-cd "$REPO_DIR"
-rm -f "${IMAGE_FILENAME}.part" "$IMAGE_FILENAME" "$IMAGE_UNZIPPED_FILENAME"
-wget --progress=dot:giga "$IMAGE_URL" -O "${IMAGE_FILENAME}.part"
-mv "${IMAGE_FILENAME}.part" "$IMAGE_FILENAME"
-gzip --test "$IMAGE_FILENAME"
-EOSU
-
 # PM2 sends a catchable signal and allows the node to run its graceful shutdown
 # handlers before the database is replaced.
 printf "\nStopping ADAMANT %s process '%s' through pm2.\n" "$network" "$processname"
@@ -289,27 +274,41 @@ runuser -u postgres -- psql -X --set=ON_ERROR_STOP=1 -c \
   "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='${databasename}' AND pid <> pg_backend_pid();" \
   postgres
 
-printf "Dropping and recreating database '%s'.\n" "$databasename"
+printf "Dropping database '%s' to free disk space before downloading the image.\n" "$databasename"
 runuser -u postgres -- psql -X --set=ON_ERROR_STOP=1 -c \
   "DROP DATABASE IF EXISTS ${databasename} WITH (FORCE);" postgres || \
 runuser -u postgres -- psql -X --set=ON_ERROR_STOP=1 -c \
   "DROP DATABASE IF EXISTS ${databasename};" postgres
-runuser -u postgres -- createdb -O "$username" "$databasename"
+# DROP DATABASE removes the database files from PostgreSQL storage; VACUUM is
+# only useful for live tables, not for a database that no longer exists.
 
-printf "\nExtracting and loading the validated blockchain image.\n"
+printf "\nDownloading and validating the %s blockchain image after freeing database space.\n" "$network"
+runuser -u "$username" -- env \
+  HOME="$NODE_HOME" \
+  REPO_DIR="$REPO_DIR" \
+  IMAGE_URL="$image_url" \
+  IMAGE_FILENAME="$image_filename" \
+  bash <<'EOSU'
+set -Eeuo pipefail
+cd "$REPO_DIR"
+rm -f "${IMAGE_FILENAME}.part" "$IMAGE_FILENAME"
+wget --progress=dot:giga "$IMAGE_URL" -O "${IMAGE_FILENAME}.part"
+mv "${IMAGE_FILENAME}.part" "$IMAGE_FILENAME"
+gzip --test "$IMAGE_FILENAME"
+EOSU
+
+printf "\nCreating database '%s' and streaming the validated blockchain image.\n" "$databasename"
+runuser -u postgres -- createdb -O "$username" "$databasename"
 runuser -u "$username" -- env \
   HOME="$NODE_HOME" \
   REPO_DIR="$REPO_DIR" \
   DATABASE_NAME="$databasename" \
   IMAGE_FILENAME="$image_filename" \
-  IMAGE_UNZIPPED_FILENAME="$image_unzipped_filename" \
   bash <<'EOSU'
 set -Eeuo pipefail
 cd "$REPO_DIR"
-rm -f "$IMAGE_UNZIPPED_FILENAME"
-gunzip -f "$IMAGE_FILENAME"
-psql -X --set=ON_ERROR_STOP=1 "$DATABASE_NAME" < "$IMAGE_UNZIPPED_FILENAME"
-rm -f "$IMAGE_UNZIPPED_FILENAME"
+gzip -dc "$IMAGE_FILENAME" | psql -X --set=ON_ERROR_STOP=1 "$DATABASE_NAME"
+rm -f "$IMAGE_FILENAME"
 EOSU
 
 printf "\nRestarting ADAMANT %s process '%s'.\n" "$network" "$processname"

--- a/tools/fix_node.sh
+++ b/tools/fix_node.sh
@@ -19,7 +19,7 @@ port="36666"
 image_url="https://explorer.adamant.im/db_backup.sql.gz"
 
 usage() {
-  printf "Usage: %s [-n mainnet|testnet]\n" "${0##*/}"
+  printf "Usage: %s [-h] [-n mainnet|testnet]\n" "${0##*/}"
 }
 
 while getopts ":n:h" OPTION; do
@@ -173,7 +173,9 @@ runuser -u "$username" -- env HOME="$NODE_HOME" PROCESS_NAME="$processname" bash
   set -Eeuo pipefail
   source "$HOME/.nvm/nvm.sh"
   command -v pm2 >/dev/null
-  pm2 describe "$PROCESS_NAME" >/dev/null
+  if ! pm2 describe "$PROCESS_NAME" >/dev/null 2>&1; then
+    printf "WARNING: pm2 process '%s' is not registered; repair will recreate it after loading the image.\n" "$PROCESS_NAME"
+  fi
 '
 
 # Download to a partial file and validate gzip before touching the database.
@@ -200,19 +202,23 @@ printf "\nStopping ADAMANT %s process '%s' through pm2.\n" "$network" "$processn
 runuser -u "$username" -- env HOME="$NODE_HOME" PROCESS_NAME="$processname" bash -c '
   set -Eeuo pipefail
   source "$HOME/.nvm/nvm.sh"
-  pm2 stop "$PROCESS_NAME"
+  if pm2 describe "$PROCESS_NAME" >/dev/null 2>&1; then
+    pm2 stop "$PROCESS_NAME"
+  else
+    printf "WARNING: pm2 process '%s' is not registered; skipping stop.\n" "$PROCESS_NAME"
+  fi
   pm2 save
 '
 
 printf "\nTerminating active connections to database '%s'.\n" "$databasename"
-runuser -u postgres -- psql -Xv ON_ERROR_STOP=1 -c \
+runuser -u postgres -- psql -X --set=ON_ERROR_STOP=1 -c \
   "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='${databasename}' AND pid <> pg_backend_pid();" \
   postgres
 
 printf "Dropping and recreating database '%s'.\n" "$databasename"
-runuser -u postgres -- psql -Xv ON_ERROR_STOP=1 -c \
+runuser -u postgres -- psql -X --set=ON_ERROR_STOP=1 -c \
   "DROP DATABASE IF EXISTS ${databasename} WITH (FORCE);" postgres || \
-runuser -u postgres -- psql -Xv ON_ERROR_STOP=1 -c \
+runuser -u postgres -- psql -X --set=ON_ERROR_STOP=1 -c \
   "DROP DATABASE IF EXISTS ${databasename};" postgres
 runuser -u postgres -- createdb -O "$username" "$databasename"
 
@@ -226,17 +232,25 @@ runuser -u "$username" -- env \
   bash <<'EOSU'
 set -Eeuo pipefail
 cd "$REPO_DIR"
-gunzip "$IMAGE_FILENAME"
-psql -Xv ON_ERROR_STOP=1 "$DATABASE_NAME" < "$IMAGE_UNZIPPED_FILENAME"
+rm -f "$IMAGE_UNZIPPED_FILENAME"
+gunzip -f "$IMAGE_FILENAME"
+psql -X --set=ON_ERROR_STOP=1 "$DATABASE_NAME" < "$IMAGE_UNZIPPED_FILENAME"
 rm -f "$IMAGE_UNZIPPED_FILENAME"
 EOSU
 
 printf "\nRestarting ADAMANT %s process '%s'.\n" "$network" "$processname"
 # shellcheck disable=SC2016
-runuser -u "$username" -- env HOME="$NODE_HOME" PROCESS_NAME="$processname" bash -c '
+runuser -u "$username" -- env HOME="$NODE_HOME" NETWORK="$network" PROCESS_NAME="$processname" bash -c '
   set -Eeuo pipefail
   source "$HOME/.nvm/nvm.sh"
-  pm2 restart "$PROCESS_NAME" --update-env
+  if pm2 describe "$PROCESS_NAME" >/dev/null 2>&1; then
+    pm2 restart "$PROCESS_NAME" --update-env
+  elif [[ "$NETWORK" == "mainnet" ]]; then
+    pm2 start --name "$PROCESS_NAME" app.js
+  else
+    pm2 start --name "$PROCESS_NAME" app.js -- \
+      --config test/config.json --genesis test/genesisBlock.json
+  fi
   pm2 save
 '
 

--- a/tools/fix_node.sh
+++ b/tools/fix_node.sh
@@ -8,7 +8,7 @@ on_error() {
 }
 trap on_error ERR
 
-readonly TOOL_VERSION="1.4.0"
+readonly TOOL_VERSION="1.4.1"
 
 network="mainnet"
 username="adamant"
@@ -173,10 +173,43 @@ APT_OPTIONS=(-y -o Dpkg::Options::=--force-confold)
 apt-get update
 apt-get "${APT_OPTIONS[@]}" install gzip jq postgresql-client wget
 
-if command -v systemctl >/dev/null 2>&1 && systemctl list-unit-files postgresql.service >/dev/null 2>&1; then
-  systemctl start postgresql
+postgresql_started=false
+if command -v pg_lsclusters >/dev/null 2>&1 && command -v pg_ctlcluster >/dev/null 2>&1; then
+  while read -r cluster_version cluster_name _ cluster_status _; do
+    if [[ -n "$cluster_version" && -n "$cluster_name" && "$cluster_status" != "online" ]]; then
+      pg_ctlcluster "$cluster_version" "$cluster_name" start
+    fi
+  done < <(pg_lsclusters -h)
+  postgresql_started=true
+elif command -v systemctl >/dev/null 2>&1 && [[ "$(ps -p 1 -o comm=)" == "systemd" ]]; then
+  postgresql_units="$(systemctl list-units --all --type=service 'postgresql*' --no-legend 2>/dev/null \
+    | awk '$1 ~ /^postgresql(@.+|-[0-9]+)?\.service$/ && $1 != "postgresql@.service" { print $1 }' || true)"
+  if [[ -z "$postgresql_units" ]]; then
+    postgresql_units="$(systemctl list-unit-files --type=service --no-legend 'postgresql*' 2>/dev/null \
+      | awk '$1 ~ /^postgresql(@.+|-[0-9]+)?\.service$/ && $1 != "postgresql@.service" { print $1 }' || true)"
+  fi
+
+  if [[ -n "$postgresql_units" ]]; then
+    while read -r postgresql_unit; do
+      [[ -n "$postgresql_unit" ]] || continue
+      systemctl start "$postgresql_unit"
+    done <<< "$postgresql_units"
+    postgresql_started=true
+  elif systemctl list-unit-files postgresql.service >/dev/null 2>&1; then
+    systemctl start postgresql
+    postgresql_started=true
+  fi
 else
-  service postgresql start
+  if [[ -x /etc/init.d/postgresql ]]; then
+    service postgresql start
+    postgresql_started=true
+  fi
+fi
+
+if [[ "$postgresql_started" != "true" ]]; then
+  printf "Cannot find a PostgreSQL cluster or service to start. Check installed PostgreSQL packages and cluster status.\n" >&2
+  printf "Useful diagnostics: dpkg -l 'postgresql-*'; pg_lsclusters; systemctl list-units --all 'postgresql*'\n" >&2
+  exit 1
 fi
 
 role_exists="$(runuser -u postgres -- psql -XAtqc \

--- a/tools/fix_node.sh
+++ b/tools/fix_node.sh
@@ -8,7 +8,7 @@ on_error() {
 }
 trap on_error ERR
 
-readonly TOOL_VERSION="1.4.1"
+readonly TOOL_VERSION="1.4.2"
 
 network="mainnet"
 username="adamant"
@@ -175,12 +175,18 @@ apt-get "${APT_OPTIONS[@]}" install gzip jq postgresql-client wget
 
 postgresql_started=false
 if command -v pg_lsclusters >/dev/null 2>&1 && command -v pg_ctlcluster >/dev/null 2>&1; then
+  postgresql_cluster_found=false
   while read -r cluster_version cluster_name _ cluster_status _; do
     if [[ -n "$cluster_version" && -n "$cluster_name" && "$cluster_status" != "online" ]]; then
       pg_ctlcluster "$cluster_version" "$cluster_name" start
     fi
+    if [[ -n "$cluster_version" && -n "$cluster_name" ]]; then
+      postgresql_cluster_found=true
+    fi
   done < <(pg_lsclusters -h)
-  postgresql_started=true
+  if [[ "$postgresql_cluster_found" == "true" ]]; then
+    postgresql_started=true
+  fi
 elif command -v systemctl >/dev/null 2>&1 && [[ "$(ps -p 1 -o comm=)" == "systemd" ]]; then
   postgresql_units="$(systemctl list-units --all --type=service 'postgresql*' --no-legend 2>/dev/null \
     | awk '$1 ~ /^postgresql(@.+|-[0-9]+)?\.service$/ && $1 != "postgresql@.service" { print $1 }' || true)"
@@ -204,6 +210,10 @@ else
     service postgresql start
     postgresql_started=true
   fi
+fi
+
+if [[ "$postgresql_started" == "true" ]] && ! runuser -u postgres -- pg_isready -q; then
+  postgresql_started=false
 fi
 
 if [[ "$postgresql_started" != "true" ]]; then

--- a/tools/fix_node.sh
+++ b/tools/fix_node.sh
@@ -8,7 +8,7 @@ on_error() {
 }
 trap on_error ERR
 
-readonly TOOL_VERSION="1.4.2"
+readonly TOOL_VERSION="1.4.3"
 
 network="mainnet"
 username="adamant"
@@ -38,6 +38,15 @@ read_from_tty() {
   printf "%s" "$prompt_text" > /dev/tty
   IFS= read -r response < /dev/tty
   printf "%s" "$response"
+}
+
+repair_node_user_permissions() {
+  for path in "$NODE_HOME/.nvm" "$NODE_HOME/.pm2" "$REPO_DIR"; do
+    if [[ -e "$path" ]]; then
+      chown -R "$username:$username" "$path"
+      chmod -R u+rwX "$path"
+    fi
+  done
 }
 
 while getopts ":n:h" OPTION; do
@@ -154,6 +163,7 @@ if [[ -z "$NODE_HOME" || ! -d "$REPO_DIR/.git" ]]; then
   printf "\nADAMANT repository '%s' was not found.\n\n" "$REPO_DIR" >&2
   exit 1
 fi
+repair_node_user_permissions
 if [[ ! -f "$CFG_PATH" ]]; then
   printf "\nADAMANT configuration '%s' was not found.\n\n" "$CFG_PATH" >&2
   exit 1
@@ -233,6 +243,7 @@ fi
 # shellcheck disable=SC2016
 runuser -u "$username" -- env HOME="$NODE_HOME" PROCESS_NAME="$processname" bash -c '
   set -Eeuo pipefail
+  cd "$HOME"
   source "$HOME/.nvm/nvm.sh"
   command -v pm2 >/dev/null
   if ! pm2 describe "$PROCESS_NAME" >/dev/null 2>&1; then
@@ -263,6 +274,7 @@ printf "\nStopping ADAMANT %s process '%s' through pm2.\n" "$network" "$processn
 # shellcheck disable=SC2016
 runuser -u "$username" -- env HOME="$NODE_HOME" PROCESS_NAME="$processname" bash -c '
   set -Eeuo pipefail
+  cd "$HOME"
   source "$HOME/.nvm/nvm.sh"
   if pm2 describe "$PROCESS_NAME" >/dev/null 2>&1; then
     pm2 stop "$PROCESS_NAME"
@@ -304,6 +316,7 @@ printf "\nRestarting ADAMANT %s process '%s'.\n" "$network" "$processname"
 # shellcheck disable=SC2016
 runuser -u "$username" -- env HOME="$NODE_HOME" NETWORK="$network" PROCESS_NAME="$processname" bash -c '
   set -Eeuo pipefail
+  cd "$HOME"
   source "$HOME/.nvm/nvm.sh"
   if pm2 describe "$PROCESS_NAME" >/dev/null 2>&1; then
     pm2 restart "$PROCESS_NAME" --update-env

--- a/tools/install_node.sh
+++ b/tools/install_node.sh
@@ -22,7 +22,8 @@ nodejs="24"
 image_url="https://explorer.adamant.im/db_backup.sql.gz"
 
 usage() {
-  printf "Usage: %s [-b branch] [-n mainnet|testnet] [-j 22|24|26]\n" "${0##*/}"
+  printf "Usage: %s [-h] [-b branch] [-n mainnet|testnet] [-j 22|24|26]\n" "${0##*/}"
+  printf "       Node.js aliases: jod=22, krypton=24. Version 24 is the default.\n"
 }
 
 # Parse command-line options before creating the network-specific log file.
@@ -129,6 +130,7 @@ printf "\nWelcome to the ADAMANT Node Installer v%s for Ubuntu 20.04-26.04 LTS.\
   "$INSTALLER_VERSION"
 printf "Make sure you obtained this script from adamant.im or the official GitHub repository.\n"
 printf "The installer updates system packages and preserves existing ADAMANT configuration and local Git changes.\n"
+printf "Package upgrades may restart PostgreSQL, Redis, and other affected system services.\n"
 printf "Review backups and custom service configuration before continuing on an existing server.\n\n"
 printf "Installation guide: https://docs.adamant.im/own-node/installation.html\n\n"
 
@@ -137,7 +139,7 @@ printf "Selected network:  %s\n" "$network"
 printf "Selected branch:   %s\n" "$branch"
 printf "Selected Node.js:  %s (24 is recommended for production)\n\n" "$nodejs"
 
-read -r -p "The script will update packages and configure ADAMANT services. Type \"yes\" to continue: " agreement
+read -r -p "The script will upgrade packages, may restart services, and configure ADAMANT. Type \"yes\" to continue: " agreement
 if [[ "$agreement" != "yes" ]]; then
   printf "\nInstallation cancelled.\n\n"
   exit 1
@@ -222,6 +224,12 @@ case "$architecture" in
       install -d -m 0755 /usr/share/postgresql-common/pgdg
       curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
         -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+      pgdg_key_fingerprint="$(gpg --show-keys --with-colons /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+        | awk -F: '$1 == "fpr" { print $10; exit }')"
+      if [[ "$pgdg_key_fingerprint" != "B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8" ]]; then
+        printf "Unexpected PostgreSQL APT key fingerprint: %s\n" "${pgdg_key_fingerprint:-unknown}" >&2
+        exit 1
+      fi
       cat > /etc/apt/sources.list.d/pgdg.sources <<EOF
 Types: deb
 URIs: ${pgdg_url}
@@ -275,6 +283,13 @@ if command -v systemctl >/dev/null 2>&1 && systemctl list-unit-files postgresql.
 else
   service postgresql start
 fi
+for _ in {1..30}; do
+  if runuser -u postgres -- pg_isready -q; then
+    break
+  fi
+  sleep 1
+done
+runuser -u postgres -- pg_isready -q
 
 if command -v systemctl >/dev/null 2>&1 && systemctl list-unit-files redis-server.service >/dev/null 2>&1; then
   systemctl enable --now redis-server
@@ -302,12 +317,14 @@ role_exists="$(runuser -u postgres -- psql -XAtqc \
   "SELECT 1 FROM pg_roles WHERE rolname = '${username}'" postgres)"
 if [[ "$role_exists" == "1" ]]; then
   printf "\nUpdating the password for existing PostgreSQL role '%s'.\n" "$username"
-  runuser -u postgres -- psql -Xv ON_ERROR_STOP=1 -c \
-    "ALTER ROLE ${username} WITH LOGIN PASSWORD '${DB_PASSWORD_SQL}';" postgres
+  runuser -u postgres -- psql -X --set=ON_ERROR_STOP=1 postgres <<EOSQL
+ALTER ROLE ${username} WITH LOGIN PASSWORD '${DB_PASSWORD_SQL}';
+EOSQL
 else
   printf "\nCreating PostgreSQL role '%s'.\n" "$username"
-  runuser -u postgres -- psql -Xv ON_ERROR_STOP=1 -c \
-    "CREATE ROLE ${username} WITH LOGIN PASSWORD '${DB_PASSWORD_SQL}';" postgres
+  runuser -u postgres -- psql -X --set=ON_ERROR_STOP=1 postgres <<EOSQL
+CREATE ROLE ${username} WITH LOGIN PASSWORD '${DB_PASSWORD_SQL}';
+EOSQL
 fi
 
 database_exists="$(runuser -u postgres -- psql -XAtqc \
@@ -318,7 +335,7 @@ else
   printf "Creating database '%s'.\n" "$databasename"
   runuser -u postgres -- createdb -O "$username" "$databasename"
 fi
-runuser -u postgres -- psql -Xv ON_ERROR_STOP=1 -c \
+runuser -u postgres -- psql -X --set=ON_ERROR_STOP=1 -c \
   "ALTER DATABASE ${databasename} OWNER TO ${username};" postgres
 
 database_has_tables="$(runuser -u postgres -- psql -XAtqc \
@@ -353,7 +370,20 @@ trap 'status=$?; printf "\n[ERROR] User setup failed at line %s.\n\n" "$LINENO" 
 
 printf "\nInstalling or updating nvm v%s and Node.js %s.\n" "$NVM_INSTALL_VERSION" "$NODEJS_VERSION"
 export NVM_DIR="$HOME/.nvm"
-curl -fsSL "https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_INSTALL_VERSION}/install.sh" | bash
+if [[ -d "$NVM_DIR/.git" ]]; then
+  git -C "$NVM_DIR" fetch --tags --depth 1 origin "v${NVM_INSTALL_VERSION}"
+  git -C "$NVM_DIR" checkout --quiet "v${NVM_INSTALL_VERSION}"
+else
+  rm -rf "$NVM_DIR"
+  git clone --depth 1 --branch "v${NVM_INSTALL_VERSION}" https://github.com/nvm-sh/nvm.git "$NVM_DIR"
+fi
+nvm_profile="$HOME/.bashrc"
+if ! grep -q 'NVM_DIR="$HOME/.nvm"' "$nvm_profile" 2>/dev/null; then
+  {
+    printf '\nexport NVM_DIR="$HOME/.nvm"\n'
+    printf '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"\n'
+  } >> "$nvm_profile"
+fi
 # shellcheck disable=SC1091
 source "$NVM_DIR/nvm.sh"
 nvm install "$NODEJS_VERSION" --latest-npm
@@ -417,7 +447,7 @@ DB_PASSWORD_DECODED="$(printf '%s' "$DB_PASSWORD_BASE64" | base64 --decode)"
 export DB_PASSWORD_DECODED
 config_tmp="$(mktemp "${CONFIG_FILE}.tmp.XXXXXX")"
 jq '.db.password = env.DB_PASSWORD_DECODED' "$CONFIG_FILE" > "$config_tmp"
-chmod --reference="$CONFIG_FILE" "$config_tmp" 2>/dev/null || true
+chmod 0600 "$config_tmp"
 mv "$config_tmp" "$CONFIG_FILE"
 unset DB_PASSWORD_DECODED DB_PASSWORD_BASE64
 
@@ -429,7 +459,7 @@ if [[ "$USE_IMAGE" == "true" ]]; then
   gzip --test "$IMAGE_FILENAME"
   printf "Extracting and loading the blockchain image.\n"
   gunzip "$IMAGE_FILENAME"
-  psql -Xv ON_ERROR_STOP=1 "$DATABASE_NAME" < "$IMAGE_UNZIPPED_FILENAME"
+  psql -X --set=ON_ERROR_STOP=1 "$DATABASE_NAME" < "$IMAGE_UNZIPPED_FILENAME"
   rm -f "$IMAGE_UNZIPPED_FILENAME"
 fi
 

--- a/tools/install_node.sh
+++ b/tools/install_node.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
-trap 'echo -e "\n[ERROR] Line $LINENO failed. Aborting.\n\n" >&2' ERR
+
+on_error() {
+  local exit_status=$?
+  printf "\n[ERROR] Line %s failed. Installation stopped.\n\n" "${BASH_LINENO[0]}" >&2
+  exit "$exit_status"
+}
+trap on_error ERR
+
+readonly INSTALLER_VERSION="2.4.0"
+readonly NVM_VERSION="0.40.5"
 
 branch="master"
 network="mainnet"
@@ -9,265 +18,464 @@ databasename="adamant_main"
 configfile="config.json"
 processname="adamant"
 port="36666"
-nodejs="jod" # LTS=22 by default
+nodejs="24"
 image_url="https://explorer.adamant.im/db_backup.sql.gz"
 
-# Parse options
-while getopts ":b:n:j:" OPTION; do
+usage() {
+  printf "Usage: %s [-b branch] [-n mainnet|testnet] [-j 22|24|26]\n" "${0##*/}"
+}
+
+# Parse command-line options before creating the network-specific log file.
+while getopts ":b:n:j:h" OPTION; do
   case "$OPTION" in
     b)
       branch="$OPTARG"
       ;;
     n)
-      if [[ "$OPTARG" == "testnet" ]]; then
-        network="testnet"
-        username="adamanttest"
-        databasename="adamant_test"
-        configfile="test/config.json"
-        processname="adamanttest"
-        port="36667"
-        image_url="https://testnet.adamant.im/db_test_backup.sql.gz"
-      elif [[ "$OPTARG" == "mainnet" ]]; then
-        network="mainnet"
-      else
-        printf "\nNetwork should be 'mainnet' or 'testnet'.\n\n"
-        trap - ERR; exit 2
-      fi
+      case "$OPTARG" in
+        testnet)
+          network="testnet"
+          username="adamanttest"
+          databasename="adamant_test"
+          configfile="test/config.json"
+          processname="adamanttest"
+          port="36667"
+          image_url="https://testnet.adamant.im/db_test_backup.sql.gz"
+          ;;
+        mainnet) : ;;
+        *)
+          printf "\nNetwork must be 'mainnet' or 'testnet'.\n\n" >&2
+          usage
+          trap - ERR
+          exit 2
+          ;;
+      esac
       ;;
     j)
-      if [[ "$OPTARG" == "20" || "$OPTARG" == "iron" ]]; then
-        nodejs="iron"
-      elif [[ "$OPTARG" == "22" || "$OPTARG" == "jod" ]]; then
-        nodejs="jod"
-      else
-        printf "\nNodejs should be 'iron' = '20', or 'jod' = '22'.\n\n"
-        trap - ERR; exit 2
-      fi
+      case "$OPTARG" in
+        22|jod) nodejs="22" ;;
+        24|krypton) nodejs="24" ;;
+        26) nodejs="26" ;;
+        *)
+          printf "\nNode.js must be version 22, 24, or 26. Version 24 is the default.\n\n" >&2
+          trap - ERR
+          exit 2
+          ;;
+      esac
+      ;;
+    h)
+      usage
+      exit 0
       ;;
     :)
-      printf "\nOption '-%s' requires an argument.\n\n" "$OPTARG"
-      trap - ERR; exit 2
+      printf "\nOption '-%s' requires an argument.\n\n" "$OPTARG" >&2
+      usage
+      trap - ERR
+      exit 2
       ;;
     \?)
-      printf "\nWrong parameters. Use '-b' for branch, '-n' for network, '-j' for Nodejs version.\n\n"
-      trap - ERR; exit 2
+      printf "\nUnknown option: '-%s'.\n\n" "$OPTARG" >&2
+      usage
+      trap - ERR
+      exit 2
       ;;
   esac
 done
 
-image_filename="$(basename "$image_url")"       # db_backup.sql.gz
-image_unzipped_filename="${image_filename%.gz}" # db_backup.sql
-
-# Everything sent to stdout/stderr → goes both to the log and to the screen
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-LOGFILE="${SCRIPT_DIR}/adamant_${network}_install.log"
-exec > >(tee -a "$LOGFILE") 2>&1
-if [ -s "$LOGFILE" ]; then
-  printf "\n\n\n===========================\n" >> "$LOGFILE"
-fi
-printf "%s Installing ADAMANT %s node…\n" \
-  "$(date -u '+%Y-%m-%d %H:%M UTC+0')" "$network" >> "$LOGFILE"
-
-printf "\nWelcome to the ADAMANT mainnet/testnet Node Installer v2.3.0 for Ubuntu 20, 22, and 24.\n"
-printf "Make sure you obtained this file from the adamant.im website or GitHub.\n"
-printf "This installer is the easiest way to run an ADAMANT mainnet/testnet node. However, if you're not familiar with Linux, consult an IT specialist.\n\n"
-printf "Full guide: https://news.adamant.im/how-to-run-your-adamant-node-on-ubuntu-990e391e8fcc\n\n"
-printf "The installer will prompt you to set database and user passwords.\n"
-printf "The system may also ask for locale/keyboard/GRUB options — defaults are usually fine.\n\n"
-
-printf "Selected network: '%s'\n" "$network"
-printf "Selected branch:  '%s'\n" "$branch"
-printf "Selected Node.js: '%s' LTS\n\n" "$nodejs"
-
-read -r -p "WARNING! Intended for NEW droplets. Existing data MAY BE DAMAGED. Type \"yes\" to continue: " agreement
-if [[ $agreement != "yes" ]]; then
-  printf "\nInstallation cancelled.\n\n"; exit 1
+if [[ "$(id -u)" -ne 0 ]]; then
+  printf "\nRun this installer as root, for example: sudo bash %s\n\n" "${0##*/}" >&2
+  trap - ERR
+  exit 1
 fi
 
-if [ "$(id -u)" -ne 0 ]; then
-  printf "\n\nRun the script as a user with sudo privileges as it installs packages and configures system services."
-  printf "\nInstallation cancelled.\n\n"; exit 1
+if [[ ! -r /etc/os-release ]]; then
+  printf "\nCannot identify the operating system: /etc/os-release is missing.\n\n" >&2
+  trap - ERR
+  exit 1
 fi
 
-# Choosing whether to use blockchain image for bootstrapping
-IMAGE=false
-printf "\n\nUsing a blockchain image can significantly reduce sync time, but you must fully trust its source.\n"
-printf "If you skip it, your '%s' node will verify every transaction (may take several days).\n" "$network"
-read -r -p "Use the ADAMANT blockchain image to bootstrap? [Y/n]: " useimage
-case ${useimage:-Y} in
-  [yY][eE][sS]|[yY]|[jJ]|'') IMAGE=true; printf "\nThe '%s' image will be downloaded; your node should reach the current height in minutes.\n\n" "$network" ;;
-  *) printf "\nYour '%s' node will sync from scratch; reaching current height may take several days.\n\n" "$network" ;;
-esac
-
-# Fix /etc/hosts hostname record if missing
-hostname="$(cat /etc/hostname)"
-if ! grep -qE "^[[:space:]]*127\.0\.1\.1[[:space:]]+.*\b$hostname\b" /etc/hosts; then
-  printf "No hostname record in /etc/hosts. Adding it…\n\n"
-  printf '\n127.0.1.1\t%s\n' "$hostname" >> /etc/hosts
-else
-  printf "Hostname /etc/hosts looks good.\n\n"
-fi
-
-# Ask for DB password
-get_database_password () {
-  printf 'Set the database password:\n> ' >&2
-  read -r -s postgrespwd; printf '\n' >&2
-
-  printf 'Confirm password:\n> ' >&2
-  read -r -s postgrespwdconfirmation; printf '\n' >&2
-
-  if [[ $postgrespwd == "$postgrespwdconfirmation" ]]; then
-    echo "$postgrespwd"
-  else
-    printf '\nPassword mismatch. Try again.\n\n' >&2
-    get_database_password
-  fi
-}
-DB_PASSWORD="$(get_database_password)"
-# Escape single quotes for SQL, then encode the password in Base64 to safely pass into an unquoted heredoc (su - "$username" <<EOSU)
-DB_PASSWORD_SQL=${DB_PASSWORD//\'/\'\'}
-DB_PASSWORD_BASE64="$(printf '%s' "$DB_PASSWORD" | base64 -w0 2>/dev/null || printf '%s' "$DB_PASSWORD" | base64)"
-
-# Create system user if needed
-printf "\n\nChecking if user '%s' exists…\n\n" "$username"
-if ! id -u "$username" >/dev/null 2>&1; then
-  printf "Creating system user '%s'…\n" "$username"
-  adduser --gecos "" "$username"
-  printf "User '%s' has been created.\n\n" "$username"
-fi
-
-# Don't disturb with dialogs about restarting services
-# needrestart: temporary override (removed later)
-printf "Configuring needrestart to skip dialogs during installation…\n"
-mkdir -p /etc/needrestart/conf.d
-cat >/etc/needrestart/conf.d/99-adamant-temp.conf <<'NREOF'
-$nrconf{restart} = 'a';
-$nrconf{kernelhints} = 0;
-NREOF
-
-# Packages
-printf "\nUpdating system packages…\n\n"
-apt update
-apt -y upgrade
-
-printf "\n\nInstalling PostgreSQL and prerequisites…\n\n"
-install -d -m 0755 /etc/apt/keyrings || true
-curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor >/etc/apt/trusted.gpg.d/postgresql.gpg
 # shellcheck disable=SC1091
 . /etc/os-release
-echo "deb http://apt.postgresql.org/pub/repos/apt/ ${VERSION_CODENAME}-pgdg main" >/etc/apt/sources.list.d/pgdg.list
-apt update
-DEBIAN_FRONTEND=noninteractive apt install -y \
-  build-essential curl automake autoconf libtool htop jq rpl mc git wget \
-  postgresql postgresql-contrib libpq-dev redis-server
+if [[ "${ID:-}" != "ubuntu" ]]; then
+  printf "\nThis installer supports Ubuntu. Detected: %s %s.\n\n" \
+    "${PRETTY_NAME:-unknown OS}" "${VERSION_ID:-}" >&2
+  trap - ERR
+  exit 1
+fi
 
-# Ensure postgres is running (Windows Subsystem for Linux case)
-systemctl is-active --quiet postgresql || service postgresql start
+case "${VERSION_ID:-}" in
+  20.04|22.04|24.04|26.04) ;;
+  *)
+    printf "\nUnsupported Ubuntu release '%s'. Supported releases: 20.04, 22.04, 24.04, and 26.04.\n\n" \
+      "${VERSION_ID:-unknown}" >&2
+    trap - ERR
+    exit 1
+    ;;
+esac
 
-# PostgreSQL: DB & role
-printf "\n\nCreating database '%s' and role '%s'…\n\n" "$databasename" "$username"
-cd /tmp || exit 1
-sudo -u postgres psql -c "CREATE ROLE ${username} LOGIN PASSWORD '${DB_PASSWORD_SQL}';" || true
-sudo -u postgres psql -c "CREATE DATABASE ${databasename} OWNER ${username};" || true
-sudo -u postgres psql -c "ALTER DATABASE ${databasename} OWNER TO ${username};" || true
+image_filename="$(basename "$image_url")"
+image_unzipped_filename="${image_filename%.gz}"
+LOGFILE="/var/log/adamant_${network}_install.log"
 
-# ------- Commands below run as the ADM node user; Variables expanded by parent -------
-su - "$username" <<EOSU
+# Send all output to both the terminal and a persistent log file.
+exec > >(tee -a "$LOGFILE") 2>&1
+if [[ -s "$LOGFILE" ]]; then
+  printf "\n\n\n===========================\n"
+fi
+printf "%s ADAMANT %s node installation started\n" \
+  "$(date -u '+%Y-%m-%d %H:%M UTC')" "$network"
+
+printf "\nWelcome to the ADAMANT Node Installer v%s for Ubuntu 20.04-26.04 LTS.\n" \
+  "$INSTALLER_VERSION"
+printf "Make sure you obtained this script from adamant.im or the official GitHub repository.\n"
+printf "The installer updates system packages and preserves existing ADAMANT configuration and local Git changes.\n"
+printf "Review backups and custom service configuration before continuing on an existing server.\n\n"
+printf "Installation guide: https://docs.adamant.im/own-node/installation.html\n\n"
+
+printf "Operating system:  %s\n" "$PRETTY_NAME"
+printf "Selected network:  %s\n" "$network"
+printf "Selected branch:   %s\n" "$branch"
+printf "Selected Node.js:  %s (24 is recommended for production)\n\n" "$nodejs"
+
+read -r -p "The script will update packages and configure ADAMANT services. Type \"yes\" to continue: " agreement
+if [[ "$agreement" != "yes" ]]; then
+  printf "\nInstallation cancelled.\n\n"
+  exit 1
+fi
+
+# A trusted blockchain image reduces initial synchronization time.
+IMAGE=false
+printf "\nA blockchain image can reduce synchronization time, but its source must be trusted.\n"
+printf "Without an image, the node verifies the blockchain from height 1, which may take several days.\n"
+read -r -p "Use the official ADAMANT blockchain image to bootstrap? [Y/n]: " useimage
+case "${useimage:-Y}" in
+  [yY][eE][sS]|[yY]|[jJ]|'') IMAGE=true ;;
+  *) printf "The node will synchronize from scratch.\n" ;;
+esac
+
+# Add an exact hostname token only when /etc/hosts does not already contain one.
+hostname_value="$(hostname)"
+if ! awk -v hostname="$hostname_value" '
+  $1 !~ /^#/ {
+    for (field = 2; field <= NF; field++) {
+      if ($field == hostname) {
+        found = 1
+      }
+    }
+  }
+  END { exit !found }
+' /etc/hosts; then
+  printf "\nAdding hostname '%s' to /etc/hosts.\n" "$hostname_value"
+  printf '\n127.0.1.1\t%s\n' "$hostname_value" >> /etc/hosts
+else
+  printf "\nThe /etc/hosts hostname entry is already present.\n"
+fi
+
+get_database_password() {
+  local password confirmation
+
+  while true; do
+    printf '\nSet the PostgreSQL password for role %s:\n> ' "$username" >&2
+    read -r -s password
+    printf '\nConfirm the password:\n> ' >&2
+    read -r -s confirmation
+    printf '\n' >&2
+
+    if [[ -z "$password" ]]; then
+      printf 'The database password cannot be empty. Try again.\n' >&2
+    elif [[ "$password" != "$confirmation" ]]; then
+      printf 'The passwords do not match. Try again.\n' >&2
+    else
+      printf '%s' "$password"
+      return
+    fi
+  done
+}
+
+DB_PASSWORD="$(get_database_password)"
+DB_PASSWORD_SQL=${DB_PASSWORD//\'/\'\'}
+DB_PASSWORD_BASE64="$(printf '%s' "$DB_PASSWORD" | base64 | tr -d '\n')"
+unset DB_PASSWORD
+
+printf "\nUpdating package indexes and installing package-management prerequisites.\n"
+export DEBIAN_FRONTEND=noninteractive
+export NEEDRESTART_MODE=a
+APT_OPTIONS=(-y -o Dpkg::Options::=--force-confold)
+apt-get update
+apt-get "${APT_OPTIONS[@]}" install ca-certificates curl gnupg
+
+# Ubuntu 20.04 packages are in the official PGDG archive; newer supported LTS
+# releases use the current PGDG repository. Unsupported architectures fall back
+# to Ubuntu's PostgreSQL packages.
+pgdg_url="https://apt.postgresql.org/pub/repos/apt"
+if [[ "$VERSION_ID" == "20.04" ]]; then
+  pgdg_url="https://apt-archive.postgresql.org/pub/repos/apt"
+fi
+architecture="$(dpkg --print-architecture)"
+pgdg_release_url="${pgdg_url}/dists/${VERSION_CODENAME}-pgdg/Release"
+pgdg_enabled=false
+postgresql_package="postgresql"
+
+case "$architecture" in
+  amd64|arm64|ppc64el)
+    if curl -fsSL -o /dev/null "$pgdg_release_url"; then
+      install -d -m 0755 /usr/share/postgresql-common/pgdg
+      curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+        -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+      cat > /etc/apt/sources.list.d/pgdg.sources <<EOF
+Types: deb
+URIs: ${pgdg_url}
+Suites: ${VERSION_CODENAME}-pgdg
+Architectures: ${architecture}
+Components: main
+Signed-By: /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+EOF
+      pgdg_enabled=true
+      if [[ "$VERSION_ID" == "20.04" ]]; then
+        postgresql_package="postgresql-17"
+      else
+        postgresql_package="postgresql-18"
+      fi
+      printf "Configured the official PostgreSQL repository for %s.\n" "$VERSION_CODENAME"
+    fi
+    ;;
+esac
+
+if [[ "$pgdg_enabled" != "true" ]]; then
+  printf "WARNING: PGDG is unavailable for this release or architecture; using Ubuntu PostgreSQL packages.\n"
+fi
+
+printf "\nUpdating installed system packages. Existing package configuration files will be preserved.\n"
+apt-get update
+apt-get "${APT_OPTIONS[@]}" upgrade
+
+printf "\nInstalling ADAMANT system dependencies.\n"
+apt-get "${APT_OPTIONS[@]}" install \
+  build-essential automake autoconf libtool pkg-config \
+  ca-certificates curl git gnupg gzip jq wget \
+  libpq-dev postgresql-client redis-server
+
+if ! git check-ref-format --branch "$branch" >/dev/null 2>&1; then
+  printf "Invalid Git branch name: '%s'.\n" "$branch" >&2
+  exit 2
+fi
+
+# Keep an existing PostgreSQL major version. On a fresh host, install the latest
+# stable server supplied by the configured repository.
+if dpkg-query -W -f='${Package}\n' 'postgresql-[0-9]*' 2>/dev/null \
+  | grep -Eq '^postgresql-[0-9]+$'; then
+  printf "Existing PostgreSQL server installation detected; preserving its major version.\n"
+else
+  printf "Installing PostgreSQL server package '%s'.\n" "$postgresql_package"
+  apt-get "${APT_OPTIONS[@]}" install "$postgresql_package"
+fi
+
+if command -v systemctl >/dev/null 2>&1 && systemctl list-unit-files postgresql.service >/dev/null 2>&1; then
+  systemctl enable --now postgresql
+else
+  service postgresql start
+fi
+
+if command -v systemctl >/dev/null 2>&1 && systemctl list-unit-files redis-server.service >/dev/null 2>&1; then
+  systemctl enable --now redis-server
+else
+  service redis-server start
+fi
+
+# Create the system account without changing an existing account or password.
+if id -u "$username" >/dev/null 2>&1; then
+  printf "\nSystem user '%s' already exists; preserving it.\n" "$username"
+else
+  printf "\nCreating system user '%s'.\n" "$username"
+  adduser --disabled-password --gecos "" "$username"
+fi
+
+NODE_HOME="$(getent passwd "$username" | cut -d: -f6)"
+if [[ -z "$NODE_HOME" || ! -d "$NODE_HOME" ]]; then
+  printf "Cannot determine a valid home directory for user '%s'.\n" "$username" >&2
+  exit 1
+fi
+REPO_DIR="${NODE_HOME}/adamant"
+
+# Create or update the PostgreSQL role and database without masking SQL errors.
+role_exists="$(runuser -u postgres -- psql -XAtqc \
+  "SELECT 1 FROM pg_roles WHERE rolname = '${username}'" postgres)"
+if [[ "$role_exists" == "1" ]]; then
+  printf "\nUpdating the password for existing PostgreSQL role '%s'.\n" "$username"
+  runuser -u postgres -- psql -Xv ON_ERROR_STOP=1 -c \
+    "ALTER ROLE ${username} WITH LOGIN PASSWORD '${DB_PASSWORD_SQL}';" postgres
+else
+  printf "\nCreating PostgreSQL role '%s'.\n" "$username"
+  runuser -u postgres -- psql -Xv ON_ERROR_STOP=1 -c \
+    "CREATE ROLE ${username} WITH LOGIN PASSWORD '${DB_PASSWORD_SQL}';" postgres
+fi
+
+database_exists="$(runuser -u postgres -- psql -XAtqc \
+  "SELECT 1 FROM pg_database WHERE datname = '${databasename}'" postgres)"
+if [[ "$database_exists" == "1" ]]; then
+  printf "Database '%s' already exists; preserving its contents.\n" "$databasename"
+else
+  printf "Creating database '%s'.\n" "$databasename"
+  runuser -u postgres -- createdb -O "$username" "$databasename"
+fi
+runuser -u postgres -- psql -Xv ON_ERROR_STOP=1 -c \
+  "ALTER DATABASE ${databasename} OWNER TO ${username};" postgres
+
+database_has_tables="$(runuser -u postgres -- psql -XAtqc \
+  "SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_tables WHERE schemaname NOT IN ('pg_catalog', 'information_schema'))" \
+  "$databasename")"
+if [[ "$database_has_tables" == "t" && "$IMAGE" == "true" ]]; then
+  printf "Database '%s' already contains tables; skipping the blockchain image to avoid overwriting data.\n" \
+    "$databasename"
+  IMAGE=false
+fi
+
+# Run application setup as the dedicated node user. Values are passed through
+# env arguments so branch names and passwords are not evaluated as shell code.
+runuser -u "$username" -- env \
+  HOME="$NODE_HOME" \
+  NETWORK="$network" \
+  BRANCH="$branch" \
+  NODEJS_VERSION="$nodejs" \
+  NVM_INSTALL_VERSION="$NVM_VERSION" \
+  REPO_DIR="$REPO_DIR" \
+  CONFIG_FILE="$configfile" \
+  PROCESS_NAME="$processname" \
+  DATABASE_NAME="$databasename" \
+  DB_PASSWORD_BASE64="$DB_PASSWORD_BASE64" \
+  USE_IMAGE="$IMAGE" \
+  IMAGE_URL="$image_url" \
+  IMAGE_FILENAME="$image_filename" \
+  IMAGE_UNZIPPED_FILENAME="$image_unzipped_filename" \
+  bash <<'EOSU'
 set -Eeuo pipefail
+trap 'status=$?; printf "\n[ERROR] User setup failed at line %s.\n\n" "$LINENO" >&2; exit "$status"' ERR
 
-# NodeJS
-printf "\n\nInstalling nvm & Node.js…\n\n"
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
-export NVM_DIR="\$HOME/.nvm"
-source "\$NVM_DIR/nvm.sh"
-nvm i --lts=$nodejs
-npm i -g pm2
+printf "\nInstalling or updating nvm v%s and Node.js %s.\n" "$NVM_INSTALL_VERSION" "$NODEJS_VERSION"
+export NVM_DIR="$HOME/.nvm"
+curl -fsSL "https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_INSTALL_VERSION}/install.sh" | bash
+# shellcheck disable=SC1091
+source "$NVM_DIR/nvm.sh"
+nvm install "$NODEJS_VERSION" --latest-npm
+nvm alias default "$NODEJS_VERSION"
+nvm use "$NODEJS_VERSION"
+npm install --global pm2@latest
+pm2 update
+printf "Using Node.js %s, npm %s, and pm2 %s.\n" "$(node --version)" "$(npm --version)" "$(pm2 --version)"
 
-# pm2-logrotate
-printf "\n\n"
-pm2 install pm2-logrotate
+printf "\nConfiguring pm2 log rotation.\n"
+if pm2 describe pm2-logrotate >/dev/null 2>&1; then
+  pm2 module:update pm2-logrotate
+else
+  pm2 install pm2-logrotate
+fi
 pm2 set pm2-logrotate:max_size 500M
 pm2 set pm2-logrotate:retain 5
 pm2 set pm2-logrotate:compress true
 pm2 set pm2-logrotate:rotateInterval '0 0 0 1 *'
 
-# ADAMANT
-printf "\n\nInstalling ADAMANT '$network' node. Cloning the '$branch' branch from GitHub…\n\n"
-git clone --branch $branch https://github.com/Adamant-im/adamant
-cd adamant || { printf "\n\nCannot enter 'adamant' blockchain directory. Aborting.\n\n"; exit 1; }
-npm i
-
-# ADAMANT node configuration
-printf "\n\nSetting up the ADM node configuration…\n"
-if [[ "$configfile" == "config.json" ]]; then
-  cp config.default.json config.json
+if [[ ! -e "$REPO_DIR" ]]; then
+  printf "\nCloning ADAMANT branch '%s'.\n" "$BRANCH"
+  git clone --branch "$BRANCH" --single-branch https://github.com/Adamant-im/adamant "$REPO_DIR"
+elif [[ ! -d "$REPO_DIR/.git" ]]; then
+  printf "\nExisting path '%s' is not an ADAMANT Git checkout. Refusing to overwrite it.\n" "$REPO_DIR" >&2
+  exit 1
 else
-  cp test/config.default.json test/config.json
+  printf "\nExisting ADAMANT checkout found. Fetching branch '%s'.\n" "$BRANCH"
+  cd "$REPO_DIR"
+  git fetch --prune origin "$BRANCH"
+  if [[ -n "$(git status --porcelain)" ]]; then
+    printf "Local repository changes detected; preserving the current checkout without switching branches.\n"
+  else
+    if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+      git checkout "$BRANCH"
+    else
+      git checkout --track -b "$BRANCH" "origin/$BRANCH"
+    fi
+    if ! git merge --ff-only "origin/$BRANCH"; then
+      printf "WARNING: The local branch cannot be fast-forwarded; preserving its current history.\n"
+    fi
+  fi
 fi
 
-# Inject DB password into $configfile. Decode Base64 **inside** the child shell (parent never sees the raw password).
-# Using env.DB_PASSWORD_DECODED avoids any '$' in the jq filter, so the parent shell won't expand it.
-DB_PASSWORD_DECODED=\$(printf '%s' "$DB_PASSWORD_BASE64" | base64 -d)
+cd "$REPO_DIR"
+printf "\nInstalling Node.js dependencies.\n"
+npm install
+
+printf "\nConfiguring the ADAMANT node.\n"
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  if [[ "$CONFIG_FILE" == "config.json" ]]; then
+    cp config.default.json "$CONFIG_FILE"
+  else
+    cp test/config.default.json "$CONFIG_FILE"
+  fi
+else
+  printf "Configuration file '%s' already exists; preserving its settings.\n" "$CONFIG_FILE"
+fi
+
+DB_PASSWORD_DECODED="$(printf '%s' "$DB_PASSWORD_BASE64" | base64 --decode)"
 export DB_PASSWORD_DECODED
-jq '.db.password = env.DB_PASSWORD_DECODED' $configfile > "$configfile.tmp" && mv "$configfile.tmp" $configfile
+config_tmp="$(mktemp "${CONFIG_FILE}.tmp.XXXXXX")"
+jq '.db.password = env.DB_PASSWORD_DECODED' "$CONFIG_FILE" > "$config_tmp"
+chmod --reference="$CONFIG_FILE" "$config_tmp" 2>/dev/null || true
+mv "$config_tmp" "$CONFIG_FILE"
+unset DB_PASSWORD_DECODED DB_PASSWORD_BASE64
 
-# Download actual blockchain image for mainnet/testnet network, bootstrapping the ADM node
-if [[ "$IMAGE" == "true" ]]; then
-  printf "\n\nDownloading '$network' blockchain image…\n\n"
-  wget --progress=bar:force:noscroll "$image_url" -O "$image_filename" 2>/dev/tty
-  printf "\nUnzipping the blockchain image (may take a few minutes)…\n\n"
-  gunzip -f "$image_filename"
-  printf "\nLoading the image into '$databasename' database…\n\n"
-  psql "$databasename" < "$image_unzipped_filename"
-  printf "\nCleaning up temp image…\n"
-  rm -f "$image_unzipped_filename"
+if [[ "$USE_IMAGE" == "true" ]]; then
+  printf "\nDownloading the %s blockchain image.\n" "$NETWORK"
+  rm -f "${IMAGE_FILENAME}.part" "$IMAGE_FILENAME" "$IMAGE_UNZIPPED_FILENAME"
+  wget --progress=dot:giga "$IMAGE_URL" -O "${IMAGE_FILENAME}.part"
+  mv "${IMAGE_FILENAME}.part" "$IMAGE_FILENAME"
+  gzip --test "$IMAGE_FILENAME"
+  printf "Extracting and loading the blockchain image.\n"
+  gunzip "$IMAGE_FILENAME"
+  psql -Xv ON_ERROR_STOP=1 "$DATABASE_NAME" < "$IMAGE_UNZIPPED_FILENAME"
+  rm -f "$IMAGE_UNZIPPED_FILENAME"
 fi
 
-printf "\n\nRunning ADAMANT '$network' node…\n\n"
-if [[ "$network" == "mainnet" ]]; then
-  pm2 start --name adamant app.js
+printf "\nStarting the ADAMANT %s node.\n" "$NETWORK"
+if pm2 describe "$PROCESS_NAME" >/dev/null 2>&1; then
+  pm2 restart "$PROCESS_NAME" --update-env
+elif [[ "$NETWORK" == "mainnet" ]]; then
+  pm2 start --name "$PROCESS_NAME" app.js
 else
-  pm2 start --name adamanttest app.js -- --config test/config.json --genesis test/genesisBlock.json
+  pm2 start --name "$PROCESS_NAME" app.js -- \
+    --config test/config.json --genesis test/genesisBlock.json
 fi
-
 pm2 save
 EOSU
-# ------- End of run-as-user block -------
 
-printf "\n\nEnabling ADAMANT '%s' node auto-restart on system reboot…\n\n" "$network"
-adamant_startup_output=$(su - "$username" -c "source ~/.nvm/nvm.sh; pm2 startup" || true)
-adamant_startup=$(echo "$adamant_startup_output" | grep -oP 'sudo env PATH=.*' || true)
-bash -c "$adamant_startup"
+unset DB_PASSWORD_BASE64 DB_PASSWORD_SQL
 
-# Remove temporary needrestart override
-rm -f /etc/needrestart/conf.d/99-adamant-temp.conf
+# Configure boot startup directly when systemd is available.
+if command -v systemctl >/dev/null 2>&1 && [[ "$(ps -p 1 -o comm=)" == "systemd" ]]; then
+  # shellcheck disable=SC2016
+  NODE_BIN_DIR="$(runuser -u "$username" -- env HOME="$NODE_HOME" bash -c \
+    'source "$HOME/.nvm/nvm.sh" && dirname "$(command -v node)"')"
+  printf "\nEnabling pm2 startup for user '%s'.\n" "$username"
+  env PATH="${NODE_BIN_DIR}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+    "${NODE_BIN_DIR}/pm2" startup systemd -u "$username" --hp "$NODE_HOME"
+else
+  printf "\nWARNING: systemd was not detected. Configure pm2 startup manually for user '%s'.\n" "$username"
+fi
 
-# Done
 minutes=$(( (SECONDS + 59) / 60 ))
-printf "\n\nADAMANT '%s' node installation completed successfully.\n" "$network"
+printf "\nADAMANT %s node installation completed successfully.\n" "$network"
 printf "Total installation time: %d minutes.\n" "$minutes"
-printf "See installation logs in: %s\n\n" "$LOGFILE"
-
-printf "To check your node status:\n"
-printf "    su - %s    # Use pm2 while logged in as '%s'\n" "$username" "$username"
+printf "Installation log: %s\n\n" "$LOGFILE"
+printf "Check the node as user '%s':\n" "$username"
+printf "    su - %s\n" "$username"
 printf "    pm2 list\n"
 printf "    pm2 show %s\n" "$processname"
 printf "    pm2 logs %s\n\n" "$processname"
-printf "To query current blockchain height:\n    curl http://localhost:%s/api/blocks/getHeight\n\n" "$port"
-printf "Thank you for supporting the truly decentralized ADAMANT Messenger! 🚀\n\n"
+printf "Query the current blockchain height:\n"
+printf "    curl http://localhost:%s/api/blocks/getHeight\n\n" "$port"
 
 if [[ "$network" == "mainnet" ]]; then
-  printf "Tip: You can also install the ADAMANT testnet node on the same server using this script.\n"
-  printf "Mainnet and testnet run under different users, ports, and databases, so they do not conflict.\n"
-  printf "Example:\n    sudo bash -c \"\$(wget -O - https://adamant.im/install_node.sh)\" -O -b dev -n testnet -j jod\n\n"
+  printf "Mainnet and testnet use separate users, ports, databases, and pm2 processes.\n"
 fi
 
-read -n1 -r -p "Press any key to continue…"
-printf "\n\n"
-
-# Remind the user that a 'screen' session is currently running
-if [[ -n ${STY:-} ]]; then
-  printf "You are running inside a 'screen' session (%s). To finish cleanly,\n" "$STY"
-  printf "    Detach:    Press Ctrl-A D (screen keeps running in background)\n"
-  printf "    Exit:      Type 'exit' or press Ctrl-D (screen will terminate)\n\n\n"
+if [[ -n "${STY:-}" ]]; then
+  printf "\nThis command is running inside screen session '%s'.\n" "$STY"
+  printf "Detach with Ctrl-A D, or exit the shell to close the session.\n"
 fi

--- a/tools/install_node.sh
+++ b/tools/install_node.sh
@@ -3,12 +3,15 @@ set -Eeuo pipefail
 
 on_error() {
   local exit_status=$?
+  if [[ -n "${db_password_file:-}" ]]; then
+    rm -f -- "$db_password_file"
+  fi
   printf "\n[ERROR] Line %s failed. Installation stopped.\n\n" "${BASH_LINENO[0]}" >&2
   exit "$exit_status"
 }
 trap on_error ERR
 
-readonly INSTALLER_VERSION="2.4.7"
+readonly INSTALLER_VERSION="2.4.8"
 readonly NVM_VERSION="0.40.5"
 
 branch="master"
@@ -20,6 +23,7 @@ processname="adamant"
 port="36666"
 nodejs="24"
 image_url="https://explorer.adamant.im/db_backup.sql.gz"
+db_password_file=""
 
 usage() {
   printf "Usage: %s [-h] [-b branch] [-n mainnet|testnet] [-j 22|24|26]\n" "${0##*/}"
@@ -239,8 +243,6 @@ get_database_password() {
 
 DB_PASSWORD="$(get_database_password)"
 DB_PASSWORD_SQL=${DB_PASSWORD//\'/\'\'}
-DB_PASSWORD_BASE64="$(printf '%s' "$DB_PASSWORD" | base64 | tr -d '\n')"
-unset DB_PASSWORD
 
 printf "\nUpdating package indexes and installing package-management prerequisites.\n"
 export DEBIAN_FRONTEND=noninteractive
@@ -401,6 +403,11 @@ if [[ -z "$NODE_HOME" || ! -d "$NODE_HOME" ]]; then
 fi
 REPO_DIR="${NODE_HOME}/adamant"
 repair_node_user_permissions
+db_password_file="$(mktemp "${NODE_HOME}/.adamant-db-password.XXXXXX")"
+chmod 0600 "$db_password_file"
+printf '%s' "$DB_PASSWORD" > "$db_password_file"
+chown "$username:$username" "$db_password_file"
+unset DB_PASSWORD
 
 # Create or update the PostgreSQL role and database without masking SQL errors.
 role_exists="$(runuser -u postgres -- psql -XAtqc \
@@ -449,7 +456,7 @@ runuser -u "$username" -- env \
   CONFIG_FILE="$configfile" \
   PROCESS_NAME="$processname" \
   DATABASE_NAME="$databasename" \
-  DB_PASSWORD_BASE64="$DB_PASSWORD_BASE64" \
+  DB_PASSWORD_FILE="$db_password_file" \
   USE_IMAGE="$IMAGE" \
   IMAGE_URL="$image_url" \
   IMAGE_FILENAME="$image_filename" \
@@ -554,13 +561,13 @@ else
   printf "Configuration file '%s' already exists; preserving its settings.\n" "$CONFIG_FILE"
 fi
 
-DB_PASSWORD_DECODED="$(printf '%s' "$DB_PASSWORD_BASE64" | base64 --decode)"
+DB_PASSWORD_DECODED="$(cat "$DB_PASSWORD_FILE")"
 export DB_PASSWORD_DECODED
 config_tmp="$(mktemp "${CONFIG_FILE}.tmp.XXXXXX")"
 jq '.db.password = env.DB_PASSWORD_DECODED' "$CONFIG_FILE" > "$config_tmp"
 chmod 0600 "$config_tmp"
 mv "$config_tmp" "$CONFIG_FILE"
-unset DB_PASSWORD_DECODED DB_PASSWORD_BASE64
+unset DB_PASSWORD_DECODED
 
 if [[ "$USE_IMAGE" == "true" ]]; then
   printf "\nDownloading the %s blockchain image.\n" "$NETWORK"
@@ -585,7 +592,9 @@ fi
 pm2 save
 EOSU
 
-unset DB_PASSWORD_BASE64 DB_PASSWORD_SQL
+rm -f -- "$db_password_file"
+db_password_file=""
+unset DB_PASSWORD_SQL
 
 # Configure boot startup directly when systemd is available.
 if command -v systemctl >/dev/null 2>&1 && [[ "$(ps -p 1 -o comm=)" == "systemd" ]]; then

--- a/tools/install_node.sh
+++ b/tools/install_node.sh
@@ -8,7 +8,7 @@ on_error() {
 }
 trap on_error ERR
 
-readonly INSTALLER_VERSION="2.4.1"
+readonly INSTALLER_VERSION="2.4.3"
 readonly NVM_VERSION="0.40.5"
 
 branch="master"
@@ -52,6 +52,15 @@ read_secret_from_tty() {
   IFS= read -r -s response < /dev/tty
   printf "\n" > /dev/tty
   printf "%s" "$response"
+}
+
+detect_installed_postgresql_server_majors() {
+  dpkg-query -W -f='${db:Status-Status} ${Package}\n' 'postgresql-[0-9]*' 2>/dev/null \
+    | awk '$1 == "installed" && $2 ~ /^postgresql-[0-9]+$/ {
+        sub(/^postgresql-/, "", $2)
+        print $2
+      }' \
+    | sort -Vu
 }
 
 # Parse command-line options before creating the network-specific log file.
@@ -296,15 +305,13 @@ fi
 
 # Keep an existing PostgreSQL major version. On a fresh host, install the latest
 # stable server supplied by the configured repository.
-postgresql_major_packages="$(dpkg-query -W -f='${Package}\n' 'postgresql-[0-9]*' 2>/dev/null \
-  | sed -n 's/^postgresql-\([0-9][0-9]*\)$/\1/p' | sort -Vu || true)"
+postgresql_major_packages="$(detect_installed_postgresql_server_majors || true)"
 if [[ -n "$postgresql_major_packages" ]]; then
   printf "Existing PostgreSQL server installation detected; preserving its major version.\n"
 else
   printf "Installing PostgreSQL server package '%s'.\n" "$postgresql_package"
   apt-get "${APT_OPTIONS[@]}" install "$postgresql_package"
-  postgresql_major_packages="$(dpkg-query -W -f='${Package}\n' 'postgresql-[0-9]*' 2>/dev/null \
-    | sed -n 's/^postgresql-\([0-9][0-9]*\)$/\1/p' | sort -Vu || true)"
+  postgresql_major_packages="$(detect_installed_postgresql_server_majors || true)"
 fi
 
 postgresql_major="$(printf '%s\n' "$postgresql_major_packages" | tail -1)"

--- a/tools/install_node.sh
+++ b/tools/install_node.sh
@@ -123,7 +123,7 @@ exec > >(tee -a "$LOGFILE") 2>&1
 if [[ -s "$LOGFILE" ]]; then
   printf "\n\n\n===========================\n"
 fi
-printf "%s ADAMANT %s node installation started\n" \
+printf "\n%s ADAMANT %s node installation started\n" \
   "$(date -u '+%Y-%m-%d %H:%M UTC')" "$network"
 
 printf "\nWelcome to the ADAMANT Node Installer v%s for Ubuntu 20.04-26.04 LTS.\n" \
@@ -137,7 +137,7 @@ printf "Installation guide: https://docs.adamant.im/own-node/installation.html\n
 printf "Operating system:  %s\n" "$PRETTY_NAME"
 printf "Selected network:  %s\n" "$network"
 printf "Selected branch:   %s\n" "$branch"
-printf "Selected Node.js:  %s (24 is recommended for production)\n\n" "$nodejs"
+printf "Selected Node.js:  %s\n\n" "$nodejs"
 
 read -r -p "The script will upgrade packages, may restart services, and configure ADAMANT. Type \"yes\" to continue: " agreement
 if [[ "$agreement" != "yes" ]]; then

--- a/tools/install_node.sh
+++ b/tools/install_node.sh
@@ -8,7 +8,7 @@ on_error() {
 }
 trap on_error ERR
 
-readonly INSTALLER_VERSION="2.4.3"
+readonly INSTALLER_VERSION="2.4.4"
 readonly NVM_VERSION="0.40.5"
 
 branch="master"
@@ -61,6 +61,15 @@ detect_installed_postgresql_server_majors() {
         print $2
       }' \
     | sort -Vu
+}
+
+repair_node_user_permissions() {
+  for path in "$NODE_HOME/.nvm" "$NODE_HOME/.pm2" "$REPO_DIR"; do
+    if [[ -e "$path" ]]; then
+      chown -R "$username:$username" "$path"
+      chmod -R u+rwX "$path"
+    fi
+  done
 }
 
 # Parse command-line options before creating the network-specific log file.
@@ -389,6 +398,7 @@ if [[ -z "$NODE_HOME" || ! -d "$NODE_HOME" ]]; then
   exit 1
 fi
 REPO_DIR="${NODE_HOME}/adamant"
+repair_node_user_permissions
 
 # Create or update the PostgreSQL role and database without masking SQL errors.
 role_exists="$(runuser -u postgres -- psql -XAtqc \
@@ -446,14 +456,15 @@ runuser -u "$username" -- env \
 set -Eeuo pipefail
 trap 'status=$?; printf "\n[ERROR] User setup failed at line %s.\n\n" "$LINENO" >&2; exit "$status"' ERR
 
+cd "$HOME"
 printf "\nInstalling or updating nvm v%s and Node.js %s.\n" "$NVM_INSTALL_VERSION" "$NODEJS_VERSION"
 export NVM_DIR="$HOME/.nvm"
 if [[ -d "$NVM_DIR/.git" ]]; then
   git -C "$NVM_DIR" fetch --tags --depth 1 origin "v${NVM_INSTALL_VERSION}"
-  git -C "$NVM_DIR" checkout --quiet "v${NVM_INSTALL_VERSION}"
+  git -c advice.detachedHead=false -C "$NVM_DIR" checkout --quiet "v${NVM_INSTALL_VERSION}"
 else
   rm -rf "$NVM_DIR"
-  git clone --depth 1 --branch "v${NVM_INSTALL_VERSION}" https://github.com/nvm-sh/nvm.git "$NVM_DIR"
+  git -c advice.detachedHead=false clone --depth 1 --branch "v${NVM_INSTALL_VERSION}" https://github.com/nvm-sh/nvm.git "$NVM_DIR"
 fi
 nvm_profile="$HOME/.bashrc"
 if ! grep -q 'NVM_DIR="$HOME/.nvm"' "$nvm_profile" 2>/dev/null; then
@@ -559,7 +570,7 @@ unset DB_PASSWORD_BASE64 DB_PASSWORD_SQL
 if command -v systemctl >/dev/null 2>&1 && [[ "$(ps -p 1 -o comm=)" == "systemd" ]]; then
   # shellcheck disable=SC2016
   NODE_BIN_DIR="$(runuser -u "$username" -- env HOME="$NODE_HOME" bash -c \
-    'source "$HOME/.nvm/nvm.sh" && dirname "$(command -v node)"')"
+    'cd "$HOME" && source "$HOME/.nvm/nvm.sh" && dirname "$(command -v node)"')"
   printf "\nEnabling pm2 startup for user '%s'.\n" "$username"
   env PATH="${NODE_BIN_DIR}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
     "${NODE_BIN_DIR}/pm2" startup systemd -u "$username" --hp "$NODE_HOME"

--- a/tools/install_node.sh
+++ b/tools/install_node.sh
@@ -8,7 +8,7 @@ on_error() {
 }
 trap on_error ERR
 
-readonly INSTALLER_VERSION="2.4.0"
+readonly INSTALLER_VERSION="2.4.1"
 readonly NVM_VERSION="0.40.5"
 
 branch="master"
@@ -308,6 +308,7 @@ else
 fi
 
 postgresql_major="$(printf '%s\n' "$postgresql_major_packages" | tail -1)"
+postgresql_started=false
 if command -v pg_lsclusters >/dev/null 2>&1 && command -v pg_ctlcluster >/dev/null 2>&1; then
   if ! pg_lsclusters -h | awk 'NF { found = 1 } END { exit !found }'; then
     if [[ -z "$postgresql_major" ]]; then
@@ -322,10 +323,36 @@ if command -v pg_lsclusters >/dev/null 2>&1 && command -v pg_ctlcluster >/dev/nu
       pg_ctlcluster "$cluster_version" "$cluster_name" start
     fi
   done < <(pg_lsclusters -h)
-elif command -v systemctl >/dev/null 2>&1 && systemctl list-unit-files postgresql.service >/dev/null 2>&1; then
-  systemctl enable --now postgresql
+  postgresql_started=true
+elif command -v systemctl >/dev/null 2>&1 && [[ "$(ps -p 1 -o comm=)" == "systemd" ]]; then
+  postgresql_units="$(systemctl list-units --all --type=service 'postgresql*' --no-legend 2>/dev/null \
+    | awk '$1 ~ /^postgresql(@.+|-[0-9]+)?\.service$/ && $1 != "postgresql@.service" { print $1 }' || true)"
+  if [[ -z "$postgresql_units" ]]; then
+    postgresql_units="$(systemctl list-unit-files --type=service --no-legend 'postgresql*' 2>/dev/null \
+      | awk '$1 ~ /^postgresql(@.+|-[0-9]+)?\.service$/ && $1 != "postgresql@.service" { print $1 }' || true)"
+  fi
+
+  if [[ -n "$postgresql_units" ]]; then
+    while read -r postgresql_unit; do
+      [[ -n "$postgresql_unit" ]] || continue
+      systemctl enable --now "$postgresql_unit" || systemctl start "$postgresql_unit"
+    done <<< "$postgresql_units"
+    postgresql_started=true
+  elif systemctl list-unit-files postgresql.service >/dev/null 2>&1; then
+    systemctl enable --now postgresql
+    postgresql_started=true
+  fi
 else
-  service postgresql start
+  if [[ -x /etc/init.d/postgresql ]]; then
+    service postgresql start
+    postgresql_started=true
+  fi
+fi
+
+if [[ "$postgresql_started" != "true" ]]; then
+  printf "Cannot find a PostgreSQL cluster or service to start. Check installed PostgreSQL packages and cluster status.\n" >&2
+  printf "Useful diagnostics: dpkg -l 'postgresql-*'; pg_lsclusters; systemctl list-units --all 'postgresql*'\n" >&2
+  exit 1
 fi
 for _ in {1..30}; do
   if runuser -u postgres -- pg_isready -q; then

--- a/tools/install_node.sh
+++ b/tools/install_node.sh
@@ -8,7 +8,7 @@ on_error() {
 }
 trap on_error ERR
 
-readonly INSTALLER_VERSION="2.4.4"
+readonly INSTALLER_VERSION="2.4.5"
 readonly NVM_VERSION="0.40.5"
 
 branch="master"
@@ -456,15 +456,35 @@ runuser -u "$username" -- env \
 set -Eeuo pipefail
 trap 'status=$?; printf "\n[ERROR] User setup failed at line %s.\n\n" "$LINENO" >&2; exit "$status"' ERR
 
+run_quiet() {
+  local description="$1"
+  local log_file
+
+  shift
+  log_file="$(mktemp)"
+  printf "%s\n" "$description"
+  if "$@" > "$log_file" 2>&1; then
+    rm -f "$log_file"
+    return 0
+  fi
+  cat "$log_file" >&2
+  rm -f "$log_file"
+  return 1
+}
+
 cd "$HOME"
 printf "\nInstalling or updating nvm v%s and Node.js %s.\n" "$NVM_INSTALL_VERSION" "$NODEJS_VERSION"
 export NVM_DIR="$HOME/.nvm"
 if [[ -d "$NVM_DIR/.git" ]]; then
-  git -C "$NVM_DIR" fetch --tags --depth 1 origin "v${NVM_INSTALL_VERSION}"
+  run_quiet "Updating nvm source." \
+    git -C "$NVM_DIR" fetch --quiet --depth 1 origin \
+      "refs/tags/v${NVM_INSTALL_VERSION}:refs/tags/v${NVM_INSTALL_VERSION}"
   git -c advice.detachedHead=false -C "$NVM_DIR" checkout --quiet "v${NVM_INSTALL_VERSION}"
 else
   rm -rf "$NVM_DIR"
-  git -c advice.detachedHead=false clone --depth 1 --branch "v${NVM_INSTALL_VERSION}" https://github.com/nvm-sh/nvm.git "$NVM_DIR"
+  run_quiet "Cloning nvm source." \
+    git -c advice.detachedHead=false clone --quiet --depth 1 --branch "v${NVM_INSTALL_VERSION}" \
+      https://github.com/nvm-sh/nvm.git "$NVM_DIR"
 fi
 nvm_profile="$HOME/.bashrc"
 if ! grep -q 'NVM_DIR="$HOME/.nvm"' "$nvm_profile" 2>/dev/null; then
@@ -478,20 +498,21 @@ source "$NVM_DIR/nvm.sh"
 nvm install "$NODEJS_VERSION" --latest-npm
 nvm alias default "$NODEJS_VERSION"
 nvm use "$NODEJS_VERSION"
-npm install --global pm2@latest
-pm2 update
+run_quiet "Installing or updating pm2." npm install --global pm2@latest
+run_quiet "Refreshing the pm2 daemon." pm2 update
 printf "Using Node.js %s, npm %s, and pm2 %s.\n" "$(node --version)" "$(npm --version)" "$(pm2 --version)"
 
 printf "\nConfiguring pm2 log rotation.\n"
 if pm2 describe pm2-logrotate >/dev/null 2>&1; then
-  pm2 module:update pm2-logrotate
+  run_quiet "Updating pm2-logrotate module." pm2 module:update pm2-logrotate
 else
-  pm2 install pm2-logrotate
+  run_quiet "Installing pm2-logrotate module." pm2 install pm2-logrotate
 fi
-pm2 set pm2-logrotate:max_size 500M
-pm2 set pm2-logrotate:retain 5
-pm2 set pm2-logrotate:compress true
-pm2 set pm2-logrotate:rotateInterval '0 0 0 1 *'
+run_quiet "Setting pm2-logrotate:max_size=500M." pm2 set pm2-logrotate:max_size 500M
+run_quiet "Setting pm2-logrotate:retain=5." pm2 set pm2-logrotate:retain 5
+run_quiet "Setting pm2-logrotate:compress=true." pm2 set pm2-logrotate:compress true
+run_quiet "Setting pm2-logrotate:rotateInterval='0 0 0 1 *'." \
+  pm2 set pm2-logrotate:rotateInterval '0 0 0 1 *'
 
 if [[ ! -e "$REPO_DIR" ]]; then
   printf "\nCloning ADAMANT branch '%s'.\n" "$BRANCH"

--- a/tools/install_node.sh
+++ b/tools/install_node.sh
@@ -26,6 +26,34 @@ usage() {
   printf "       Node.js aliases: jod=22, krypton=24. Version 24 is the default.\n"
 }
 
+require_interactive_tty() {
+  if [[ ! -r /dev/tty || ! -w /dev/tty ]]; then
+    printf "\nThis installer requires an interactive terminal for confirmations and passwords.\n" >&2
+    printf "Run it from a normal shell session, for example:\n" >&2
+    printf "    curl -fsSL https://adamant.im/install_node.sh | sudo bash -s -- -n mainnet\n\n" >&2
+    exit 1
+  fi
+}
+
+read_from_tty() {
+  local prompt_text="$1"
+  local response
+
+  printf "%s" "$prompt_text" > /dev/tty
+  IFS= read -r response < /dev/tty
+  printf "%s" "$response"
+}
+
+read_secret_from_tty() {
+  local prompt_text="$1"
+  local response
+
+  printf "%s" "$prompt_text" > /dev/tty
+  IFS= read -r -s response < /dev/tty
+  printf "\n" > /dev/tty
+  printf "%s" "$response"
+}
+
 # Parse command-line options before creating the network-specific log file.
 while getopts ":b:n:j:h" OPTION; do
   case "$OPTION" in
@@ -139,7 +167,8 @@ printf "Selected network:  %s\n" "$network"
 printf "Selected branch:   %s\n" "$branch"
 printf "Selected Node.js:  %s\n\n" "$nodejs"
 
-read -r -p "The script will upgrade packages, may restart services, and configure ADAMANT. Type \"yes\" to continue: " agreement
+require_interactive_tty
+agreement="$(read_from_tty "The script will upgrade packages, may restart services, and configure ADAMANT. Type \"yes\" to continue: ")"
 if [[ "$agreement" != "yes" ]]; then
   printf "\nInstallation cancelled.\n\n"
   exit 1
@@ -149,7 +178,7 @@ fi
 IMAGE=false
 printf "\nA blockchain image can reduce synchronization time, but its source must be trusted.\n"
 printf "Without an image, the node verifies the blockchain from height 1, which may take several days.\n"
-read -r -p "Use the official ADAMANT blockchain image to bootstrap? [Y/n]: " useimage
+useimage="$(read_from_tty "Use the official ADAMANT blockchain image to bootstrap? [Y/n]: ")"
 case "${useimage:-Y}" in
   [yY][eE][sS]|[yY]|[jJ]|'') IMAGE=true ;;
   *) printf "The node will synchronize from scratch.\n" ;;
@@ -177,11 +206,8 @@ get_database_password() {
   local password confirmation
 
   while true; do
-    printf '\nSet the PostgreSQL password for role %s:\n> ' "$username" >&2
-    read -r -s password
-    printf '\nConfirm the password:\n> ' >&2
-    read -r -s confirmation
-    printf '\n' >&2
+    password="$(read_secret_from_tty "$(printf '\nSet the PostgreSQL database password for role %s.\nThis is not the Linux user login password.\n> ' "$username")")"
+    confirmation="$(read_secret_from_tty "$(printf 'Confirm the PostgreSQL database password:\n> ')")"
 
     if [[ -z "$password" ]]; then
       printf 'The database password cannot be empty. Try again.\n' >&2
@@ -270,15 +296,33 @@ fi
 
 # Keep an existing PostgreSQL major version. On a fresh host, install the latest
 # stable server supplied by the configured repository.
-if dpkg-query -W -f='${Package}\n' 'postgresql-[0-9]*' 2>/dev/null \
-  | grep -Eq '^postgresql-[0-9]+$'; then
+postgresql_major_packages="$(dpkg-query -W -f='${Package}\n' 'postgresql-[0-9]*' 2>/dev/null \
+  | sed -n 's/^postgresql-\([0-9][0-9]*\)$/\1/p' | sort -Vu || true)"
+if [[ -n "$postgresql_major_packages" ]]; then
   printf "Existing PostgreSQL server installation detected; preserving its major version.\n"
 else
   printf "Installing PostgreSQL server package '%s'.\n" "$postgresql_package"
   apt-get "${APT_OPTIONS[@]}" install "$postgresql_package"
+  postgresql_major_packages="$(dpkg-query -W -f='${Package}\n' 'postgresql-[0-9]*' 2>/dev/null \
+    | sed -n 's/^postgresql-\([0-9][0-9]*\)$/\1/p' | sort -Vu || true)"
 fi
 
-if command -v systemctl >/dev/null 2>&1 && systemctl list-unit-files postgresql.service >/dev/null 2>&1; then
+postgresql_major="$(printf '%s\n' "$postgresql_major_packages" | tail -1)"
+if command -v pg_lsclusters >/dev/null 2>&1 && command -v pg_ctlcluster >/dev/null 2>&1; then
+  if ! pg_lsclusters -h | awk 'NF { found = 1 } END { exit !found }'; then
+    if [[ -z "$postgresql_major" ]]; then
+      printf "Cannot determine installed PostgreSQL major version for cluster creation.\n" >&2
+      exit 1
+    fi
+    pg_createcluster "$postgresql_major" main --start
+  fi
+
+  while read -r cluster_version cluster_name _ cluster_status _; do
+    if [[ -n "$cluster_version" && -n "$cluster_name" && "$cluster_status" != "online" ]]; then
+      pg_ctlcluster "$cluster_version" "$cluster_name" start
+    fi
+  done < <(pg_lsclusters -h)
+elif command -v systemctl >/dev/null 2>&1 && systemctl list-unit-files postgresql.service >/dev/null 2>&1; then
   systemctl enable --now postgresql
 else
   service postgresql start

--- a/tools/install_node.sh
+++ b/tools/install_node.sh
@@ -600,7 +600,7 @@ else
 fi
 
 minutes=$(( (SECONDS + 59) / 60 ))
-printf "\nADAMANT %s node installation completed successfully.\n" "$network"
+printf "\n\nADAMANT %s node installation completed successfully.\n" "$network"
 printf "Total installation time: %d minutes.\n" "$minutes"
 printf "Installation log: %s\n\n" "$LOGFILE"
 printf "Check the node as user '%s':\n" "$username"
@@ -612,10 +612,10 @@ printf "Query the current blockchain height:\n"
 printf "    curl http://localhost:%s/api/blocks/getHeight\n\n" "$port"
 
 if [[ "$network" == "mainnet" ]]; then
-  printf "Mainnet and testnet use separate users, ports, databases, and pm2 processes.\n"
+  printf "Mainnet and testnet use separate users, ports, databases, and pm2 processes.\n\n"
 fi
 
 if [[ -n "${STY:-}" ]]; then
   printf "\nThis command is running inside screen session '%s'.\n" "$STY"
-  printf "Detach with Ctrl-A D, or exit the shell to close the session.\n"
+  printf "Detach with Ctrl-A D, or exit the shell to close the session.\n\n"
 fi

--- a/tools/install_node.sh
+++ b/tools/install_node.sh
@@ -8,7 +8,7 @@ on_error() {
 }
 trap on_error ERR
 
-readonly INSTALLER_VERSION="2.4.5"
+readonly INSTALLER_VERSION="2.4.7"
 readonly NVM_VERSION="0.40.5"
 
 branch="master"
@@ -161,7 +161,6 @@ case "${VERSION_ID:-}" in
 esac
 
 image_filename="$(basename "$image_url")"
-image_unzipped_filename="${image_filename%.gz}"
 LOGFILE="/var/log/adamant_${network}_install.log"
 
 # Send all output to both the terminal and a persistent log file.
@@ -246,6 +245,9 @@ unset DB_PASSWORD
 printf "\nUpdating package indexes and installing package-management prerequisites.\n"
 export DEBIAN_FRONTEND=noninteractive
 export NEEDRESTART_MODE=a
+# Skip needrestart hooks during installer-managed apt runs. Some VPS images ship
+# a broken needrestart.conf, which can print scary Perl parse errors after dpkg.
+export NEEDRESTART_SUSPEND=1
 APT_OPTIONS=(-y -o Dpkg::Options::=--force-confold)
 apt-get update
 apt-get "${APT_OPTIONS[@]}" install ca-certificates curl gnupg
@@ -451,7 +453,6 @@ runuser -u "$username" -- env \
   USE_IMAGE="$IMAGE" \
   IMAGE_URL="$image_url" \
   IMAGE_FILENAME="$image_filename" \
-  IMAGE_UNZIPPED_FILENAME="$image_unzipped_filename" \
   bash <<'EOSU'
 set -Eeuo pipefail
 trap 'status=$?; printf "\n[ERROR] User setup failed at line %s.\n\n" "$LINENO" >&2; exit "$status"' ERR
@@ -563,14 +564,13 @@ unset DB_PASSWORD_DECODED DB_PASSWORD_BASE64
 
 if [[ "$USE_IMAGE" == "true" ]]; then
   printf "\nDownloading the %s blockchain image.\n" "$NETWORK"
-  rm -f "${IMAGE_FILENAME}.part" "$IMAGE_FILENAME" "$IMAGE_UNZIPPED_FILENAME"
+  rm -f "${IMAGE_FILENAME}.part" "$IMAGE_FILENAME"
   wget --progress=dot:giga "$IMAGE_URL" -O "${IMAGE_FILENAME}.part"
   mv "${IMAGE_FILENAME}.part" "$IMAGE_FILENAME"
   gzip --test "$IMAGE_FILENAME"
-  printf "Extracting and loading the blockchain image.\n"
-  gunzip "$IMAGE_FILENAME"
-  psql -X --set=ON_ERROR_STOP=1 "$DATABASE_NAME" < "$IMAGE_UNZIPPED_FILENAME"
-  rm -f "$IMAGE_UNZIPPED_FILENAME"
+  printf "Streaming the blockchain image into PostgreSQL.\n"
+  gzip -dc "$IMAGE_FILENAME" | psql -X --set=ON_ERROR_STOP=1 "$DATABASE_NAME"
+  rm -f "$IMAGE_FILENAME"
 fi
 
 printf "\nStarting the ADAMANT %s node.\n" "$NETWORK"

--- a/tools/install_node_centos.sh
+++ b/tools/install_node_centos.sh
@@ -1,4 +1,16 @@
 #!/usr/bin/env bash
+set -Eeuo pipefail
+
+on_error() {
+  local exit_status=$?
+  printf "\n[ERROR] Line %s failed. Installation stopped.\n\n" "${BASH_LINENO[0]}" >&2
+  exit "$exit_status"
+}
+trap on_error ERR
+
+readonly INSTALLER_VERSION="2.4.0"
+readonly NVM_VERSION="0.40.5"
+readonly POSTGRESQL_VERSION="18"
 
 branch="master"
 network="mainnet"
@@ -7,216 +19,440 @@ databasename="adamant_main"
 configfile="config.json"
 processname="adamant"
 port="36666"
-nodejs="jod"
+nodejs="24"
+image_url="https://explorer.adamant.im/db_backup.sql.gz"
 
-while getopts 'b:n:j:' OPTION; do
-  OPTARG=$(echo "$OPTARG" | xargs)
+usage() {
+  printf "Usage: %s [-b branch] [-n mainnet|testnet] [-j 22|24|26]\n" "${0##*/}"
+}
+
+while getopts ":b:n:j:h" OPTION; do
   case "$OPTION" in
     b)
       branch="$OPTARG"
       ;;
     n)
-      if [ "$OPTARG" == "testnet" ]
-      then
-        network="$OPTARG"
-        username="adamanttest"
-        databasename="adamant_test"
-        configfile="test/config.json"
-        processname="adamanttest"
-        port="36667"
-      elif [ "$OPTARG" != "mainnet" ]
-      then
-        printf "\nNetwork should be 'mainnet' or 'testnet'.\n\n"
-        exit 1
-      fi
+      case "$OPTARG" in
+        testnet)
+          network="testnet"
+          username="adamanttest"
+          databasename="adamant_test"
+          configfile="test/config.json"
+          processname="adamanttest"
+          port="36667"
+          image_url="https://testnet.adamant.im/db_test_backup.sql.gz"
+          ;;
+        mainnet) : ;;
+        *)
+          printf "\nNetwork must be 'mainnet' or 'testnet'.\n\n" >&2
+          usage
+          trap - ERR
+          exit 2
+          ;;
+      esac
       ;;
     j)
-      if [ "$OPTARG" == "20" ] || [ "$OPTARG" == "iron" ]
-      then
-        nodejs="iron"
-      elif [ "$OPTARG" != "22" ] && [ "$OPTARG" != "jod" ]
-      then
-        printf "\nNodejs should be 'iron' = '20', or 'jod' = '22'.\n\n"
-        exit 1
-      fi
+      case "$OPTARG" in
+        22|jod) nodejs="22" ;;
+        24|krypton) nodejs="24" ;;
+        26) nodejs="26" ;;
+        *)
+          printf "\nNode.js must be version 22, 24, or 26. Version 24 is the default.\n\n" >&2
+          trap - ERR
+          exit 2
+          ;;
+      esac
       ;;
-    *)
-      printf "\nWrong parameters. Use '-b' for branch, '-t' for network.\n\n"
-      exit 1
-    ;;
+    h)
+      usage
+      exit 0
+      ;;
+    :)
+      printf "\nOption '-%s' requires an argument.\n\n" "$OPTARG" >&2
+      usage
+      trap - ERR
+      exit 2
+      ;;
+    \?)
+      printf "\nUnknown option: '-%s'.\n\n" "$OPTARG" >&2
+      usage
+      trap - ERR
+      exit 2
+      ;;
   esac
 done
 
-printf "\n"
-printf "Welcome to the ADAMANT Node Installer v2.2.0 for CentOS 8.\n"
-printf "Please ensure you obtained this file from the adamant.im website or GitHub.\n"
-printf "This installer is the easiest way to run an ADAMANT node. However, we still recommend consulting an IT specialist if you are not familiar with Linux systems.\n"
-printf "You can find full installation instructions (for Ubuntu) at:\nhttps://news.adamant.im/how-to-run-your-adamant-node-on-ubuntu-990e391e8fcc\n"
-printf "During installation, you will be asked to set database and user passwords.\n"
-printf "The system may also prompt you to choose parameters such as encoding, keyboard layout, and GRUB settings. You can generally leave the defaults.\n\n"
+if [[ "$(id -u)" -ne 0 ]]; then
+  printf "\nRun this installer as root, for example: sudo bash %s\n\n" "${0##*/}" >&2
+  trap - ERR
+  exit 1
+fi
 
-printf "Note: You have selected the '%s' network.\n" "$network"
-printf "Note: You have selected the '%s' branch.\n" "$branch"
-printf "Note: You have selected Node.js version '%s'.\n" "$nodejs"
-printf "\n"
+if [[ ! -r /etc/os-release ]]; then
+  printf "\nCannot identify the operating system: /etc/os-release is missing.\n\n" >&2
+  trap - ERR
+  exit 1
+fi
 
-read -r -p "WARNING! This script is intended for new droplets. Existing data MAY BE DAMAGED. If you agree to continue, type \"yes\": " agreement
-if [[ $agreement != "yes" ]]
-then
+# shellcheck disable=SC1091
+. /etc/os-release
+el_major="$(rpm -E '%{rhel}' 2>/dev/null || true)"
+if [[ ! "$el_major" =~ ^(8|9|10)$ ]]; then
+  el_major="${VERSION_ID%%.*}"
+fi
+if [[ ! "$el_major" =~ ^(8|9|10)$ ]]; then
+  printf "\nUnsupported operating system '%s'. This installer supports RHEL-compatible releases 8-10.\n\n" \
+    "${PRETTY_NAME:-unknown OS}" >&2
+  trap - ERR
+  exit 1
+fi
+
+case "${ID:-} ${ID_LIKE:-}" in
+  *rhel*|*centos*|*rocky*|*almalinux*|*ol*) ;;
+  *)
+    printf "\nUnsupported operating system family: %s.\n\n" "${PRETTY_NAME:-unknown OS}" >&2
+    trap - ERR
+    exit 1
+    ;;
+esac
+
+case "$(uname -m)" in
+  x86_64) pgdg_arch="x86_64" ;;
+  aarch64|arm64) pgdg_arch="aarch64" ;;
+  *)
+    printf "\nUnsupported architecture '%s'. Supported architectures: x86_64 and aarch64.\n\n" \
+      "$(uname -m)" >&2
+    trap - ERR
+    exit 1
+    ;;
+esac
+
+image_filename="$(basename "$image_url")"
+image_unzipped_filename="${image_filename%.gz}"
+LOGFILE="/var/log/adamant_${network}_install.log"
+
+exec > >(tee -a "$LOGFILE") 2>&1
+if [[ -s "$LOGFILE" ]]; then
+  printf "\n\n\n===========================\n"
+fi
+printf "%s ADAMANT %s node installation started\n" \
+  "$(date -u '+%Y-%m-%d %H:%M UTC')" "$network"
+
+printf "\nWelcome to the ADAMANT Node Installer v%s for RHEL-compatible releases 8-10.\n" \
+  "$INSTALLER_VERSION"
+printf "Supported distributions include CentOS Stream, Rocky Linux, AlmaLinux, and RHEL.\n"
+printf "The installer updates system packages and preserves existing ADAMANT configuration and local Git changes.\n"
+printf "Review backups and custom service configuration before continuing on an existing server.\n\n"
+printf "Installation guide: https://docs.adamant.im/own-node/installation.html\n\n"
+
+printf "Operating system:  %s\n" "$PRETTY_NAME"
+printf "Selected network:  %s\n" "$network"
+printf "Selected branch:   %s\n" "$branch"
+printf "Selected Node.js:  %s (24 is recommended for production)\n\n" "$nodejs"
+
+read -r -p "The script will update packages and configure ADAMANT services. Type \"yes\" to continue: " agreement
+if [[ "$agreement" != "yes" ]]; then
   printf "\nInstallation cancelled.\n\n"
   exit 1
 fi
 
 IMAGE=false
-if [[ $network == "mainnet" ]]
-then
-  printf "\nUsing a blockchain image can significantly reduce sync time, but you must fully trust its source.\n"
-  printf "If you skip this step, your node will verify every single transaction, which can take several days.\n"
-  read -r -p "Do you want to use the ADAMANT blockchain image to bootstrap the node? [Y/n]: " useimage
-  case $useimage in
-    [yY][eE][sS]|[yY]|[jJ]|'')
-      IMAGE=true
-      printf "\nThe blockchain image will be downloaded, and your node will reach the current height in a few minutes.\n\n"
-    ;;
-    *)
-      printf "\nYour node will sync from scratch. This process may take several days to reach the current blockchain height.\n\n"
-    ;;
-  esac
-fi
+printf "\nA blockchain image can reduce synchronization time, but its source must be trusted.\n"
+printf "Without an image, the node verifies the blockchain from height 1, which may take several days.\n"
+read -r -p "Use the official ADAMANT blockchain image to bootstrap? [Y/n]: " useimage
+case "${useimage:-Y}" in
+  [yY][eE][sS]|[yY]|[jJ]|'') IMAGE=true ;;
+  *) printf "The node will synchronize from scratch.\n" ;;
+esac
 
-hostname=$(cat "/etc/hostname")
-if grep -q "$hostname" "/etc/hosts"
-then
-  printf "Hostname /etc/hosts seems to be good.\n\n"
+hostname_value="$(hostname)"
+if ! awk -v hostname="$hostname_value" '
+  $1 !~ /^#/ {
+    for (field = 2; field <= NF; field++) {
+      if ($field == hostname) {
+        found = 1
+      }
+    }
+  }
+  END { exit !found }
+' /etc/hosts; then
+  printf "\nAdding hostname '%s' to /etc/hosts.\n" "$hostname_value"
+  printf '\n127.0.1.1\t%s\n' "$hostname_value" >> /etc/hosts
 else
-  printf "File /etc/hosts has no hostname record. I'll fix it.\n\n"
-  sh -c -e "echo '\n127.0.1.1  $hostname' >> /etc/hosts";
+  printf "\nThe /etc/hosts hostname entry is already present.\n"
 fi
 
-get_database_password () {
-  read -r -sp "Set the database password: $(echo $'\n> ')" postgrespwd
-  read -r -sp "$(echo $'\n')Confirm password: $(echo $'\n> ')" postgrespwdconfirmation
-  if [[ $postgrespwd = "$postgrespwdconfirmation" ]]
-  then
-    echo "$postgrespwd"
-  else
-    printf "\nPassword mismatch. Try again.\n\n"
-    get_database_password
-  fi
+get_database_password() {
+  local password confirmation
+
+  while true; do
+    printf '\nSet the PostgreSQL password for role %s:\n> ' "$username" >&2
+    read -r -s password
+    printf '\nConfirm the password:\n> ' >&2
+    read -r -s confirmation
+    printf '\n' >&2
+
+    if [[ -z "$password" ]]; then
+      printf 'The database password cannot be empty. Try again.\n' >&2
+    elif [[ "$password" != "$confirmation" ]]; then
+      printf 'The passwords do not match. Try again.\n' >&2
+    else
+      printf '%s' "$password"
+      return
+    fi
+  done
 }
 
 DB_PASSWORD="$(get_database_password)"
+DB_PASSWORD_SQL=${DB_PASSWORD//\'/\'\'}
+DB_PASSWORD_BASE64="$(printf '%s' "$DB_PASSWORD" | base64 | tr -d '\n')"
+unset DB_PASSWORD
 
-#User
-printf "\n\nChecking if user '%s' exists…\n\n" "$username"
-if [[ $(id -u "$username" > /dev/null 2>&1; echo $?) = 1 ]]
-then
-  printf "Creating system user named '%s'…\n" "$username"
-  sudo adduser "$username"
-  sudo passwd "$username"
-  printf "User '%s' has been created.\n\n" "$username"
+printf "\nInstalling package-management and build prerequisites.\n"
+dnf -y install \
+  ca-certificates curl git gzip jq tar wget \
+  gcc gcc-c++ make automake autoconf libtool pkgconf-pkg-config python3
+
+# Use the official PGDG repository on fresh installations. Installing the
+# repository is harmless on reruns and keeps installed PostgreSQL packages
+# eligible for security updates.
+pgdg_rpm="https://download.postgresql.org/pub/repos/yum/reporpms/EL-${el_major}-${pgdg_arch}/pgdg-redhat-repo-latest.noarch.rpm"
+dnf -y install "$pgdg_rpm"
+
+printf "\nUpdating installed system packages.\n"
+dnf -y upgrade --refresh
+
+printf "\nInstalling Redis and PostgreSQL client development files.\n"
+dnf -y install redis libpq-devel
+
+if ! git check-ref-format --branch "$branch" >/dev/null 2>&1; then
+  printf "Invalid Git branch name: '%s'.\n" "$branch" >&2
+  exit 2
 fi
 
-#Packages
-printf "Updating system packages…\n\n"
+postgresql_service=""
+if rpm -qa | grep -Eq '^postgresql([0-9]+)?-server-'; then
+  printf "Existing PostgreSQL server installation detected; preserving its major version.\n"
+  while IFS= read -r service_name; do
+    if systemctl is-active --quiet "$service_name"; then
+      postgresql_service="$service_name"
+      break
+    fi
+    if [[ -z "$postgresql_service" ]]; then
+      postgresql_service="$service_name"
+    fi
+  done < <(systemctl list-unit-files --type=service --no-legend \
+    | awk '$1 ~ /^postgresql(-[0-9]+)?\.service$/ { sub(/\.service$/, "", $1); print $1 }')
+else
+  printf "Installing PostgreSQL %s from the official PGDG repository.\n" "$POSTGRESQL_VERSION"
+  dnf -qy module disable postgresql || true
+  dnf -y install \
+    "postgresql${POSTGRESQL_VERSION}" \
+    "postgresql${POSTGRESQL_VERSION}-server" \
+    "postgresql${POSTGRESQL_VERSION}-contrib"
+  postgresql_service="postgresql-${POSTGRESQL_VERSION}"
+  if [[ ! -s "/var/lib/pgsql/${POSTGRESQL_VERSION}/data/PG_VERSION" ]]; then
+    "/usr/pgsql-${POSTGRESQL_VERSION}/bin/postgresql-${POSTGRESQL_VERSION}-setup" initdb
+  fi
+fi
 
-sudo dnf config-manager --set-enabled powertools
-sudo dnf -y install epel-release
-sudo dnf -y update
+if [[ -z "$postgresql_service" ]]; then
+  printf "Cannot determine the installed PostgreSQL systemd service.\n" >&2
+  exit 1
+fi
+systemctl enable --now "$postgresql_service"
+systemctl enable --now redis
 
-printf "\n\nInstalling postgresql and other prerequisites…\n\n"
+if id -u "$username" >/dev/null 2>&1; then
+  printf "\nSystem user '%s' already exists; preserving it.\n" "$username"
+else
+  printf "\nCreating system user '%s'.\n" "$username"
+  useradd --create-home --shell /bin/bash "$username"
+fi
 
-sudo dnf -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-sudo dnf -qy module disable postgresql
-sudo dnf -y install postgresql13 postgresql13-server postgresql13-contrib
-sudo /usr/pgsql-13/bin/postgresql-13-setup initdb
-sudo systemctl enable --now postgresql-13
-sudo dnf group install "Development Tools" -y
-sudo dnf -y install wget python2 curl mc git nano automake autoconf libtool jq rpl wget libpq5-devel redis
-sudo systemctl enable --now redis
+NODE_HOME="$(getent passwd "$username" | cut -d: -f6)"
+if [[ -z "$NODE_HOME" || ! -d "$NODE_HOME" ]]; then
+  printf "Cannot determine a valid home directory for user '%s'.\n" "$username" >&2
+  exit 1
+fi
+REPO_DIR="${NODE_HOME}/adamant"
 
-#Postgres
-printf "\n\nCreating database '%s' and database user '%s'…\n\n" "$databasename" "$username"
-cd /tmp || echo "/tmp: No such directory"
-sudo -u postgres psql -c "CREATE ROLE ${username} LOGIN PASSWORD '${DB_PASSWORD}';"
-sudo -u postgres psql -c "CREATE DATABASE ${databasename};"
-sudo -u postgres psql -c "ALTER DATABASE ${databasename} OWNER TO ${username};"
+PSQL_BIN="$(command -v psql || true)"
+if [[ -z "$PSQL_BIN" && -x "/usr/pgsql-${POSTGRESQL_VERSION}/bin/psql" ]]; then
+  PSQL_BIN="/usr/pgsql-${POSTGRESQL_VERSION}/bin/psql"
+fi
+if [[ -z "$PSQL_BIN" ]]; then
+  PSQL_BIN="$(find /usr/pgsql-* -maxdepth 2 -type f -name psql 2>/dev/null | sort -V | tail -1)"
+fi
+if [[ -z "$PSQL_BIN" ]]; then
+  printf "Cannot locate the PostgreSQL client.\n" >&2
+  exit 1
+fi
+PG_BIN_DIR="$(dirname "$PSQL_BIN")"
 
-#Run next commands as user
-su - "$username" <<EOSU
+role_exists="$(runuser -u postgres -- "$PSQL_BIN" -XAtqc \
+  "SELECT 1 FROM pg_roles WHERE rolname = '${username}'" postgres)"
+if [[ "$role_exists" == "1" ]]; then
+  printf "\nUpdating the password for existing PostgreSQL role '%s'.\n" "$username"
+  runuser -u postgres -- "$PSQL_BIN" -Xv ON_ERROR_STOP=1 -c \
+    "ALTER ROLE ${username} WITH LOGIN PASSWORD '${DB_PASSWORD_SQL}';" postgres
+else
+  printf "\nCreating PostgreSQL role '%s'.\n" "$username"
+  runuser -u postgres -- "$PSQL_BIN" -Xv ON_ERROR_STOP=1 -c \
+    "CREATE ROLE ${username} WITH LOGIN PASSWORD '${DB_PASSWORD_SQL}';" postgres
+fi
 
-#NodeJS
-printf "\n\nInstalling nvm & node.js…\n\n"
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
-source ~/.nvm/nvm.sh
-source ~/.profile
-source ~/.bashrc
-nvm i --lts=$nodejs
-npm i -g pm2
+database_exists="$(runuser -u postgres -- "$PSQL_BIN" -XAtqc \
+  "SELECT 1 FROM pg_database WHERE datname = '${databasename}'" postgres)"
+if [[ "$database_exists" == "1" ]]; then
+  printf "Database '%s' already exists; preserving its contents.\n" "$databasename"
+else
+  printf "Creating database '%s'.\n" "$databasename"
+  runuser -u postgres -- "$PG_BIN_DIR/createdb" -O "$username" "$databasename"
+fi
+runuser -u postgres -- "$PSQL_BIN" -Xv ON_ERROR_STOP=1 -c \
+  "ALTER DATABASE ${databasename} OWNER TO ${username};" postgres
 
-#Logrotate
-printf "\n\n"
-pm2 install pm2-logrotate
+database_has_tables="$(runuser -u postgres -- "$PSQL_BIN" -XAtqc \
+  "SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_tables WHERE schemaname NOT IN ('pg_catalog', 'information_schema'))" \
+  "$databasename")"
+if [[ "$database_has_tables" == "t" && "$IMAGE" == "true" ]]; then
+  printf "Database '%s' already contains tables; skipping the blockchain image to avoid overwriting data.\n" \
+    "$databasename"
+  IMAGE=false
+fi
+
+runuser -u "$username" -- env \
+  HOME="$NODE_HOME" \
+  PATH="${PG_BIN_DIR}:/usr/local/bin:/usr/bin:/bin" \
+  NETWORK="$network" \
+  BRANCH="$branch" \
+  NODEJS_VERSION="$nodejs" \
+  NVM_INSTALL_VERSION="$NVM_VERSION" \
+  REPO_DIR="$REPO_DIR" \
+  CONFIG_FILE="$configfile" \
+  PROCESS_NAME="$processname" \
+  DATABASE_NAME="$databasename" \
+  DB_PASSWORD_BASE64="$DB_PASSWORD_BASE64" \
+  USE_IMAGE="$IMAGE" \
+  IMAGE_URL="$image_url" \
+  IMAGE_FILENAME="$image_filename" \
+  IMAGE_UNZIPPED_FILENAME="$image_unzipped_filename" \
+  bash <<'EOSU'
+set -Eeuo pipefail
+trap 'status=$?; printf "\n[ERROR] User setup failed at line %s.\n\n" "$LINENO" >&2; exit "$status"' ERR
+
+printf "\nInstalling or updating nvm v%s and Node.js %s.\n" "$NVM_INSTALL_VERSION" "$NODEJS_VERSION"
+export NVM_DIR="$HOME/.nvm"
+curl -fsSL "https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_INSTALL_VERSION}/install.sh" | bash
+# shellcheck disable=SC1091
+source "$NVM_DIR/nvm.sh"
+nvm install "$NODEJS_VERSION" --latest-npm
+nvm alias default "$NODEJS_VERSION"
+nvm use "$NODEJS_VERSION"
+npm install --global pm2@latest
+pm2 update
+printf "Using Node.js %s, npm %s, and pm2 %s.\n" "$(node --version)" "$(npm --version)" "$(pm2 --version)"
+
+printf "\nConfiguring pm2 log rotation.\n"
+if pm2 describe pm2-logrotate >/dev/null 2>&1; then
+  pm2 module:update pm2-logrotate
+else
+  pm2 install pm2-logrotate
+fi
 pm2 set pm2-logrotate:max_size 500M
 pm2 set pm2-logrotate:retain 5
 pm2 set pm2-logrotate:compress true
 pm2 set pm2-logrotate:rotateInterval '0 0 0 1 *'
 
-#ADAMANT
-printf "\n\nInstalling ADAMANT '%s' node. Cloning project repository from GitHub ('%s' branch)…\n\n" "$network" "$branch"
-git clone https://github.com/Adamant-im/adamant --branch $branch
-cd adamant || { printf "\n\nUnable to enter node's directory 'adamant'. Something is wrong, halting.\n\n"; exit 1; }
-npm i
-
-#Setup node: set DB password in config.json
-printf "\n\nSetting node's config…\n\n"
-
-if [[ $configfile == "config.json" ]]
-then
-  cp config.default.json config.json
-elif [ "$configfile" == "test/config.json" ]
-then
-  cp test/config.default.json test/config.json
-fi
-
-rpl -i -q '"password": "password",' "\"password\": \"${DB_PASSWORD}\"," "$configfile"
-
-#By default, node's API is available only from localhost
-#rpl -i -q '"public": false,' '"public": true,' "$configfile"
-
-# Download actual blockchain image for 'mainnet' network
-if [[ $IMAGE = true ]]
-then
-  printf "\n\nDownloading actual blockchain image…\n\n"
-  wget https://explorer.adamant.im/db_backup.sql.gz
-  printf "\nUnzipping the blockchain image, it can take a few minutes…\n\n"
-  gunzip db_backup.sql.gz
-  printf "\nLoading the blockchain image…\n\n"
-  psql adamant_main < db_backup.sql
-  printf "\nDeleting temporary blockchain image file…\n"
-  rm db_backup.sql
-fi
-
-printf "\n\nAdding ADAMANT '%s' node to crontab for autostart after system reboot…\n\n" "$network"
-if [[ $network == "mainnet" ]]
-then
-  crontab -l | { cat; echo "@reboot cd /home/adamant/adamant && pm2 start --name adamant app.js"; } | crontab -
+if [[ ! -e "$REPO_DIR" ]]; then
+  printf "\nCloning ADAMANT branch '%s'.\n" "$BRANCH"
+  git clone --branch "$BRANCH" --single-branch https://github.com/Adamant-im/adamant "$REPO_DIR"
+elif [[ ! -d "$REPO_DIR/.git" ]]; then
+  printf "\nExisting path '%s' is not an ADAMANT Git checkout. Refusing to overwrite it.\n" "$REPO_DIR" >&2
+  exit 1
 else
-  crontab -l | { cat; echo "@reboot cd /home/adamanttest/adamant && pm2 start --name adamanttest app.js -- --config test/config.json --genesis test/genesisBlock.json"; } | crontab -
+  printf "\nExisting ADAMANT checkout found. Fetching branch '%s'.\n" "$BRANCH"
+  cd "$REPO_DIR"
+  git fetch --prune origin "$BRANCH"
+  if [[ -n "$(git status --porcelain)" ]]; then
+    printf "Local repository changes detected; preserving the current checkout without switching branches.\n"
+  else
+    if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+      git checkout "$BRANCH"
+    else
+      git checkout --track -b "$BRANCH" "origin/$BRANCH"
+    fi
+    if ! git merge --ff-only "origin/$BRANCH"; then
+      printf "WARNING: The local branch cannot be fast-forwarded; preserving its current history.\n"
+    fi
+  fi
 fi
 
-printf "\n\nRunning ADAMANT '%s' node…\n\n" "$network"
-if [[ $network == "mainnet" ]]
-then
-  pm2 start --name adamant app.js
+cd "$REPO_DIR"
+printf "\nInstalling Node.js dependencies.\n"
+npm install
+
+printf "\nConfiguring the ADAMANT node.\n"
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  if [[ "$CONFIG_FILE" == "config.json" ]]; then
+    cp config.default.json "$CONFIG_FILE"
+  else
+    cp test/config.default.json "$CONFIG_FILE"
+  fi
 else
-  pm2 start --name adamanttest app.js -- --config test/config.json --genesis test/genesisBlock.json
+  printf "Configuration file '%s' already exists; preserving its settings.\n" "$CONFIG_FILE"
 fi
 
+DB_PASSWORD_DECODED="$(printf '%s' "$DB_PASSWORD_BASE64" | base64 --decode)"
+export DB_PASSWORD_DECODED
+config_tmp="$(mktemp "${CONFIG_FILE}.tmp.XXXXXX")"
+jq '.db.password = env.DB_PASSWORD_DECODED' "$CONFIG_FILE" > "$config_tmp"
+chmod --reference="$CONFIG_FILE" "$config_tmp" 2>/dev/null || true
+mv "$config_tmp" "$CONFIG_FILE"
+unset DB_PASSWORD_DECODED DB_PASSWORD_BASE64
+
+if [[ "$USE_IMAGE" == "true" ]]; then
+  printf "\nDownloading the %s blockchain image.\n" "$NETWORK"
+  rm -f "${IMAGE_FILENAME}.part" "$IMAGE_FILENAME" "$IMAGE_UNZIPPED_FILENAME"
+  wget --progress=dot:giga "$IMAGE_URL" -O "${IMAGE_FILENAME}.part"
+  mv "${IMAGE_FILENAME}.part" "$IMAGE_FILENAME"
+  gzip --test "$IMAGE_FILENAME"
+  printf "Extracting and loading the blockchain image.\n"
+  gunzip "$IMAGE_FILENAME"
+  psql -Xv ON_ERROR_STOP=1 "$DATABASE_NAME" < "$IMAGE_UNZIPPED_FILENAME"
+  rm -f "$IMAGE_UNZIPPED_FILENAME"
+fi
+
+printf "\nStarting the ADAMANT %s node.\n" "$NETWORK"
+if pm2 describe "$PROCESS_NAME" >/dev/null 2>&1; then
+  pm2 restart "$PROCESS_NAME" --update-env
+elif [[ "$NETWORK" == "mainnet" ]]; then
+  pm2 start --name "$PROCESS_NAME" app.js
+else
+  pm2 start --name "$PROCESS_NAME" app.js -- \
+    --config test/config.json --genesis test/genesisBlock.json
+fi
+pm2 save
 EOSU
 
-printf "\n\nADAMANT '%s' node installation script completed. Execution time: %s seconds.\n" "$network" "$SECONDS"
-printf "Check your node status with the command: 'pm2 show %s'\n" "$processname"
-printf "To check the current node height, run: 'curl http://localhost:%s/api/blocks/getHeight'\n" "$port"
-printf "Thank you for supporting the truly decentralized ADAMANT Messenger.\n\n"
-su - "$username"
+unset DB_PASSWORD_BASE64 DB_PASSWORD_SQL
+
+# shellcheck disable=SC2016
+NODE_BIN_DIR="$(runuser -u "$username" -- env HOME="$NODE_HOME" bash -c \
+  'source "$HOME/.nvm/nvm.sh" && dirname "$(command -v node)"')"
+printf "\nEnabling pm2 startup for user '%s'.\n" "$username"
+env PATH="${NODE_BIN_DIR}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+  "${NODE_BIN_DIR}/pm2" startup systemd -u "$username" --hp "$NODE_HOME"
+
+minutes=$(( (SECONDS + 59) / 60 ))
+printf "\nADAMANT %s node installation completed successfully.\n" "$network"
+printf "Total installation time: %d minutes.\n" "$minutes"
+printf "Installation log: %s\n\n" "$LOGFILE"
+printf "Check the node as user '%s':\n" "$username"
+printf "    su - %s\n" "$username"
+printf "    pm2 list\n"
+printf "    pm2 show %s\n" "$processname"
+printf "    pm2 logs %s\n\n" "$processname"
+printf "Query the current blockchain height:\n"
+printf "    curl http://localhost:%s/api/blocks/getHeight\n\n" "$port"

--- a/tools/install_node_centos.sh
+++ b/tools/install_node_centos.sh
@@ -136,7 +136,7 @@ exec > >(tee -a "$LOGFILE") 2>&1
 if [[ -s "$LOGFILE" ]]; then
   printf "\n\n\n===========================\n"
 fi
-printf "%s ADAMANT %s node installation started\n" \
+printf "\n%s ADAMANT %s node installation started\n" \
   "$(date -u '+%Y-%m-%d %H:%M UTC')" "$network"
 
 printf "\nWelcome to the ADAMANT Node Installer v%s for RHEL-compatible releases 8-10.\n" \
@@ -150,7 +150,7 @@ printf "Installation guide: https://docs.adamant.im/own-node/installation.html\n
 printf "Operating system:  %s\n" "$PRETTY_NAME"
 printf "Selected network:  %s\n" "$network"
 printf "Selected branch:   %s\n" "$branch"
-printf "Selected Node.js:  %s (24 is recommended for production)\n\n" "$nodejs"
+printf "Selected Node.js:  %s\n\n" "$nodejs"
 
 read -r -p "The script will upgrade packages, may restart services, and configure ADAMANT. Type \"yes\" to continue: " agreement
 if [[ "$agreement" != "yes" ]]; then

--- a/tools/install_node_centos.sh
+++ b/tools/install_node_centos.sh
@@ -3,12 +3,15 @@ set -Eeuo pipefail
 
 on_error() {
   local exit_status=$?
+  if [[ -n "${db_password_file:-}" ]]; then
+    rm -f -- "$db_password_file"
+  fi
   printf "\n[ERROR] Line %s failed. Installation stopped.\n\n" "${BASH_LINENO[0]}" >&2
   exit "$exit_status"
 }
 trap on_error ERR
 
-readonly INSTALLER_VERSION="2.4.5"
+readonly INSTALLER_VERSION="2.4.6"
 readonly NVM_VERSION="0.40.5"
 readonly POSTGRESQL_VERSION="18"
 
@@ -21,6 +24,7 @@ processname="adamant"
 port="36666"
 nodejs="24"
 image_url="https://explorer.adamant.im/db_backup.sql.gz"
+db_password_file=""
 
 usage() {
   printf "Usage: %s [-h] [-b branch] [-n mainnet|testnet] [-j 22|24|26]\n" "${0##*/}"
@@ -257,8 +261,6 @@ get_database_password() {
 
 DB_PASSWORD="$(get_database_password)"
 DB_PASSWORD_SQL=${DB_PASSWORD//\'/\'\'}
-DB_PASSWORD_BASE64="$(printf '%s' "$DB_PASSWORD" | base64 | tr -d '\n')"
-unset DB_PASSWORD
 
 printf "\nInstalling package-management and build prerequisites.\n"
 dnf -y install \
@@ -355,6 +357,11 @@ if [[ -z "$NODE_HOME" || ! -d "$NODE_HOME" ]]; then
 fi
 REPO_DIR="${NODE_HOME}/adamant"
 repair_node_user_permissions
+db_password_file="$(mktemp "${NODE_HOME}/.adamant-db-password.XXXXXX")"
+chmod 0600 "$db_password_file"
+printf '%s' "$DB_PASSWORD" > "$db_password_file"
+chown "$username:$username" "$db_password_file"
+unset DB_PASSWORD
 
 PSQL_BIN="$(command -v psql || true)"
 if [[ -z "$PSQL_BIN" && -x "/usr/pgsql-${POSTGRESQL_VERSION}/bin/psql" ]]; then
@@ -422,7 +429,7 @@ runuser -u "$username" -- env \
   CONFIG_FILE="$configfile" \
   PROCESS_NAME="$processname" \
   DATABASE_NAME="$databasename" \
-  DB_PASSWORD_BASE64="$DB_PASSWORD_BASE64" \
+  DB_PASSWORD_FILE="$db_password_file" \
   USE_IMAGE="$IMAGE" \
   IMAGE_URL="$image_url" \
   IMAGE_FILENAME="$image_filename" \
@@ -527,13 +534,13 @@ else
   printf "Configuration file '%s' already exists; preserving its settings.\n" "$CONFIG_FILE"
 fi
 
-DB_PASSWORD_DECODED="$(printf '%s' "$DB_PASSWORD_BASE64" | base64 --decode)"
+DB_PASSWORD_DECODED="$(cat "$DB_PASSWORD_FILE")"
 export DB_PASSWORD_DECODED
 config_tmp="$(mktemp "${CONFIG_FILE}.tmp.XXXXXX")"
 jq '.db.password = env.DB_PASSWORD_DECODED' "$CONFIG_FILE" > "$config_tmp"
 chmod 0600 "$config_tmp"
 mv "$config_tmp" "$CONFIG_FILE"
-unset DB_PASSWORD_DECODED DB_PASSWORD_BASE64
+unset DB_PASSWORD_DECODED
 
 if [[ "$USE_IMAGE" == "true" ]]; then
   printf "\nDownloading the %s blockchain image.\n" "$NETWORK"
@@ -558,7 +565,9 @@ fi
 pm2 save
 EOSU
 
-unset DB_PASSWORD_BASE64 DB_PASSWORD_SQL
+rm -f -- "$db_password_file"
+db_password_file=""
+unset DB_PASSWORD_SQL
 
 if command -v systemctl >/dev/null 2>&1 && [[ "$(ps -p 1 -o comm=)" == "systemd" ]]; then
   # shellcheck disable=SC2016

--- a/tools/install_node_centos.sh
+++ b/tools/install_node_centos.sh
@@ -8,7 +8,7 @@ on_error() {
 }
 trap on_error ERR
 
-readonly INSTALLER_VERSION="2.4.4"
+readonly INSTALLER_VERSION="2.4.5"
 readonly NVM_VERSION="0.40.5"
 readonly POSTGRESQL_VERSION="18"
 
@@ -182,7 +182,6 @@ case "$(uname -m)" in
 esac
 
 image_filename="$(basename "$image_url")"
-image_unzipped_filename="${image_filename%.gz}"
 LOGFILE="/var/log/adamant_${network}_install.log"
 
 exec > >(tee -a "$LOGFILE") 2>&1
@@ -427,7 +426,6 @@ runuser -u "$username" -- env \
   USE_IMAGE="$IMAGE" \
   IMAGE_URL="$image_url" \
   IMAGE_FILENAME="$image_filename" \
-  IMAGE_UNZIPPED_FILENAME="$image_unzipped_filename" \
   bash <<'EOSU'
 set -Eeuo pipefail
 trap 'status=$?; printf "\n[ERROR] User setup failed at line %s.\n\n" "$LINENO" >&2; exit "$status"' ERR
@@ -539,14 +537,13 @@ unset DB_PASSWORD_DECODED DB_PASSWORD_BASE64
 
 if [[ "$USE_IMAGE" == "true" ]]; then
   printf "\nDownloading the %s blockchain image.\n" "$NETWORK"
-  rm -f "${IMAGE_FILENAME}.part" "$IMAGE_FILENAME" "$IMAGE_UNZIPPED_FILENAME"
+  rm -f "${IMAGE_FILENAME}.part" "$IMAGE_FILENAME"
   wget --progress=dot:giga "$IMAGE_URL" -O "${IMAGE_FILENAME}.part"
   mv "${IMAGE_FILENAME}.part" "$IMAGE_FILENAME"
   gzip --test "$IMAGE_FILENAME"
-  printf "Extracting and loading the blockchain image.\n"
-  gunzip "$IMAGE_FILENAME"
-  psql -X --set=ON_ERROR_STOP=1 "$DATABASE_NAME" < "$IMAGE_UNZIPPED_FILENAME"
-  rm -f "$IMAGE_UNZIPPED_FILENAME"
+  printf "Streaming the blockchain image into PostgreSQL.\n"
+  gzip -dc "$IMAGE_FILENAME" | psql -X --set=ON_ERROR_STOP=1 "$DATABASE_NAME"
+  rm -f "$IMAGE_FILENAME"
 fi
 
 printf "\nStarting the ADAMANT %s node.\n" "$NETWORK"

--- a/tools/install_node_centos.sh
+++ b/tools/install_node_centos.sh
@@ -8,7 +8,7 @@ on_error() {
 }
 trap on_error ERR
 
-readonly INSTALLER_VERSION="2.4.1"
+readonly INSTALLER_VERSION="2.4.2"
 readonly NVM_VERSION="0.40.5"
 readonly POSTGRESQL_VERSION="18"
 
@@ -53,6 +53,22 @@ read_secret_from_tty() {
   IFS= read -r -s response < /dev/tty
   printf "\n" > /dev/tty
   printf "%s" "$response"
+}
+
+detect_installed_postgresql_services() {
+  rpm -qa --qf '%{NAME}\n' \
+    | awk '
+        /^postgresql[0-9]+-server$/ {
+          service = $0
+          sub(/^postgresql/, "", service)
+          sub(/-server$/, "", service)
+          print "postgresql-" service
+        }
+        /^postgresql-server$/ {
+          print "postgresql"
+        }
+      ' \
+    | sort -Vu
 }
 
 while getopts ":b:n:j:h" OPTION; do
@@ -265,18 +281,24 @@ if ! git check-ref-format --branch "$branch" >/dev/null 2>&1; then
 fi
 
 postgresql_service=""
-if rpm -qa | grep -Eq '^postgresql([0-9]+)?-server-'; then
+postgresql_installed_services="$(detect_installed_postgresql_services || true)"
+if [[ -n "$postgresql_installed_services" ]]; then
   printf "Existing PostgreSQL server installation detected; preserving its major version.\n"
-  while IFS= read -r service_name; do
-    if systemctl is-active --quiet "$service_name"; then
-      postgresql_service="$service_name"
-      break
-    fi
-    if [[ -z "$postgresql_service" ]]; then
-      postgresql_service="$service_name"
-    fi
-  done < <(systemctl list-unit-files --type=service --no-legend \
-    | awk '$1 ~ /^postgresql(-[0-9]+)?\.service$/ { sub(/\.service$/, "", $1); print $1 }')
+  if command -v systemctl >/dev/null 2>&1 && [[ "$(ps -p 1 -o comm=)" == "systemd" ]]; then
+    while IFS= read -r service_name; do
+      if systemctl is-active --quiet "$service_name"; then
+        postgresql_service="$service_name"
+        break
+      fi
+      if [[ -z "$postgresql_service" ]]; then
+        postgresql_service="$service_name"
+      fi
+    done < <(systemctl list-unit-files --type=service --no-legend \
+      | awk '$1 ~ /^postgresql(-[0-9]+)?\.service$/ { sub(/\.service$/, "", $1); print $1 }')
+  fi
+  if [[ -z "$postgresql_service" ]]; then
+    postgresql_service="$(printf '%s\n' "$postgresql_installed_services" | tail -1)"
+  fi
 else
   if [[ "$pgdg_enabled" == "true" ]]; then
     printf "Installing PostgreSQL %s from the official PGDG repository.\n" "$POSTGRESQL_VERSION"

--- a/tools/install_node_centos.sh
+++ b/tools/install_node_centos.sh
@@ -8,7 +8,7 @@ on_error() {
 }
 trap on_error ERR
 
-readonly INSTALLER_VERSION="2.4.2"
+readonly INSTALLER_VERSION="2.4.3"
 readonly NVM_VERSION="0.40.5"
 readonly POSTGRESQL_VERSION="18"
 
@@ -69,6 +69,15 @@ detect_installed_postgresql_services() {
         }
       ' \
     | sort -Vu
+}
+
+repair_node_user_permissions() {
+  for path in "$NODE_HOME/.nvm" "$NODE_HOME/.pm2" "$REPO_DIR"; do
+    if [[ -e "$path" ]]; then
+      chown -R "$username:$username" "$path"
+      chmod -R u+rwX "$path"
+    fi
+  done
 }
 
 while getopts ":b:n:j:h" OPTION; do
@@ -346,6 +355,7 @@ if [[ -z "$NODE_HOME" || ! -d "$NODE_HOME" ]]; then
   exit 1
 fi
 REPO_DIR="${NODE_HOME}/adamant"
+repair_node_user_permissions
 
 PSQL_BIN="$(command -v psql || true)"
 if [[ -z "$PSQL_BIN" && -x "/usr/pgsql-${POSTGRESQL_VERSION}/bin/psql" ]]; then
@@ -422,14 +432,15 @@ runuser -u "$username" -- env \
 set -Eeuo pipefail
 trap 'status=$?; printf "\n[ERROR] User setup failed at line %s.\n\n" "$LINENO" >&2; exit "$status"' ERR
 
+cd "$HOME"
 printf "\nInstalling or updating nvm v%s and Node.js %s.\n" "$NVM_INSTALL_VERSION" "$NODEJS_VERSION"
 export NVM_DIR="$HOME/.nvm"
 if [[ -d "$NVM_DIR/.git" ]]; then
   git -C "$NVM_DIR" fetch --tags --depth 1 origin "v${NVM_INSTALL_VERSION}"
-  git -C "$NVM_DIR" checkout --quiet "v${NVM_INSTALL_VERSION}"
+  git -c advice.detachedHead=false -C "$NVM_DIR" checkout --quiet "v${NVM_INSTALL_VERSION}"
 else
   rm -rf "$NVM_DIR"
-  git clone --depth 1 --branch "v${NVM_INSTALL_VERSION}" https://github.com/nvm-sh/nvm.git "$NVM_DIR"
+  git -c advice.detachedHead=false clone --depth 1 --branch "v${NVM_INSTALL_VERSION}" https://github.com/nvm-sh/nvm.git "$NVM_DIR"
 fi
 nvm_profile="$HOME/.bashrc"
 if ! grep -q 'NVM_DIR="$HOME/.nvm"' "$nvm_profile" 2>/dev/null; then
@@ -534,7 +545,7 @@ unset DB_PASSWORD_BASE64 DB_PASSWORD_SQL
 if command -v systemctl >/dev/null 2>&1 && [[ "$(ps -p 1 -o comm=)" == "systemd" ]]; then
   # shellcheck disable=SC2016
   NODE_BIN_DIR="$(runuser -u "$username" -- env HOME="$NODE_HOME" bash -c \
-    'source "$HOME/.nvm/nvm.sh" && dirname "$(command -v node)"')"
+    'cd "$HOME" && source "$HOME/.nvm/nvm.sh" && dirname "$(command -v node)"')"
   printf "\nEnabling pm2 startup for user '%s'.\n" "$username"
   env PATH="${NODE_BIN_DIR}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
     "${NODE_BIN_DIR}/pm2" startup systemd -u "$username" --hp "$NODE_HOME"

--- a/tools/install_node_centos.sh
+++ b/tools/install_node_centos.sh
@@ -572,7 +572,7 @@ else
 fi
 
 minutes=$(( (SECONDS + 59) / 60 ))
-printf "\nADAMANT %s node installation completed successfully.\n" "$network"
+printf "\n\nADAMANT %s node installation completed successfully.\n" "$network"
 printf "Total installation time: %d minutes.\n" "$minutes"
 printf "Installation log: %s\n\n" "$LOGFILE"
 printf "Check the node as user '%s':\n" "$username"

--- a/tools/install_node_centos.sh
+++ b/tools/install_node_centos.sh
@@ -23,7 +23,8 @@ nodejs="24"
 image_url="https://explorer.adamant.im/db_backup.sql.gz"
 
 usage() {
-  printf "Usage: %s [-b branch] [-n mainnet|testnet] [-j 22|24|26]\n" "${0##*/}"
+  printf "Usage: %s [-h] [-b branch] [-n mainnet|testnet] [-j 22|24|26]\n" "${0##*/}"
+  printf "       Node.js aliases: jod=22, krypton=24. Version 24 is the default.\n"
 }
 
 while getopts ":b:n:j:h" OPTION; do
@@ -142,6 +143,7 @@ printf "\nWelcome to the ADAMANT Node Installer v%s for RHEL-compatible releases
   "$INSTALLER_VERSION"
 printf "Supported distributions include CentOS Stream, Rocky Linux, AlmaLinux, and RHEL.\n"
 printf "The installer updates system packages and preserves existing ADAMANT configuration and local Git changes.\n"
+printf "Package upgrades may restart PostgreSQL, Redis, and other affected system services.\n"
 printf "Review backups and custom service configuration before continuing on an existing server.\n\n"
 printf "Installation guide: https://docs.adamant.im/own-node/installation.html\n\n"
 
@@ -150,7 +152,7 @@ printf "Selected network:  %s\n" "$network"
 printf "Selected branch:   %s\n" "$branch"
 printf "Selected Node.js:  %s (24 is recommended for production)\n\n" "$nodejs"
 
-read -r -p "The script will update packages and configure ADAMANT services. Type \"yes\" to continue: " agreement
+read -r -p "The script will upgrade packages, may restart services, and configure ADAMANT. Type \"yes\" to continue: " agreement
 if [[ "$agreement" != "yes" ]]; then
   printf "\nInstallation cancelled.\n\n"
   exit 1
@@ -217,7 +219,13 @@ dnf -y install \
 # repository is harmless on reruns and keeps installed PostgreSQL packages
 # eligible for security updates.
 pgdg_rpm="https://download.postgresql.org/pub/repos/yum/reporpms/EL-${el_major}-${pgdg_arch}/pgdg-redhat-repo-latest.noarch.rpm"
-dnf -y install "$pgdg_rpm"
+pgdg_enabled=false
+if curl -fsSL -o /dev/null "$pgdg_rpm"; then
+  dnf -y install "$pgdg_rpm"
+  pgdg_enabled=true
+else
+  printf "WARNING: PGDG RPM is unavailable; using distribution PostgreSQL packages.\n"
+fi
 
 printf "\nUpdating installed system packages.\n"
 dnf -y upgrade --refresh
@@ -244,15 +252,24 @@ if rpm -qa | grep -Eq '^postgresql([0-9]+)?-server-'; then
   done < <(systemctl list-unit-files --type=service --no-legend \
     | awk '$1 ~ /^postgresql(-[0-9]+)?\.service$/ { sub(/\.service$/, "", $1); print $1 }')
 else
-  printf "Installing PostgreSQL %s from the official PGDG repository.\n" "$POSTGRESQL_VERSION"
-  dnf -qy module disable postgresql || true
-  dnf -y install \
-    "postgresql${POSTGRESQL_VERSION}" \
-    "postgresql${POSTGRESQL_VERSION}-server" \
-    "postgresql${POSTGRESQL_VERSION}-contrib"
-  postgresql_service="postgresql-${POSTGRESQL_VERSION}"
-  if [[ ! -s "/var/lib/pgsql/${POSTGRESQL_VERSION}/data/PG_VERSION" ]]; then
-    "/usr/pgsql-${POSTGRESQL_VERSION}/bin/postgresql-${POSTGRESQL_VERSION}-setup" initdb
+  if [[ "$pgdg_enabled" == "true" ]]; then
+    printf "Installing PostgreSQL %s from the official PGDG repository.\n" "$POSTGRESQL_VERSION"
+    dnf -qy module disable postgresql || true
+    dnf -y install \
+      "postgresql${POSTGRESQL_VERSION}" \
+      "postgresql${POSTGRESQL_VERSION}-server" \
+      "postgresql${POSTGRESQL_VERSION}-contrib"
+    postgresql_service="postgresql-${POSTGRESQL_VERSION}"
+    if [[ ! -s "/var/lib/pgsql/${POSTGRESQL_VERSION}/data/PG_VERSION" ]]; then
+      "/usr/pgsql-${POSTGRESQL_VERSION}/bin/postgresql-${POSTGRESQL_VERSION}-setup" initdb
+    fi
+  else
+    printf "Installing PostgreSQL from the distribution repository.\n"
+    dnf -y install postgresql postgresql-server postgresql-contrib
+    postgresql_service="postgresql"
+    if [[ ! -s /var/lib/pgsql/data/PG_VERSION ]]; then
+      postgresql-setup --initdb
+    fi
   fi
 fi
 
@@ -260,8 +277,13 @@ if [[ -z "$postgresql_service" ]]; then
   printf "Cannot determine the installed PostgreSQL systemd service.\n" >&2
   exit 1
 fi
-systemctl enable --now "$postgresql_service"
-systemctl enable --now redis
+if command -v systemctl >/dev/null 2>&1 && [[ "$(ps -p 1 -o comm=)" == "systemd" ]]; then
+  systemctl enable --now "$postgresql_service"
+  systemctl enable --now redis
+else
+  service "$postgresql_service" start
+  service redis start
+fi
 
 if id -u "$username" >/dev/null 2>&1; then
   printf "\nSystem user '%s' already exists; preserving it.\n" "$username"
@@ -290,16 +312,26 @@ if [[ -z "$PSQL_BIN" ]]; then
 fi
 PG_BIN_DIR="$(dirname "$PSQL_BIN")"
 
+for _ in {1..30}; do
+  if runuser -u postgres -- "$PG_BIN_DIR/pg_isready" -q; then
+    break
+  fi
+  sleep 1
+done
+runuser -u postgres -- "$PG_BIN_DIR/pg_isready" -q
+
 role_exists="$(runuser -u postgres -- "$PSQL_BIN" -XAtqc \
   "SELECT 1 FROM pg_roles WHERE rolname = '${username}'" postgres)"
 if [[ "$role_exists" == "1" ]]; then
   printf "\nUpdating the password for existing PostgreSQL role '%s'.\n" "$username"
-  runuser -u postgres -- "$PSQL_BIN" -Xv ON_ERROR_STOP=1 -c \
-    "ALTER ROLE ${username} WITH LOGIN PASSWORD '${DB_PASSWORD_SQL}';" postgres
+  runuser -u postgres -- "$PSQL_BIN" -X --set=ON_ERROR_STOP=1 postgres <<EOSQL
+ALTER ROLE ${username} WITH LOGIN PASSWORD '${DB_PASSWORD_SQL}';
+EOSQL
 else
   printf "\nCreating PostgreSQL role '%s'.\n" "$username"
-  runuser -u postgres -- "$PSQL_BIN" -Xv ON_ERROR_STOP=1 -c \
-    "CREATE ROLE ${username} WITH LOGIN PASSWORD '${DB_PASSWORD_SQL}';" postgres
+  runuser -u postgres -- "$PSQL_BIN" -X --set=ON_ERROR_STOP=1 postgres <<EOSQL
+CREATE ROLE ${username} WITH LOGIN PASSWORD '${DB_PASSWORD_SQL}';
+EOSQL
 fi
 
 database_exists="$(runuser -u postgres -- "$PSQL_BIN" -XAtqc \
@@ -310,7 +342,7 @@ else
   printf "Creating database '%s'.\n" "$databasename"
   runuser -u postgres -- "$PG_BIN_DIR/createdb" -O "$username" "$databasename"
 fi
-runuser -u postgres -- "$PSQL_BIN" -Xv ON_ERROR_STOP=1 -c \
+runuser -u postgres -- "$PSQL_BIN" -X --set=ON_ERROR_STOP=1 -c \
   "ALTER DATABASE ${databasename} OWNER TO ${username};" postgres
 
 database_has_tables="$(runuser -u postgres -- "$PSQL_BIN" -XAtqc \
@@ -344,7 +376,20 @@ trap 'status=$?; printf "\n[ERROR] User setup failed at line %s.\n\n" "$LINENO" 
 
 printf "\nInstalling or updating nvm v%s and Node.js %s.\n" "$NVM_INSTALL_VERSION" "$NODEJS_VERSION"
 export NVM_DIR="$HOME/.nvm"
-curl -fsSL "https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_INSTALL_VERSION}/install.sh" | bash
+if [[ -d "$NVM_DIR/.git" ]]; then
+  git -C "$NVM_DIR" fetch --tags --depth 1 origin "v${NVM_INSTALL_VERSION}"
+  git -C "$NVM_DIR" checkout --quiet "v${NVM_INSTALL_VERSION}"
+else
+  rm -rf "$NVM_DIR"
+  git clone --depth 1 --branch "v${NVM_INSTALL_VERSION}" https://github.com/nvm-sh/nvm.git "$NVM_DIR"
+fi
+nvm_profile="$HOME/.bashrc"
+if ! grep -q 'NVM_DIR="$HOME/.nvm"' "$nvm_profile" 2>/dev/null; then
+  {
+    printf '\nexport NVM_DIR="$HOME/.nvm"\n'
+    printf '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"\n'
+  } >> "$nvm_profile"
+fi
 # shellcheck disable=SC1091
 source "$NVM_DIR/nvm.sh"
 nvm install "$NODEJS_VERSION" --latest-npm
@@ -408,7 +453,7 @@ DB_PASSWORD_DECODED="$(printf '%s' "$DB_PASSWORD_BASE64" | base64 --decode)"
 export DB_PASSWORD_DECODED
 config_tmp="$(mktemp "${CONFIG_FILE}.tmp.XXXXXX")"
 jq '.db.password = env.DB_PASSWORD_DECODED' "$CONFIG_FILE" > "$config_tmp"
-chmod --reference="$CONFIG_FILE" "$config_tmp" 2>/dev/null || true
+chmod 0600 "$config_tmp"
 mv "$config_tmp" "$CONFIG_FILE"
 unset DB_PASSWORD_DECODED DB_PASSWORD_BASE64
 
@@ -420,7 +465,7 @@ if [[ "$USE_IMAGE" == "true" ]]; then
   gzip --test "$IMAGE_FILENAME"
   printf "Extracting and loading the blockchain image.\n"
   gunzip "$IMAGE_FILENAME"
-  psql -Xv ON_ERROR_STOP=1 "$DATABASE_NAME" < "$IMAGE_UNZIPPED_FILENAME"
+  psql -X --set=ON_ERROR_STOP=1 "$DATABASE_NAME" < "$IMAGE_UNZIPPED_FILENAME"
   rm -f "$IMAGE_UNZIPPED_FILENAME"
 fi
 
@@ -438,12 +483,16 @@ EOSU
 
 unset DB_PASSWORD_BASE64 DB_PASSWORD_SQL
 
-# shellcheck disable=SC2016
-NODE_BIN_DIR="$(runuser -u "$username" -- env HOME="$NODE_HOME" bash -c \
-  'source "$HOME/.nvm/nvm.sh" && dirname "$(command -v node)"')"
-printf "\nEnabling pm2 startup for user '%s'.\n" "$username"
-env PATH="${NODE_BIN_DIR}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
-  "${NODE_BIN_DIR}/pm2" startup systemd -u "$username" --hp "$NODE_HOME"
+if command -v systemctl >/dev/null 2>&1 && [[ "$(ps -p 1 -o comm=)" == "systemd" ]]; then
+  # shellcheck disable=SC2016
+  NODE_BIN_DIR="$(runuser -u "$username" -- env HOME="$NODE_HOME" bash -c \
+    'source "$HOME/.nvm/nvm.sh" && dirname "$(command -v node)"')"
+  printf "\nEnabling pm2 startup for user '%s'.\n" "$username"
+  env PATH="${NODE_BIN_DIR}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+    "${NODE_BIN_DIR}/pm2" startup systemd -u "$username" --hp "$NODE_HOME"
+else
+  printf "\nWARNING: systemd was not detected. Configure pm2 startup manually for user '%s'.\n" "$username"
+fi
 
 minutes=$(( (SECONDS + 59) / 60 ))
 printf "\nADAMANT %s node installation completed successfully.\n" "$network"

--- a/tools/install_node_centos.sh
+++ b/tools/install_node_centos.sh
@@ -8,7 +8,7 @@ on_error() {
 }
 trap on_error ERR
 
-readonly INSTALLER_VERSION="2.4.3"
+readonly INSTALLER_VERSION="2.4.4"
 readonly NVM_VERSION="0.40.5"
 readonly POSTGRESQL_VERSION="18"
 
@@ -432,15 +432,35 @@ runuser -u "$username" -- env \
 set -Eeuo pipefail
 trap 'status=$?; printf "\n[ERROR] User setup failed at line %s.\n\n" "$LINENO" >&2; exit "$status"' ERR
 
+run_quiet() {
+  local description="$1"
+  local log_file
+
+  shift
+  log_file="$(mktemp)"
+  printf "%s\n" "$description"
+  if "$@" > "$log_file" 2>&1; then
+    rm -f "$log_file"
+    return 0
+  fi
+  cat "$log_file" >&2
+  rm -f "$log_file"
+  return 1
+}
+
 cd "$HOME"
 printf "\nInstalling or updating nvm v%s and Node.js %s.\n" "$NVM_INSTALL_VERSION" "$NODEJS_VERSION"
 export NVM_DIR="$HOME/.nvm"
 if [[ -d "$NVM_DIR/.git" ]]; then
-  git -C "$NVM_DIR" fetch --tags --depth 1 origin "v${NVM_INSTALL_VERSION}"
+  run_quiet "Updating nvm source." \
+    git -C "$NVM_DIR" fetch --quiet --depth 1 origin \
+      "refs/tags/v${NVM_INSTALL_VERSION}:refs/tags/v${NVM_INSTALL_VERSION}"
   git -c advice.detachedHead=false -C "$NVM_DIR" checkout --quiet "v${NVM_INSTALL_VERSION}"
 else
   rm -rf "$NVM_DIR"
-  git -c advice.detachedHead=false clone --depth 1 --branch "v${NVM_INSTALL_VERSION}" https://github.com/nvm-sh/nvm.git "$NVM_DIR"
+  run_quiet "Cloning nvm source." \
+    git -c advice.detachedHead=false clone --quiet --depth 1 --branch "v${NVM_INSTALL_VERSION}" \
+      https://github.com/nvm-sh/nvm.git "$NVM_DIR"
 fi
 nvm_profile="$HOME/.bashrc"
 if ! grep -q 'NVM_DIR="$HOME/.nvm"' "$nvm_profile" 2>/dev/null; then
@@ -454,20 +474,21 @@ source "$NVM_DIR/nvm.sh"
 nvm install "$NODEJS_VERSION" --latest-npm
 nvm alias default "$NODEJS_VERSION"
 nvm use "$NODEJS_VERSION"
-npm install --global pm2@latest
-pm2 update
+run_quiet "Installing or updating pm2." npm install --global pm2@latest
+run_quiet "Refreshing the pm2 daemon." pm2 update
 printf "Using Node.js %s, npm %s, and pm2 %s.\n" "$(node --version)" "$(npm --version)" "$(pm2 --version)"
 
 printf "\nConfiguring pm2 log rotation.\n"
 if pm2 describe pm2-logrotate >/dev/null 2>&1; then
-  pm2 module:update pm2-logrotate
+  run_quiet "Updating pm2-logrotate module." pm2 module:update pm2-logrotate
 else
-  pm2 install pm2-logrotate
+  run_quiet "Installing pm2-logrotate module." pm2 install pm2-logrotate
 fi
-pm2 set pm2-logrotate:max_size 500M
-pm2 set pm2-logrotate:retain 5
-pm2 set pm2-logrotate:compress true
-pm2 set pm2-logrotate:rotateInterval '0 0 0 1 *'
+run_quiet "Setting pm2-logrotate:max_size=500M." pm2 set pm2-logrotate:max_size 500M
+run_quiet "Setting pm2-logrotate:retain=5." pm2 set pm2-logrotate:retain 5
+run_quiet "Setting pm2-logrotate:compress=true." pm2 set pm2-logrotate:compress true
+run_quiet "Setting pm2-logrotate:rotateInterval='0 0 0 1 *'." \
+  pm2 set pm2-logrotate:rotateInterval '0 0 0 1 *'
 
 if [[ ! -e "$REPO_DIR" ]]; then
   printf "\nCloning ADAMANT branch '%s'.\n" "$BRANCH"

--- a/tools/install_node_centos.sh
+++ b/tools/install_node_centos.sh
@@ -8,7 +8,7 @@ on_error() {
 }
 trap on_error ERR
 
-readonly INSTALLER_VERSION="2.4.0"
+readonly INSTALLER_VERSION="2.4.1"
 readonly NVM_VERSION="0.40.5"
 readonly POSTGRESQL_VERSION="18"
 

--- a/tools/install_node_centos.sh
+++ b/tools/install_node_centos.sh
@@ -27,6 +27,34 @@ usage() {
   printf "       Node.js aliases: jod=22, krypton=24. Version 24 is the default.\n"
 }
 
+require_interactive_tty() {
+  if [[ ! -r /dev/tty || ! -w /dev/tty ]]; then
+    printf "\nThis installer requires an interactive terminal for confirmations and passwords.\n" >&2
+    printf "Run it from a normal shell session, for example:\n" >&2
+    printf "    curl -fsSL https://adamant.im/install_node_centos.sh | sudo bash -s -- -n mainnet\n\n" >&2
+    exit 1
+  fi
+}
+
+read_from_tty() {
+  local prompt_text="$1"
+  local response
+
+  printf "%s" "$prompt_text" > /dev/tty
+  IFS= read -r response < /dev/tty
+  printf "%s" "$response"
+}
+
+read_secret_from_tty() {
+  local prompt_text="$1"
+  local response
+
+  printf "%s" "$prompt_text" > /dev/tty
+  IFS= read -r -s response < /dev/tty
+  printf "\n" > /dev/tty
+  printf "%s" "$response"
+}
+
 while getopts ":b:n:j:h" OPTION; do
   case "$OPTION" in
     b)
@@ -152,7 +180,8 @@ printf "Selected network:  %s\n" "$network"
 printf "Selected branch:   %s\n" "$branch"
 printf "Selected Node.js:  %s\n\n" "$nodejs"
 
-read -r -p "The script will upgrade packages, may restart services, and configure ADAMANT. Type \"yes\" to continue: " agreement
+require_interactive_tty
+agreement="$(read_from_tty "The script will upgrade packages, may restart services, and configure ADAMANT. Type \"yes\" to continue: ")"
 if [[ "$agreement" != "yes" ]]; then
   printf "\nInstallation cancelled.\n\n"
   exit 1
@@ -161,7 +190,7 @@ fi
 IMAGE=false
 printf "\nA blockchain image can reduce synchronization time, but its source must be trusted.\n"
 printf "Without an image, the node verifies the blockchain from height 1, which may take several days.\n"
-read -r -p "Use the official ADAMANT blockchain image to bootstrap? [Y/n]: " useimage
+useimage="$(read_from_tty "Use the official ADAMANT blockchain image to bootstrap? [Y/n]: ")"
 case "${useimage:-Y}" in
   [yY][eE][sS]|[yY]|[jJ]|'') IMAGE=true ;;
   *) printf "The node will synchronize from scratch.\n" ;;
@@ -188,11 +217,8 @@ get_database_password() {
   local password confirmation
 
   while true; do
-    printf '\nSet the PostgreSQL password for role %s:\n> ' "$username" >&2
-    read -r -s password
-    printf '\nConfirm the password:\n> ' >&2
-    read -r -s confirmation
-    printf '\n' >&2
+    password="$(read_secret_from_tty "$(printf '\nSet the PostgreSQL database password for role %s.\nThis is not the Linux user login password.\n> ' "$username")")"
+    confirmation="$(read_secret_from_tty "$(printf 'Confirm the PostgreSQL database password:\n> ')")"
 
     if [[ -z "$password" ]]; then
       printf 'The database password cannot be empty. Try again.\n' >&2


### PR DESCRIPTION
## Description

Modernize the ADAMANT node installation and repair scripts for current VPS environments.

The branch updates:

- `tools/install_node.sh` for Ubuntu 20.04, 22.04, 24.04, and 26.04 LTS;
- `tools/install_node_centos.sh` for RHEL-compatible releases 8-10;
- `tools/fix_node.sh` to validate a downloaded snapshot before replacing the database;
- `README.md` with current support, rerun behavior, logging, and repair guidance.

Both installers now support Node.js 22, 24, and 26, default to Node.js 24, install nvm 0.40.5, use current official PostgreSQL sources, and preserve existing users, databases, PostgreSQL major versions, configuration files, and local Git changes where practical.

Repeated installation skips blockchain image import when the selected database already contains tables. The repair tool remains intentionally destructive, but it now completes preflight checks and validates the downloaded gzip image before stopping the node and dropping the database.

## Related issue

Closes #240

## External links (optional)

- [Node.js release schedule](https://nodejs.org/en/about/previous-releases)
- [nvm releases](https://github.com/nvm-sh/nvm/releases)
- [Ubuntu release cycle](https://ubuntu.com/about/release-cycle)
- [PostgreSQL APT repository](https://apt.postgresql.org/)
- [PostgreSQL RPM repository](https://www.postgresql.org/download/linux/redhat/)

## Screenshots or videos (optional)

Not applicable.

## Breaking changes

No consensus, protocol, serialization, API, or storage-schema behavior changes are introduced.

The installer no longer offers Node.js 20 because the node now requires Node.js 22.13.0 or newer. Node.js 24 becomes the default. New PostgreSQL installations use PostgreSQL 18 where available, or PostgreSQL 17 on Ubuntu 20.04; existing PostgreSQL major versions are preserved.

The installers update system packages and configure services, so operators should review backups and custom package/service configuration before running them on an existing server.

## How to test

Executed:

```sh
bash -n tools/install_node.sh tools/install_node_centos.sh tools/fix_node.sh
npx --yes shellcheck@4.1.0 tools/install_node.sh tools/install_node_centos.sh tools/fix_node.sh
git diff --check origin/dev...HEAD
```

Also verified:

- `-h` output for all three scripts;
- invalid network, unsupported Node.js, missing argument, and unknown option handling;
- availability of nvm 0.40.5, the PostgreSQL signing key and supported APT repositories, PGDG RPM repository packages, and both blockchain snapshot URLs.

Not executed:

- full installation or repair against live VPS instances, because these workflows update system packages and services and can replace a PostgreSQL database.

Recommended QA:

1. Run each installer on a disposable clean supported VPS.
2. Run it again with an existing user, repository, configuration, PostgreSQL database, and PM2 process.
3. Confirm local Git changes and existing configuration values are preserved except for the requested database password update.
4. Confirm a non-empty database prevents blockchain image import.
5. Run `fix_node.sh` against a disposable node and confirm the snapshot is downloaded and validated before database replacement.
6. Reboot and confirm PM2 restores the configured node.

## Notes for reviewers

Please pay particular attention to:

- PostgreSQL repository selection on Ubuntu 20.04 versus newer Ubuntu releases;
- detection and preservation of existing PostgreSQL installations;
- RHEL-compatible PostgreSQL service and binary discovery;
- Git/configuration preservation during repeated runs;
- PM2 update, startup, and graceful stop/restart behavior;
- snapshot validation and the ordering of destructive repair operations;
- database password handling and avoidance of secret values in logs.

This branch does not touch consensus-critical node logic.

## Checklist

- [x] Code is formatted
- [x] Tests added/updated (not needed for shell-only operational tooling)
- [x] Documentation updated
- [ ] Changes tested in all relevant environments
