### PR TITLE
Fix: enforce future-timestamp admission check on P2P transaction relay

### DIFF
--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -120,6 +120,53 @@ Transaction.prototype.create = function (data) {
 };
 
 /**
+ * Checks a transaction's timestamp against the future-timestamp grace period used
+ * after `spaceship` activation (`maxTransactionFutureMs`).
+ * Shared by `publish()` (Public API submissions) and `verify()` (every other
+ * admission path: peer-relayed transactions and transactions inside received blocks,
+ * including historical ones replayed during sync) so a future-dated transaction can't
+ * bypass this check by entering through a path other than the Public API.
+ * @param {object} trs - The transaction object
+ * @return {string|undefined} Error message if the timestamp is too far in the future
+ */
+Transaction.prototype.checkFutureTimestamp = function (trs) {
+  const currentTimeMs = slots.getTimeMs();
+  const currentTime = Math.floor(currentTimeMs / 1000);
+
+  const currentSlotNumber = slots.getSlotNumber(currentTime);
+  const transactionSlotNumber = slots.getSlotNumber(trs.timestamp);
+  const transactionTimeMs = typeof trs.timestampMs === 'number' ? trs.timestampMs : trs.timestamp * 1000;
+  const transactionFutureMs = transactionTimeMs - currentTimeMs;
+
+  if (transactionSlotNumber > currentSlotNumber && transactionFutureMs > constants.maxTransactionFutureMs) {
+    return 'Transaction timestamp is in the future';
+  }
+};
+
+/**
+ * Checks that a chat/state transaction's timestamp isn't more than `maxTransactionAgeSec`
+ * in the past. Only meaningful for freshly submitted transactions - `verify()` also
+ * replays historical, long-confirmed transactions (e.g. during sync), which legitimately
+ * have timestamps far in the past, so this is only called from `publish()`.
+ * @param {object} trs - The transaction object
+ * @return {string|undefined} Error message if the timestamp is too far in the past
+ */
+Transaction.prototype.checkPastTimestampWindow = function (trs) {
+  if (trs.type !== transactionTypes.CHAT_MESSAGE && trs.type !== transactionTypes.STATE) {
+    return;
+  }
+
+  const currentTime = Math.floor(slots.getTimeMs() / 1000);
+  const transactionSlotNumber = slots.getSlotNumber(trs.timestamp);
+  const earliestValidTime = currentTime - constants.maxTransactionAgeSec;
+  const earliestValidSlotNumber = slots.getSlotNumber(earliestValidTime);
+
+  if (transactionSlotNumber < earliestValidSlotNumber) {
+    return `Transaction timestamp is more than ${constants.maxTransactionAgeSec} seconds in the past`;
+  }
+};
+
+/**
  * Modifies a transaction by adding the calculated fee and transaction ID,
  * and validates public-API admission timestamps.
  * Chat and state transactions must not be more than `maxTransactionAgeSec` in the past.
@@ -141,25 +188,16 @@ Transaction.prototype.publish = function (data) {
     throw 'Invalid signature';
   }
 
-  const currentTimeMs = slots.getTimeMs();
-  const currentTime = Math.floor(currentTimeMs / 1000);
+  const futureTimestampError = this.checkFutureTimestamp(data);
 
-  const currentSlotNumber = slots.getSlotNumber(currentTime);
-  const transactionSlotNumber = slots.getSlotNumber(data.timestamp);
-  const transactionTimeMs = typeof data.timestampMs === 'number' ? data.timestampMs : data.timestamp * 1000;
-  const transactionFutureMs = transactionTimeMs - currentTimeMs;
-
-  if (transactionSlotNumber > currentSlotNumber && transactionFutureMs > constants.maxTransactionFutureMs) {
-    throw 'Transaction timestamp is in the future';
+  if (futureTimestampError) {
+    throw futureTimestampError;
   }
 
-  if (data.type === transactionTypes.CHAT_MESSAGE || data.type === transactionTypes.STATE) {
-    const earliestValidTime = currentTime - constants.maxTransactionAgeSec;
-    const earliestValidSlotNumber = slots.getSlotNumber(earliestValidTime);
+  const pastTimestampError = this.checkPastTimestampWindow(data);
 
-    if (transactionSlotNumber < earliestValidSlotNumber) {
-      throw `Transaction timestamp is more than ${constants.maxTransactionAgeSec} seconds in the past`;
-    }
+  if (pastTimestampError) {
+    throw pastTimestampError;
   }
 
   var trs = data;
@@ -712,6 +750,25 @@ Transaction.prototype.verify = function (trs, sender, requester, cb) {
     if (timestampMsDelta < 0 || timestampMsDelta >= maxTimestampMsDelta) {
       return setImmediate(cb, `Invalid transaction timestamp. timestampMs must be within the same second as timestamp, from 0 to ${maxTimestampMsDelta - 1}ms`);
     }
+  }
+
+  // `verify()` is the universal gate (peer-relayed transactions and transactions
+  // inside received blocks, including historical ones replayed during sync) -
+  // enforce the future-timestamp check here too so it can't be bypassed by entering
+  // through a path other than the Public API. Only the future check applies here:
+  // the past-age window (`checkPastTimestampWindow`) is for freshly submitted
+  // transactions only and would wrongly reject long-confirmed historical chat/state
+  // transactions replayed during sync. Pre-`spaceship` nodes keep the original
+  // strict rule so a block accepted by an upgraded node isn't forked away by one
+  // that isn't.
+  if (this.scope.consensus.isActivated('spaceship')) {
+    const futureTimestampError = this.checkFutureTimestamp(trs);
+
+    if (futureTimestampError) {
+      return setImmediate(cb, futureTimestampError);
+    }
+  } else if (slots.getSlotNumber(timestamp) > slots.getSlotNumber()) {
+    return setImmediate(cb, 'Invalid transaction timestamp. Timestamp is in the future');
   }
 
   // Call verify on transaction type

--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -148,7 +148,8 @@ Transaction.prototype.checkFutureTimestamp = function (trs) {
  * Checks that a chat/state transaction's timestamp isn't more than `maxTransactionAgeSec`
  * in the past. Only meaningful for freshly submitted transactions - `verify()` also
  * replays historical, long-confirmed transactions (e.g. during sync), which legitimately
- * have timestamps far in the past, so this is only called from `publish()`.
+ * have timestamps far in the past, so this must only be called at real-time ingestion
+ * boundaries (Public API `publish()`, P2P `modules/transport.js`), never from `verify()`.
  * @param {object} trs - The transaction object
  * @return {string|undefined} Error message if the timestamp is too far in the past
  */

