### PR TITLE
Chore: Update post-phase-2 dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "GPL-3.0",
       "dependencies": {
         "async": "=3.2.6",
-        "axios": "^1.17.0",
+        "axios": "^1.18.0",
         "bignumber.js": "=11.1.3",
         "bitcore-mnemonic": "=10.10.7",
-        "body-parser": "=2.2.2",
+        "body-parser": "=2.3.0",
         "bytebuffer": "=5.0.1",
         "change-case": "^5.4.4",
         "colors": "=1.4.0",
@@ -55,7 +55,7 @@
         "chai-bignumber": "^3.1.0",
         "eslint-config-google": "^0.14.0",
         "eslint-formatter-codeframe": "^7.32.2",
-        "eslint-plugin-jsdoc": "^63.0.2",
+        "eslint-plugin-jsdoc": "^63.0.4",
         "globals": "^17.6.0",
         "grunt": "^1.6.2",
         "grunt-cli": "^1.5.0",
@@ -1234,9 +1234,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -1537,21 +1537,34 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -2559,9 +2572,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "63.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.0.2.tgz",
-      "integrity": "sha512-0TchoK1uS4VxHSo3P4CyWQ31Lm+6zsT+xkHMC5KbFKwgOf8YrXPf1Bl8EP7kpgw1wfe/Ui5jz5mSX7ou8WAVuw==",
+      "version": "63.0.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.0.4.tgz",
+      "integrity": "sha512-CzfD5nlKm91L0b4DQq47ERIlL4s4cK5+iQJMI99MDvVWLz+SkwUSGYcIr8ZYsyRw2gQ2MSKsE2StbT1CctdG0A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -9098,17 +9111,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/type-is/node_modules/mime-db": {
@@ -9415,9 +9445,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
   "license": "GPL-3.0",
   "dependencies": {
     "async": "=3.2.6",
-    "axios": "^1.17.0",
+    "axios": "^1.18.0",
     "bignumber.js": "=11.1.3",
     "bitcore-mnemonic": "=10.10.7",
-    "body-parser": "=2.2.2",
+    "body-parser": "=2.3.0",
     "bytebuffer": "=5.0.1",
     "change-case": "^5.4.4",
     "colors": "=1.4.0",
@@ -91,7 +91,7 @@
     "chai-bignumber": "^3.1.0",
     "eslint-config-google": "^0.14.0",
     "eslint-formatter-codeframe": "^7.32.2",
-    "eslint-plugin-jsdoc": "^63.0.2",
+    "eslint-plugin-jsdoc": "^63.0.4",
     "grunt": "^1.6.2",
     "grunt-cli": "^1.5.0",
     "grunt-contrib-compress": "^2.0.0",
@@ -109,7 +109,8 @@
     "grunt-contrib-obfuscator": {
       "javascript-obfuscator": "^4.0.0"
     },
-    "serialize-javascript": "7.0.5"
+    "serialize-javascript": "7.0.5",
+    "ws": "8.21.0"
   },
   "config": {
     "minVersion": ">=0.6.0"


### PR DESCRIPTION
## Description

Apply the post-validation dependency bumps called out in #144 after the phase 2
dependency work in PR #238. This is a narrow lockfile-only follow-up that
updates the two releases published after the June 14, 2026 snapshot, plus a
small dev-tool patch and a transitive `ws` override alignment.

No application source, schema, SQL, consensus, or API behavior is changed.

## Related issue

Refs #144

## Changes

- `axios` `^1.17.0` -> `^1.18.0`
- `body-parser` `=2.2.2` -> `=2.3.0` (transitive bumps: `content-type` 2.x,
  `http-errors`, `iconv-lite`, `qs`, `raw-body`, `type-is`)
- `eslint-plugin-jsdoc` `^63.0.2` -> `^63.0.4`
- `overrides.ws` pinned to `8.21.0` to keep the WebSocket client dependency
  aligned with the resolved lockfile version
- Regenerated `package-lock.json`

## Safety and compatibility

- No consensus rules, activation heights, block or transaction serialization,
  IDs, signatures, fees, rewards, delegate ordering, or replay behavior are
  intentionally changed.
- `axios` is used for outbound HTTP in peer/transport paths; the bump is a
  minor release within the same major line.
- `body-parser` remains on the Express 5 / Node 18+ line already required by
  the repository; request parsing behavior is unchanged at the application
  layer.
- `eslint-plugin-jsdoc` is a development-only lint dependency.
- Registry URLs, integrity hashes, and lockfile diffs were reviewed.

## How to test

```bash
npm ci
npm run eslint
npm run test:single -- test/unit/helpers/ed.js test/unit/modules/accounts.js test/unit/modules/transactions.js
npm audit --audit-level=high
npm audit signatures
git diff --check origin/dev...HEAD
```

With PostgreSQL and Redis available, run broader coverage as needed:

```bash
npm run test:unit
npm run start:testnet
npm run test:api
```

Stop the testnet through its graceful `SIGINT` shutdown path.

## Verification

- `npm ci`: passed.
- `npm run eslint`: passed with no errors or warnings.
- `git diff --check origin/dev...HEAD`: passed.
- Targeted unit regression tests: not run locally because PostgreSQL was
  unavailable in the PR authoring environment.
- Full `npm run test:unit` and API suite: not run locally for the same reason.
- `npm audit --audit-level=moderate`: reports 4 moderate and 5 low findings in
  existing dev-tool chains (`grunt`, `js-yaml`, `elliptic`, `diff`); no new
  high or critical findings were introduced by this lockfile update.

## Checklist

- [x] Repository artifacts and PR text are in English.
- [x] Dependency and lockfile changes were reviewed.
- [x] No consensus or protocol behavior was intentionally changed.
- [x] Repository-wide ESLint passed.
- [x] Post-phase-2 `axios` and `body-parser` releases from #144 are included.
- [ ] Full unit and API suites (requires local PostgreSQL, Redis, and testnet).