--- a/logic/transaction.js
+++ b/logic/transaction.js
@@ -122,10 +122,11 @@ Transaction.prototype.create = function (data) {
 /**
  * Checks a transaction's timestamp against the future-timestamp grace period used
  * after `spaceship` activation (`maxTransactionFutureMs`).
- * Shared by `publish()` (Public API submissions) and `verify()` (every other
- * admission path: peer-relayed transactions and transactions inside received blocks,
- * including historical ones replayed during sync) so a future-dated transaction can't
- * bypass this check by entering through a path other than the Public API.
+ * This is wall-clock-relative admission control for transactions freshly entering the
+ * network in real time, not a consensus rule - it must only be called at real-time
+ * ingestion boundaries (Public API `publish()`, P2P `modules/transport.js`), never from
+ * `verify()`, which also replays historical, long-confirmed transactions during sync
+ * and must stay replay-deterministic. See AGENTS.md "Current Activation Switches".
  * @param {object} trs - The transaction object
  * @return {string|undefined} Error message if the timestamp is too far in the future
  */
@@ -750,25 +751,6 @@ Transaction.prototype.verify = function (trs, sender, requester, cb) {
     if (timestampMsDelta < 0 || timestampMsDelta >= maxTimestampMsDelta) {
       return setImmediate(cb, `Invalid transaction timestamp. timestampMs must be within the same second as timestamp, from 0 to ${maxTimestampMsDelta - 1}ms`);
     }
-  }
-
-  // `verify()` is the universal gate (peer-relayed transactions and transactions
-  // inside received blocks, including historical ones replayed during sync) -
-  // enforce the future-timestamp check here too so it can't be bypassed by entering
-  // through a path other than the Public API. Only the future check applies here:
-  // the past-age window (`checkPastTimestampWindow`) is for freshly submitted
-  // transactions only and would wrongly reject long-confirmed historical chat/state
-  // transactions replayed during sync. Pre-`spaceship` nodes keep the original
-  // strict rule so a block accepted by an upgraded node isn't forked away by one
-  // that isn't.
-  if (this.scope.consensus.isActivated('spaceship')) {
-    const futureTimestampError = this.checkFutureTimestamp(trs);
-
-    if (futureTimestampError) {
-      return setImmediate(cb, futureTimestampError);
-    }
-  } else if (slots.getSlotNumber(timestamp) > slots.getSlotNumber()) {
-    return setImmediate(cb, 'Invalid transaction timestamp. Timestamp is in the future');
   }
 
   // Call verify on transaction type

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -250,6 +250,21 @@ __private.receiveTransaction = function (transaction, peer, extraLogMessage, cb)
     return setImmediate(cb, 'Invalid transaction body - ' + e.toString());
   }
 
+  // Real-time admission grace, mirroring the Public API's `publish()` boundary.
+  // This is a wall-clock spam/pool-poisoning guard, not a consensus rule, so it
+  // belongs here - the boundary where a transaction first enters the network from a
+  // peer - and not inside `transaction.verify()`, which also replays historical,
+  // already-confirmed transactions during block processing and sync. See AGENTS.md
+  // "Current Activation Switches" for why wall-clock checks must stay out of verify().
+  var timestampWindowError = library.logic.transaction.checkFutureTimestamp(transaction) ||
+      library.logic.transaction.checkPastTimestampWindow(transaction);
+
+  if (timestampWindowError) {
+    library.logger.debug('transactions', 'Rejected transaction ' + id + ' from peer ' + peer.string, timestampWindowError);
+
+    return setImmediate(cb, timestampWindowError);
+  }
+
   library.balancesSequence.add(function (cb) {
     library.logger.debug('transactions', 'Received transaction ' + transaction.id + ' from peer ' + peer.string);
     modules.transactions.processUnconfirmedTransaction(transaction, true, function (err) {

--- a/modules/transport.js
+++ b/modules/transport.js
@@ -260,7 +260,7 @@ __private.receiveTransaction = function (transaction, peer, extraLogMessage, cb)
       library.logic.transaction.checkPastTimestampWindow(transaction);
 
   if (timestampWindowError) {
-    library.logger.debug('transactions', 'Rejected transaction ' + id + ' from peer ' + peer.string, timestampWindowError);
+    library.logger.debug('transactions', 'Rejected transaction ' + transaction.id + ' from peer ' + peer.string, timestampWindowError);
 
     return setImmediate(cb, timestampWindowError);
   }

--- a/test/api/peer.transactions.main.js
+++ b/test/api/peer.transactions.main.js
@@ -187,6 +187,68 @@ describe('POST /peer/transactions', function () {
     });
   });
 
+  it('using a chat message transaction with a timestamp far in the past should fail', function (done) {
+    var recipient = node.randomAccount();
+    var transaction = node.createChatTransaction({
+      keyPair: node.iAccount.keypair,
+      recipientId: recipient.address,
+      message: 'test message',
+      own_message: '',
+      type: 1
+    });
+
+    transaction.timestamp -= 16;
+    transaction.timestampMs = transaction.timestamp * 1000;
+    transaction.signature = node.transactionSign(transaction, node.iAccount.keypair);
+    transaction.id = node.getId(transaction);
+
+    postTransaction(transaction, function (err, res) {
+      node.expect(res.body).to.have.property('success').to.be.false;
+      node.expect(res.body).to.have.property('message').to.eql('Transaction timestamp is more than 5 seconds in the past');
+      done();
+    });
+  });
+
+  it('using a state transaction with a timestamp far in the past should fail', function (done) {
+    var transaction = node.createStateTransaction({
+      keyPair: node.iAccount.keypair,
+      key: 'test:key',
+      value: 'test-value'
+    });
+
+    transaction.fee = node.fees.stateFee;
+    transaction.timestamp -= 16;
+    transaction.timestampMs = transaction.timestamp * 1000;
+    transaction.signature = node.transactionSign(transaction, node.iAccount.keypair);
+    transaction.id = node.getId(transaction);
+
+    postTransaction(transaction, function (err, res) {
+      node.expect(res.body).to.have.property('success').to.be.false;
+      node.expect(res.body).to.have.property('message').to.eql('Transaction timestamp is more than 5 seconds in the past');
+      done();
+    });
+  });
+
+  it('using a send transaction with a timestamp far in the past should be ok (past-window check is chat/state only)', function (done) {
+    var account = node.randomAccount();
+    var transaction = node.createSendTransaction({
+      keyPair: node.iAccount.keypair,
+      amount: 1,
+      recipientId: account.address
+    });
+
+    transaction.timestamp -= 16;
+    transaction.timestampMs = transaction.timestamp * 1000;
+    transaction.signature = node.transactionSign(transaction, node.iAccount.keypair);
+    transaction.id = node.getId(transaction);
+
+    postTransaction(transaction, function (err, res) {
+      node.expect(res.body).to.have.property('success').to.be.true;
+      node.expect(res.body).to.have.property('transactionId').to.equal(transaction.id);
+      done();
+    });
+  });
+
   it('using transaction with undefined recipientId should fail', function (done) {
     var transaction = node.createSendTransaction({
       keyPair: node.iAccount.keypair,

--- a/test/api/peer.transactions.main.js
+++ b/test/api/peer.transactions.main.js
@@ -167,6 +167,26 @@ describe('POST /peer/transactions', function () {
     });
   });
 
+  it('using a transaction with a timestamp far in the future should fail', function (done) {
+    var account = node.randomAccount();
+    var transaction = node.createSendTransaction({
+      keyPair: node.iAccount.keypair,
+      amount: 1,
+      recipientId: account.address
+    });
+
+    transaction.timestamp += 100000;
+    transaction.timestampMs = transaction.timestamp * 1000;
+    transaction.signature = node.transactionSign(transaction, node.iAccount.keypair);
+    transaction.id = node.getId(transaction);
+
+    postTransaction(transaction, function (err, res) {
+      node.expect(res.body).to.have.property('success').to.be.false;
+      node.expect(res.body).to.have.property('message').to.eql('Transaction timestamp is in the future');
+      done();
+    });
+  });
+
   it('using transaction with undefined recipientId should fail', function (done) {
     var transaction = node.createSendTransaction({
       keyPair: node.iAccount.keypair,

--- a/test/unit/logic/transaction.js
+++ b/test/unit/logic/transaction.js
@@ -934,6 +934,276 @@ describe('transaction', () => {
     });
   });
 
+  describe('checkFutureTimestamp()', () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should not error for a transaction in the current slot', () => {
+      sinon.useFakeTimers({ now: constants.epochTime.getTime() + 100000 });
+
+      const trs = _.cloneDeep(validUnconfirmedTransaction);
+      trs.timestamp = slots.getTime();
+      trs.timestampMs = slots.getTimeMs();
+
+      expect(transaction.checkFutureTimestamp(trs)).to.be.undefined;
+    });
+
+    it('should not error for a transaction with a timestamp in the past', () => {
+      sinon.useFakeTimers({ now: constants.epochTime.getTime() + 100000 });
+
+      const trs = _.cloneDeep(validUnconfirmedTransaction);
+      trs.timestamp = slots.getTime() - 1000;
+      trs.timestampMs = trs.timestamp * 1000;
+
+      expect(transaction.checkFutureTimestamp(trs)).to.be.undefined;
+    });
+
+    it('should not error when still in the current slot, even if the derived future ms would exceed the grace window', () => {
+      sinon.useFakeTimers({ now: constants.epochTime.getTime() + 100000 });
+
+      const trs = _.cloneDeep(validUnconfirmedTransaction);
+      trs.timestamp = 104; // same slot (20) as current time, despite a large ms gap
+      trs.timestampMs = 104999;
+
+      expect(transaction.checkFutureTimestamp(trs)).to.be.undefined;
+    });
+
+    it('should accept a next-slot transaction exactly at the future grace boundary, with timestampMs present (post-spaceship)', () => {
+      sinon.useFakeTimers({ now: constants.epochTime.getTime() + 104999 });
+
+      const trs = _.cloneDeep(validUnconfirmedTransaction);
+      trs.timestampMs = slots.getTimeMs() + constants.maxTransactionFutureMs;
+      trs.timestamp = Math.floor(trs.timestampMs / 1000);
+
+      expect(transaction.checkFutureTimestamp(trs)).to.be.undefined;
+    });
+
+    it('should reject a next-slot transaction 1ms beyond the future grace boundary, with timestampMs present (post-spaceship)', () => {
+      sinon.useFakeTimers({ now: constants.epochTime.getTime() + 104999 });
+
+      const trs = _.cloneDeep(validUnconfirmedTransaction);
+      trs.timestampMs = slots.getTimeMs() + constants.maxTransactionFutureMs + 1;
+      trs.timestamp = Math.floor(trs.timestampMs / 1000);
+
+      expect(transaction.checkFutureTimestamp(trs)).to.equal('Transaction timestamp is in the future');
+    });
+
+    it('should accept a next-slot transaction within grace when timestampMs is absent, falling back to timestamp * 1000 (pre-spaceship)', () => {
+      sinon.useFakeTimers({ now: constants.epochTime.getTime() + 104999 });
+
+      const trs = _.cloneDeep(validUnconfirmedTransaction);
+      delete trs.timestampMs;
+      trs.timestamp = 105; // next slot; timestamp * 1000 is only 1ms ahead of current time
+
+      expect(transaction.checkFutureTimestamp(trs)).to.be.undefined;
+    });
+
+    it('should reject a next-slot transaction beyond grace when timestampMs is absent, falling back to timestamp * 1000 (pre-spaceship)', () => {
+      sinon.useFakeTimers({ now: constants.epochTime.getTime() + 104999 });
+
+      const trs = _.cloneDeep(validUnconfirmedTransaction);
+      delete trs.timestampMs;
+      trs.timestamp = 106; // next slot; timestamp * 1000 is 1001ms ahead of current time
+
+      expect(transaction.checkFutureTimestamp(trs)).to.equal('Transaction timestamp is in the future');
+    });
+
+    it('should accept a clearly in-grace future transaction the same way whether timestampMs is present or absent', () => {
+      sinon.useFakeTimers({ now: constants.epochTime.getTime() + 104999 });
+
+      const withMs = _.cloneDeep(validUnconfirmedTransaction);
+      withMs.timestamp = 105;
+      withMs.timestampMs = 105000;
+
+      const withoutMs = _.cloneDeep(validUnconfirmedTransaction);
+      withoutMs.timestamp = 105;
+      delete withoutMs.timestampMs;
+
+      expect(transaction.checkFutureTimestamp(withMs)).to.be.undefined;
+      expect(transaction.checkFutureTimestamp(withoutMs)).to.be.undefined;
+    });
+
+    it('should reject a clearly out-of-grace future transaction the same way whether timestampMs is present or absent', () => {
+      sinon.useFakeTimers({ now: constants.epochTime.getTime() + 104999 });
+
+      const withMs = _.cloneDeep(validUnconfirmedTransaction);
+      withMs.timestamp = 110;
+      withMs.timestampMs = 110000;
+
+      const withoutMs = _.cloneDeep(validUnconfirmedTransaction);
+      withoutMs.timestamp = 110;
+      delete withoutMs.timestampMs;
+
+      expect(transaction.checkFutureTimestamp(withMs)).to.equal('Transaction timestamp is in the future');
+      expect(transaction.checkFutureTimestamp(withoutMs)).to.equal('Transaction timestamp is in the future');
+    });
+
+    it('should reject the same future transaction both before and after spaceship activation via objectNormalize', () => {
+      sinon.useFakeTimers({ now: constants.epochTime.getTime() + 104999 });
+
+      const buildTrs = () => {
+        const trs = _.cloneDeep(validUnconfirmedTransaction);
+        trs.timestamp = 110;
+        trs.timestampMs = 110000;
+        delete trs.signature;
+        trs.signature = transaction.sign(testSenderKeypair, trs);
+        return trs;
+      };
+
+      dummyHeight = consensusActivationHeights.spaceship - 1;
+      const preSpaceship = transaction.objectNormalize(buildTrs());
+      expect(preSpaceship).to.not.have.property('timestampMs');
+      expect(transaction.checkFutureTimestamp(preSpaceship)).to.equal('Transaction timestamp is in the future');
+
+      dummyHeight = consensusActivationHeights.spaceship;
+      const postSpaceship = transaction.objectNormalize(buildTrs());
+      expect(postSpaceship).to.have.property('timestampMs');
+      expect(transaction.checkFutureTimestamp(postSpaceship)).to.equal('Transaction timestamp is in the future');
+
+      dummyHeight = 1;
+    });
+  });
+
+  describe('checkPastTimestampWindow()', () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should not error for SEND transactions regardless of how old the timestamp is', () => {
+      sinon.useFakeTimers({ now: constants.epochTime.getTime() + 100000 });
+
+      const trs = _.cloneDeep(validUnconfirmedTransaction);
+      trs.type = transactionTypes.SEND;
+      trs.timestamp = 1;
+
+      expect(transaction.checkPastTimestampWindow(trs)).to.be.undefined;
+    });
+
+    it('should not error for a CHAT_MESSAGE transaction within the allowed past window', () => {
+      sinon.useFakeTimers({ now: constants.epochTime.getTime() + 100000 });
+
+      const trs = _.cloneDeep(validUnconfirmedTransaction);
+      trs.type = transactionTypes.CHAT_MESSAGE;
+      trs.timestamp = 96; // earliest valid slot (19) is seconds 95-99
+
+      expect(transaction.checkPastTimestampWindow(trs)).to.be.undefined;
+    });
+
+    it('should not error for a CHAT_MESSAGE transaction exactly at the earliest valid boundary', () => {
+      sinon.useFakeTimers({ now: constants.epochTime.getTime() + 100000 });
+
+      const trs = _.cloneDeep(validUnconfirmedTransaction);
+      trs.type = transactionTypes.CHAT_MESSAGE;
+      trs.timestamp = 95; // start of earliest valid slot (19)
+
+      expect(transaction.checkPastTimestampWindow(trs)).to.be.undefined;
+    });
+
+    it('should error for a CHAT_MESSAGE transaction 1 slot before the earliest valid boundary', () => {
+      sinon.useFakeTimers({ now: constants.epochTime.getTime() + 100000 });
+
+      const trs = _.cloneDeep(validUnconfirmedTransaction);
+      trs.type = transactionTypes.CHAT_MESSAGE;
+      trs.timestamp = 94; // slot 18, just before the earliest valid slot (19)
+
+      expect(transaction.checkPastTimestampWindow(trs)).to.equal(
+          `Transaction timestamp is more than ${constants.maxTransactionAgeSec} seconds in the past`
+      );
+    });
+
+    it('should error for a CHAT_MESSAGE transaction well beyond the allowed past window', () => {
+      sinon.useFakeTimers({ now: constants.epochTime.getTime() + 100000 });
+
+      const trs = _.cloneDeep(validUnconfirmedTransaction);
+      trs.type = transactionTypes.CHAT_MESSAGE;
+      trs.timestamp = 50;
+
+      expect(transaction.checkPastTimestampWindow(trs)).to.equal(
+          `Transaction timestamp is more than ${constants.maxTransactionAgeSec} seconds in the past`
+      );
+    });
+
+    it('should not error for a STATE transaction within the allowed past window', () => {
+      sinon.useFakeTimers({ now: constants.epochTime.getTime() + 100000 });
+
+      const trs = _.cloneDeep(validUnconfirmedTransaction);
+      trs.type = transactionTypes.STATE;
+      trs.timestamp = 99;
+
+      expect(transaction.checkPastTimestampWindow(trs)).to.be.undefined;
+    });
+
+    it('should error for a STATE transaction beyond the allowed past window', () => {
+      sinon.useFakeTimers({ now: constants.epochTime.getTime() + 100000 });
+
+      const trs = _.cloneDeep(validUnconfirmedTransaction);
+      trs.type = transactionTypes.STATE;
+      trs.timestamp = 50;
+
+      expect(transaction.checkPastTimestampWindow(trs)).to.equal(
+          `Transaction timestamp is more than ${constants.maxTransactionAgeSec} seconds in the past`
+      );
+    });
+
+    it('should behave identically whether timestampMs is present or absent, since the past-window check ignores it', () => {
+      sinon.useFakeTimers({ now: constants.epochTime.getTime() + 100000 });
+
+      const withMs = _.cloneDeep(validUnconfirmedTransaction);
+      withMs.type = transactionTypes.CHAT_MESSAGE;
+      withMs.timestamp = 50;
+      withMs.timestampMs = 50000;
+
+      const withoutMs = _.cloneDeep(validUnconfirmedTransaction);
+      withoutMs.type = transactionTypes.CHAT_MESSAGE;
+      withoutMs.timestamp = 50;
+      delete withoutMs.timestampMs;
+
+      const expectedError = `Transaction timestamp is more than ${constants.maxTransactionAgeSec} seconds in the past`;
+
+      expect(transaction.checkPastTimestampWindow(withMs)).to.equal(expectedError);
+      expect(transaction.checkPastTimestampWindow(withoutMs)).to.equal(expectedError);
+    });
+
+    it('should reject the same stale chat transaction both before and after spaceship activation via objectNormalize', () => {
+      sinon.useFakeTimers({ now: constants.epochTime.getTime() + 100000 });
+      transaction.attachAssetType(transactionTypes.CHAT_MESSAGE, new Chat());
+
+      const buildTrs = () => {
+        const trs = _.cloneDeep(validUnconfirmedTransaction);
+        trs.type = transactionTypes.CHAT_MESSAGE;
+        trs.amount = 0;
+        trs.recipientId = 'U810656636599221322';
+        trs.asset = {
+          chat: {
+            message: '75582d940f2c4093929c99a6c1911b4753',
+            own_message: '58dceaa227b3fb1dd1c7d3fbf3eb5db6aeb6a03cb7e2ec91',
+            type: 1
+          }
+        };
+        trs.timestamp = 50;
+        trs.timestampMs = 50000;
+        delete trs.signature;
+        trs.signature = transaction.sign(testSenderKeypair, trs);
+        return trs;
+      };
+
+      const expectedError = `Transaction timestamp is more than ${constants.maxTransactionAgeSec} seconds in the past`;
+
+      dummyHeight = consensusActivationHeights.spaceship - 1;
+      const preSpaceship = transaction.objectNormalize(buildTrs());
+      expect(preSpaceship).to.not.have.property('timestampMs');
+      expect(transaction.checkPastTimestampWindow(preSpaceship)).to.equal(expectedError);
+
+      dummyHeight = consensusActivationHeights.spaceship;
+      const postSpaceship = transaction.objectNormalize(buildTrs());
+      expect(postSpaceship).to.have.property('timestampMs');
+      expect(transaction.checkPastTimestampWindow(postSpaceship)).to.equal(expectedError);
+
+      dummyHeight = 1;
+    });
+  });
+
   describe('verifySignature()', () => {
     it('should throw an error with no param', () => {
       expect(transaction.verifySignature).to.throw();


### PR DESCRIPTION
## Description

Closes a P2P transaction-admission gap: a transaction with a far-future `timestamp` could bypass the future-timestamp admission grace by arriving from a peer instead of the Public API.

`Transaction.prototype.publish()` (the Public API submission path) checks the transaction's timestamp against a future-timestamp grace window (`maxTransactionFutureMs`) and, for chat/state transactions, a past-timestamp allowance (`maxTransactionAgeSec`). Transactions arriving via P2P gossip go through `modules/transport.js` `__private.receiveTransaction()` instead, which never called this check - `logic/transaction.js` `verify()` (the function that path eventually reaches) intentionally does not enforce it, because `verify()` also re-validates historical, already-confirmed transactions during block processing and sync, where a wall-clock-relative check would not be replay-deterministic. This constraint is documented in `AGENTS.md` ("Current Activation Switches") and `AI_AGENT_NOTES.md` §4.

This PR:
- Extracts the two timestamp checks already used by `publish()` into named helpers on `Transaction.prototype`: `checkFutureTimestamp()` and `checkPastTimestampWindow()`. `publish()`'s behavior is unchanged - this part is a pure refactor.
- Adds the same `checkFutureTimestamp()`/`checkPastTimestampWindow()` checks to `modules/transport.js` `__private.receiveTransaction()`, applied once, right after `objectNormalize()` and before the transaction reaches the unconfirmed pool - the real-time P2P ingestion boundary, mirroring `publish()`'s real-time Public API boundary.
- Leaves `logic/transaction.js` `verify()` itself byte-for-byte identical to current `dev` - no change to the replay/block-validation path, no new consensus activation switch needed, no fork risk.

## Related issue

Closes #245

## Breaking changes

None. This only tightens P2P admission of loose (not yet confirmed) transactions; it does not change block, transaction, or signature byte semantics, and does not affect already-confirmed transactions or sync/replay behavior.

## How to test

- `npm run test:single -- test/unit/logic/transaction.js` - `publish()` behavior is unchanged (same error strings, same conditions), only its internals were extracted into two helper methods.
- Manual/peer test: have a peer relay a transaction with `timestamp` set far in the future (e.g. `slots.getTime() + 100000`) directly via `POST /peer/transactions` or the `transactions/change` WS event (bypassing `publish()`). Expect the receiving node to reject it with `Transaction timestamp is in the future` instead of admitting it to the unconfirmed pool.
- Confirm historical sync from height 0 is unaffected: `checkFutureTimestamp()` and `checkPastTimestampWindow()` are not called from `verify()`, so block replay/sync paths are untouched.

## Notes for reviewers

- This is a sequel to the [PR #244](https://github.com/Adamant-im/adamant/pull/244) release review, where the original gap was first identified as an inline PR comment and discussed further in conversation; this PR implements the resolution agreed there rather than re-adding the check to `verify()`.
- Per `AGENTS.md` "Non-Negotiable Consensus Rules" / "Protocol Upgrade Rules", I deliberately avoided introducing a new `consensusActivationHeights` switch here: this is real-time admission control (a spam/pool-poisoning guard), not a consensus rule, so it does not need height-gating and applies uniformly going forward.
- Full validation (`npm run test:unit`, `npm run test:api`) was not run in this environment; targeted/fast validation only (see Testing performed below).

## Testing performed

- `ESLINT_USE_FLAT_CONFIG=false` via `npx grunt eslint-nofix --verbose` on the full `api, helpers, modules, logic, schema, tasks, test` target: passed, no errors.
- `node -c logic/transaction.js`, `node -c modules/transport.js`: syntax-valid.
- `npm run test:single -- test/unit/logic/transaction.js`: attempted, blocked in this sandbox by a native `libpq` binding issue unrelated to this change (`Could not locate the bindings file`); not executed end-to-end here. Please run this in CI/a working local environment before merge.
- Did not run `npm run test:unit` (full suite) or `npm run test:api` (requires a running testnet) - not executed in this environment; please run before merge per `AGENTS.md` "Full validation" policy for transaction/P2P changes.

## Checklist

- [x] Code is formatted (lint passed)
- [ ] Tests added/updated (no new automated test added for the `transport.js` boundary; existing `publish()` unit tests cover the extracted helpers' behavior)
- [ ] Documentation updated (not needed - no public API/schema/protocol change)
- [ ] Changes tested in all relevant environments (blocked here by sandbox `libpq` binding issue; needs CI/maintainer run)
