### PR TITLE
Fix: Sync watchdog so a stalled sync cannot wedge the node

### DIFF
--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -58,6 +58,10 @@ module.exports = {
     maxReconnectDelay: 60000,
     defaultReconnectionDelay: 5000
   },
+  // Maximum time a single sync run may go without applying a new block before it
+  // is treated as stalled and aborted so the loader can recover (liveness only,
+  // not a consensus parameter). Set to 0 to disable the sync watchdog.
+  syncStallTimeout: 1000 * 60 * 5, // 5 minutes without block progress
   fees: {
     send: 50000000,
     vote: 5000000000,

--- a/helpers/syncWatchdog.js
+++ b/helpers/syncWatchdog.js
@@ -1,0 +1,86 @@
+'use strict';
+
+/**
+ * Creates a progress-based watchdog for a single blockchain sync run.
+ *
+ * The node serializes a sync attempt through callback-based async flows. If any
+ * inner step fails to invoke its callback (for example a swallowed callback in
+ * the block-processing path), the sync state machine never reaches its
+ * completion handler. That leaves `loader.syncing()` permanently true, which in
+ * turn makes the node reject every live block and never start a recovery sync.
+ * The result is a node that is frozen at a height while still connected to the
+ * network, requiring a manual restart.
+ *
+ * This watchdog guards against that failure mode. It periodically samples the
+ * current blockchain height; if no new block is applied within `timeoutMs`, it
+ * invokes `onStall` exactly once so the caller can abort the stalled sync and
+ * let a fresh attempt start.
+ *
+ * It is intentionally liveness-only: it never inspects, validates, or mutates
+ * block or chain state. It only observes whether height is advancing and signals
+ * a lack of progress. Because the check is "did height advance within the
+ * window", a slow-but-progressing sync (a node many blocks behind that keeps
+ * applying blocks) is never aborted — only a genuinely stalled run is.
+ *
+ * @param {object} options
+ * @param {number} options.timeoutMs - Maximum time without block progress before
+ *   a stall is declared. Values `<= 0` (or non-finite) disable the watchdog.
+ * @param {Function} options.getHeight - Returns the current blockchain height.
+ * @param {Function} options.onStall - Called once, with the last observed height,
+ *   when no block progress is detected within the window.
+ * @return {{ start: Function, stop: Function }}
+ */
+function createSyncWatchdog (options) {
+  const timeoutMs = options.timeoutMs;
+  const getHeight = options.getHeight;
+  const onStall = options.onStall;
+
+  const enabled = Number.isFinite(timeoutMs) && timeoutMs > 0;
+
+  let timer = null;
+  let lastHeight = 0;
+  let fired = false;
+
+  function stop () {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  function tick () {
+    const height = getHeight();
+
+    // Progress observed within the window: remember it and keep waiting.
+    if (height > lastHeight) {
+      lastHeight = height;
+      return;
+    }
+
+    // No new block was applied for the whole window: the sync is stalled.
+    fired = true;
+    stop();
+    onStall(height);
+  }
+
+  function start () {
+    if (!enabled || timer || fired) {
+      return;
+    }
+
+    lastHeight = getHeight();
+    timer = setInterval(tick, timeoutMs);
+
+    // The watchdog must not by itself keep the process alive.
+    if (timer && typeof timer.unref === 'function') {
+      timer.unref();
+    }
+  }
+
+  return {
+    start: start,
+    stop: stop
+  };
+}
+
+module.exports = createSyncWatchdog;

--- a/modules/blocks/process.js
+++ b/modules/blocks/process.js
@@ -292,7 +292,9 @@ Process.prototype.loadBlocksFromPeer = function (peer, cb, shouldStop) {
 
   // Process single block
   function processBlock (block, seriesCb) {
-    // Start block processing - broadcast: false, saveBlock: true
+    // Start block processing - broadcast: false, saveBlock: true.
+    // `shouldStop` is forwarded so an aborted sync run cannot apply the block
+    // even if the abort lands while it is mid-verification.
     modules.blocks.verify.processBlock(block, false, function (err) {
       if (!err) {
         // Update last valid block
@@ -304,7 +306,7 @@ Process.prototype.loadBlocksFromPeer = function (peer, cb, shouldStop) {
         library.logger.debug('loader', 'Block processing failed', { id: id, err: err.toString(), module: 'blocks', block: block });
       }
       return seriesCb(err);
-    }, true);
+    }, true, shouldStop);
   }
 
   async.waterfall([

--- a/modules/blocks/verify.js
+++ b/modules/blocks/verify.js
@@ -402,10 +402,14 @@ Verify.prototype.verifyBlock = function (block) {
  * @param  {boolean}  broadcast Indicator that block needs to be broadcasted
  * @param  {Function} cb Callback function
  * @param  {boolean}  saveBlock Indicator that block needs to be saved to database
+ * @param  {Function} [shouldStop] Optional predicate; when it returns true the
+ *   block is verified but not applied. Used by the loader so a sync run that was
+ *   aborted (e.g. by the stall watchdog) can never apply a block, regardless of
+ *   where it was parked when the abort happened.
  * @return {Function} cb Callback function from params (through setImmediate)
  * @return {object}   cb.err Error if occurred
  */
-Verify.prototype.processBlock = function (block, broadcast, cb, saveBlock) {
+Verify.prototype.processBlock = function (block, broadcast, cb, saveBlock, shouldStop) {
   if (modules.blocks.isCleaning.get()) {
     // Break processing if node shutdown requested
     return setImmediate(cb, 'Cleaning up');
@@ -472,6 +476,13 @@ Verify.prototype.processBlock = function (block, broadcast, cb, saveBlock) {
   }, function (err) {
     if (err) {
       return setImmediate(cb, err);
+    } else if (shouldStop && shouldStop()) {
+      // The sync run owning this block was aborted (e.g. by the loader stall
+      // watchdog) while the block was being verified. Stop here, before the only
+      // state mutation: applyBlock() writes mem/account/round state outside
+      // library.sequence, so applying now could race a freshly started run.
+      library.logger.debug('blocks', 'Skipping block application: sync aborted before apply', { id: block.id });
+      return setImmediate(cb, 'Sync aborted before applying block');
     } else {
       // The block and the transactions are OK i.e:
       // * Block and transactions have valid values (signatures, block slots, etc...)

--- a/modules/blocks/verify.js
+++ b/modules/blocks/verify.js
@@ -37,10 +37,13 @@ function Verify (logger, block, transaction, db) {
  * @param  {object}   block Block object
  * @param  {object}   transaction Transaction object
  * @param  {Function} cb Callback function
+ * @param  {Function} [shouldStop] Optional predicate; when it returns true the
+ *   fork-2 unconfirmed-pool write is skipped so an aborted sync run performs no
+ *   pre-apply state mutation.
  * @return {Function} cb Callback function from params (through setImmediate)
  * @return {object}   cb.err Error if occurred
  */
-__private.checkTransaction = function (block, transaction, cb) {
+__private.checkTransaction = function (block, transaction, cb, shouldStop) {
   async.waterfall([
     function (waterCb) {
       try {
@@ -61,6 +64,14 @@ __private.checkTransaction = function (block, transaction, cb) {
         if (err) {
           // Fork: Transaction already confirmed.
           modules.delegates.fork(block, 2);
+
+          if (shouldStop && shouldStop()) {
+            // Sync aborted: do not mutate the volatile unconfirmed pool. The
+            // block is rejected anyway and the pool is rebuilt on the next run.
+            library.logger.debug('blocks', 'Skipping unconfirmed undo: sync aborted', { id: transaction.id });
+            return setImmediate(waterCb, err);
+          }
+
           // Undo the offending transaction.
           // DATABASE: write
           modules.transactions.undoUnconfirmed(transaction, function (err2) {
@@ -468,7 +479,7 @@ Verify.prototype.processBlock = function (block, broadcast, cb, saveBlock, shoul
     checkTransactions: function (seriesCb) {
       // Check against the mem_* tables that we can perform the transactions included in the block
       async.eachSeries(block.transactions, function (transaction, eachSeriesCb) {
-        __private.checkTransaction(block, transaction, eachSeriesCb);
+        __private.checkTransaction(block, transaction, eachSeriesCb, shouldStop);
       }, function (err) {
         return setImmediate(seriesCb, err);
       });

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -743,22 +743,26 @@ __private.sync = function (cb) {
         blocksToSync: __private.blocksToSync,
         timeoutMs: __private.syncTimeout
       });
-      // Signal the in-flight series to bail at its next safe checkpoint, then
-      // release the sync state once block application is idle.
+      // Set the run's abort flag, then release the sync state once any mutation
+      // that was already in progress has drained.
       aborted = true;
       finishStalled();
     }
   });
 
-  // Releases the sync state after a watchdog abort, but only once no state
-  // mutation is in flight. Block application (`applyBlock()`) and the unconfirmed
-  // undo/apply phases write mem/account/round/pool state outside
-  // `library.sequence`, so advancing the outer sequence while any of them runs
-  // could let a new sync or live block mutate the same state concurrently. We
-  // therefore wait for both `modules.blocks.isActive` and the run-local
-  // `mutatingState` to clear before tearing down. If the in-flight series reaches
-  // a checkpoint first, it finishes the run itself and this becomes a no-op via
-  // the `settled` guard.
+  // Recovery rests on one invariant: once `aborted` is set, this run can never
+  // begin a new state mutation.
+  //   - New block apply is blocked because `shouldStop()` is threaded into
+  //     `processBlock()` and checked right before `applyBlock()`, so a block
+  //     parked anywhere in verification bails before mutating when it resumes.
+  //   - New unconfirmed undo/apply phases are blocked by `skipOnStop()`.
+  // That makes it safe to release `loader.syncing()` even while an abandoned
+  // flow is still parked. The only thing left to guard is a mutation that had
+  // *already started* before the abort: `applyBlock()` and the unconfirmed
+  // phases write mem/account/round/pool state outside `library.sequence`, so we
+  // wait for `modules.blocks.isActive` and the run-local `mutatingState` to
+  // clear before tearing down. If the in-flight series reaches a checkpoint
+  // first, it finishes the run itself and this becomes a no-op via `settled`.
   function finishStalled () {
     if (settled) {
       return;

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -26,10 +26,6 @@ __private.syncInterval = 10000;
 __private.retries = 5;
 __private.stopRequested = false;
 __private.shutdownRequested = false;
-// Set true when the watchdog aborts a stalled sync; signals the in-flight sync
-// to bail at its next safe checkpoint without disabling future syncs (unlike
-// `stopRequested`, which is reserved for shutdown).
-__private.abortSync = false;
 // Maximum time a single sync run may go without block progress before it is
 // considered stalled and aborted so the loader can recover.
 __private.syncTimeout = constants.syncStallTimeout;
@@ -127,14 +123,12 @@ __private.requestStop = function () {
 };
 
 /**
- * Checks whether in-flight loader work should stop at its next safe boundary.
- * True on shutdown (`stopRequested`) or when the watchdog aborted a stalled
- * sync (`abortSync`).
+ * Checks if shutdown was requested.
  * @private
  * @return {boolean}
  */
 __private.isStopRequested = function () {
-  return __private.stopRequested || __private.abortSync;
+  return __private.stopRequested;
 };
 
 /**
@@ -605,9 +599,14 @@ __private.loadBlockChain = function () {
  * @implements {modules.blocks.getCommonBlock}
  * @return {setImmediateCallback} cb, err
  */
-__private.loadBlocksFromNetwork = function (cb) {
+__private.loadBlocksFromNetwork = function (cb, shouldStop) {
   var errorCount = 0;
   var loaded = false;
+
+  // Per-run stop predicate. Defaults to the shutdown signal; the sync watchdog
+  // passes a run-scoped predicate so an aborted run keeps its own stop signal
+  // and a fresh run cannot accidentally clear it.
+  shouldStop = shouldStop || __private.isStopRequested;
 
   self.getNetwork(function (err, network) {
     if (err) {
@@ -615,7 +614,7 @@ __private.loadBlocksFromNetwork = function (cb) {
     } else {
       async.whilst(
           function (testCb) {
-            return testCb(null, !__private.isStopRequested() && !loaded && errorCount < 5);
+            return testCb(null, !shouldStop() && !loaded && errorCount < 5);
           },
           function (next) {
             var peer = network.peers[Math.floor(Math.random() * network.peers.length)];
@@ -632,7 +631,7 @@ __private.loadBlocksFromNetwork = function (cb) {
                 loaded = lastValidBlock.id === lastBlock.id;
                 lastValidBlock = lastBlock = null;
                 next();
-              }, __private.isStopRequested);
+              }, shouldStop);
             }
 
             function getCommonBlock (cb) {
@@ -697,15 +696,24 @@ __private.sync = function (cb) {
   });
   library.bus.message('syncStarted');
 
-  __private.abortSync = false;
   __private.isActive = true;
   __private.syncTrigger(true);
 
+  // Run-scoped abort flag. Kept local (not on `__private`) so a fresh sync run
+  // can never clear the stop signal of an earlier, still-alive run, and so it
+  // stays distinct from the shutdown-only `stopRequested`.
+  var aborted = false;
   // Completion is funnelled through finishSync() and guarded by `settled` so the
-  // watchdog and the natural async.series completion are mutually exclusive: a
-  // stalled sync that the watchdog aborts releases the sync state exactly once,
-  // and a later (abandoned) completion of the series becomes a harmless no-op.
+  // watchdog and the natural async.series completion are mutually exclusive: the
+  // sync state is released exactly once, and a later (abandoned) completion of
+  // the series becomes a harmless no-op.
   var settled = false;
+
+  // Shutdown or this run's watchdog abort both stop the in-flight series at its
+  // next safe checkpoint.
+  function shouldStop () {
+    return __private.stopRequested || aborted;
+  }
 
   var watchdog = createSyncWatchdog({
     timeoutMs: __private.syncTimeout,
@@ -718,12 +726,36 @@ __private.sync = function (cb) {
         blocksToSync: __private.blocksToSync,
         timeoutMs: __private.syncTimeout
       });
-      // Ask the in-flight series to bail at its next safe checkpoint, then
-      // release the sync state so the sync timer can start a fresh attempt.
-      __private.abortSync = true;
-      finishSync('Sync watchdog timeout: no block progress');
+      // Signal the in-flight series to bail at its next safe checkpoint, then
+      // release the sync state once block application is idle.
+      aborted = true;
+      finishStalled();
     }
   });
+
+  // Releases the sync state after a watchdog abort, but only once no block is
+  // mid-application. `applyBlock()` writes mem/account/round state outside
+  // `library.sequence`, so advancing the outer sequence while it runs could let
+  // a new sync or live block mutate the same state concurrently. We therefore
+  // wait for `modules.blocks.isActive` to clear before tearing down. If the
+  // in-flight series reaches a checkpoint first, it finishes the run itself and
+  // this becomes a no-op via the `settled` guard.
+  function finishStalled () {
+    if (settled) {
+      return;
+    }
+
+    if (modules.blocks.isActive.get()) {
+      library.logger.warn('loader', 'Sync watchdog: waiting for in-flight block application to finish before recovery', {
+        height: modules.blocks.lastBlock.get().height
+      });
+      return setTimeout(finishStalled, 1000);
+    }
+
+    // Terminal for this attempt: report no error so the async.retry wrapper does
+    // not immediately restart the sync; the sync timer starts a fresh attempt.
+    return finishSync(null);
+  }
 
   function finishSync (err) {
     if (settled) {
@@ -737,14 +769,14 @@ __private.sync = function (cb) {
     __private.blocksToSync = 0;
 
     // After an abort, drop the cached network so the next attempt re-selects peers.
-    if (__private.abortSync) {
+    if (aborted) {
       __private.initialize();
     }
 
     library.logger.info('loader', __private.stopRequested ? 'Sync stopped for shutdown' : 'Finished sync', {
       height: modules.blocks.lastBlock.get().height,
       stopped: __private.stopRequested,
-      aborted: __private.abortSync,
+      aborted: aborted,
       error: err ? err.message || err : null
     });
     library.bus.message('syncFinished');
@@ -752,7 +784,7 @@ __private.sync = function (cb) {
   }
 
   function skipOnStop (seriesCb, next) {
-    if (__private.isStopRequested()) {
+    if (shouldStop()) {
       return setImmediate(seriesCb);
     }
 
@@ -780,7 +812,9 @@ __private.sync = function (cb) {
       });
     },
     loadBlocksFromNetwork: function (seriesCb) {
-      return skipOnStop(seriesCb, __private.loadBlocksFromNetwork);
+      return skipOnStop(seriesCb, function (next) {
+        return __private.loadBlocksFromNetwork(next, shouldStop);
+      });
     },
     updateSystem: function (seriesCb) {
       return skipOnStop(seriesCb, function (next) {

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -2,6 +2,7 @@
 
 var async = require('async');
 var constants = require('../helpers/constants.js');
+var createSyncWatchdog = require('../helpers/syncWatchdog.js');
 var jobsQueue = require('../helpers/jobsQueue.js');
 var ip = require('neoip');
 var sandboxHelper = require('../helpers/sandbox.js');
@@ -25,6 +26,13 @@ __private.syncInterval = 10000;
 __private.retries = 5;
 __private.stopRequested = false;
 __private.shutdownRequested = false;
+// Set true when the watchdog aborts a stalled sync; signals the in-flight sync
+// to bail at its next safe checkpoint without disabling future syncs (unlike
+// `stopRequested`, which is reserved for shutdown).
+__private.abortSync = false;
+// Maximum time a single sync run may go without block progress before it is
+// considered stalled and aborted so the loader can recover.
+__private.syncTimeout = constants.syncStallTimeout;
 
 /**
  * Initializes library with scope content.
@@ -119,12 +127,14 @@ __private.requestStop = function () {
 };
 
 /**
- * Checks if shutdown was requested.
+ * Checks whether in-flight loader work should stop at its next safe boundary.
+ * True on shutdown (`stopRequested`) or when the watchdog aborted a stalled
+ * sync (`abortSync`).
  * @private
  * @return {boolean}
  */
 __private.isStopRequested = function () {
-  return __private.stopRequested;
+  return __private.stopRequested || __private.abortSync;
 };
 
 /**
@@ -605,7 +615,7 @@ __private.loadBlocksFromNetwork = function (cb) {
     } else {
       async.whilst(
           function (testCb) {
-            return testCb(null, !__private.stopRequested && !loaded && errorCount < 5);
+            return testCb(null, !__private.isStopRequested() && !loaded && errorCount < 5);
           },
           function (next) {
             var peer = network.peers[Math.floor(Math.random() * network.peers.length)];
@@ -687,16 +697,69 @@ __private.sync = function (cb) {
   });
   library.bus.message('syncStarted');
 
+  __private.abortSync = false;
   __private.isActive = true;
   __private.syncTrigger(true);
 
+  // Completion is funnelled through finishSync() and guarded by `settled` so the
+  // watchdog and the natural async.series completion are mutually exclusive: a
+  // stalled sync that the watchdog aborts releases the sync state exactly once,
+  // and a later (abandoned) completion of the series becomes a harmless no-op.
+  var settled = false;
+
+  var watchdog = createSyncWatchdog({
+    timeoutMs: __private.syncTimeout,
+    getHeight: function () {
+      return modules.blocks.lastBlock.get().height;
+    },
+    onStall: function (height) {
+      library.logger.error('loader', 'Sync watchdog: no block progress, aborting stalled sync to allow recovery', {
+        height: height,
+        blocksToSync: __private.blocksToSync,
+        timeoutMs: __private.syncTimeout
+      });
+      // Ask the in-flight series to bail at its next safe checkpoint, then
+      // release the sync state so the sync timer can start a fresh attempt.
+      __private.abortSync = true;
+      finishSync('Sync watchdog timeout: no block progress');
+    }
+  });
+
+  function finishSync (err) {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    watchdog.stop();
+
+    __private.isActive = false;
+    __private.syncTrigger(false);
+    __private.blocksToSync = 0;
+
+    // After an abort, drop the cached network so the next attempt re-selects peers.
+    if (__private.abortSync) {
+      __private.initialize();
+    }
+
+    library.logger.info('loader', __private.stopRequested ? 'Sync stopped for shutdown' : 'Finished sync', {
+      height: modules.blocks.lastBlock.get().height,
+      stopped: __private.stopRequested,
+      aborted: __private.abortSync,
+      error: err ? err.message || err : null
+    });
+    library.bus.message('syncFinished');
+    return setImmediate(cb, err);
+  }
+
   function skipOnStop (seriesCb, next) {
-    if (__private.stopRequested) {
+    if (__private.isStopRequested()) {
       return setImmediate(seriesCb);
     }
 
     return next(seriesCb);
   }
+
+  watchdog.start();
 
   async.series({
     undoUnconfirmedList: function (seriesCb) {
@@ -742,17 +805,7 @@ __private.sync = function (cb) {
       });
     }
   }, function (err) {
-    __private.isActive = false;
-    __private.syncTrigger(false);
-    __private.blocksToSync = 0;
-
-    library.logger.info('loader', __private.stopRequested ? 'Sync stopped for shutdown' : 'Finished sync', {
-      height: modules.blocks.lastBlock.get().height,
-      stopped: __private.stopRequested,
-      error: err ? err.message || err : null
-    });
-    library.bus.message('syncFinished');
-    return setImmediate(cb, err);
+    return finishSync(err);
   });
 };
 

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -708,11 +708,28 @@ __private.sync = function (cb) {
   // sync state is released exactly once, and a later (abandoned) completion of
   // the series becomes a harmless no-op.
   var settled = false;
+  // True while a sync phase that mutates unconfirmed account/pool state is in
+  // flight. Block application is tracked separately by `modules.blocks.isActive`.
+  // The watchdog must not tear the run down while either is set, otherwise it
+  // could advance `library.sequence` while an abandoned mutation is still alive.
+  var mutatingState = false;
 
   // Shutdown or this run's watchdog abort both stop the in-flight series at its
   // next safe checkpoint.
   function shouldStop () {
     return __private.stopRequested || aborted;
+  }
+
+  // Wraps a state-mutating sync phase so the watchdog defers teardown until the
+  // phase's callback has actually returned.
+  function mutating (run) {
+    return function (next) {
+      mutatingState = true;
+      return run(function (err) {
+        mutatingState = false;
+        return next(err);
+      });
+    };
   }
 
   var watchdog = createSyncWatchdog({
@@ -733,21 +750,25 @@ __private.sync = function (cb) {
     }
   });
 
-  // Releases the sync state after a watchdog abort, but only once no block is
-  // mid-application. `applyBlock()` writes mem/account/round state outside
-  // `library.sequence`, so advancing the outer sequence while it runs could let
-  // a new sync or live block mutate the same state concurrently. We therefore
-  // wait for `modules.blocks.isActive` to clear before tearing down. If the
-  // in-flight series reaches a checkpoint first, it finishes the run itself and
-  // this becomes a no-op via the `settled` guard.
+  // Releases the sync state after a watchdog abort, but only once no state
+  // mutation is in flight. Block application (`applyBlock()`) and the unconfirmed
+  // undo/apply phases write mem/account/round/pool state outside
+  // `library.sequence`, so advancing the outer sequence while any of them runs
+  // could let a new sync or live block mutate the same state concurrently. We
+  // therefore wait for both `modules.blocks.isActive` and the run-local
+  // `mutatingState` to clear before tearing down. If the in-flight series reaches
+  // a checkpoint first, it finishes the run itself and this becomes a no-op via
+  // the `settled` guard.
   function finishStalled () {
     if (settled) {
       return;
     }
 
-    if (modules.blocks.isActive.get()) {
-      library.logger.warn('loader', 'Sync watchdog: waiting for in-flight block application to finish before recovery', {
-        height: modules.blocks.lastBlock.get().height
+    if (mutatingState || modules.blocks.isActive.get()) {
+      library.logger.warn('loader', 'Sync watchdog: waiting for in-flight state mutation to finish before recovery', {
+        height: modules.blocks.lastBlock.get().height,
+        unconfirmedMutation: mutatingState,
+        blockApplication: modules.blocks.isActive.get()
       });
       return setTimeout(finishStalled, 1000);
     }
@@ -795,12 +816,12 @@ __private.sync = function (cb) {
 
   async.series({
     undoUnconfirmedList: function (seriesCb) {
-      return skipOnStop(seriesCb, function (next) {
+      return skipOnStop(seriesCb, mutating(function (next) {
         library.logger.debug('loader', 'Undoing unconfirmed transactions before sync', {
           height: modules.blocks.lastBlock.get().height
         });
         return modules.transactions.undoUnconfirmedList(next);
-      });
+      }));
     },
     getPeersBefore: function (seriesCb) {
       return skipOnStop(seriesCb, function (next) {
@@ -831,12 +852,12 @@ __private.sync = function (cb) {
       });
     },
     applyUnconfirmedList: function (seriesCb) {
-      return skipOnStop(seriesCb, function (next) {
+      return skipOnStop(seriesCb, mutating(function (next) {
         library.logger.debug('loader', 'Applying unconfirmed transactions after sync', {
           height: modules.blocks.lastBlock.get().height
         });
         return modules.transactions.applyUnconfirmedList(next);
-      });
+      }));
     }
   }, function (err) {
     return finishSync(err);

--- a/test/unit/helpers/syncWatchdog.js
+++ b/test/unit/helpers/syncWatchdog.js
@@ -1,0 +1,143 @@
+'use strict';
+
+const { expect } = require('chai');
+const sinon = require('sinon');
+
+const createSyncWatchdog = require('../../../helpers/syncWatchdog.js');
+
+describe('helpers/syncWatchdog', () => {
+  let clock;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(() => {
+    clock.restore();
+  });
+
+  it('fires onStall once when height does not advance within the window', () => {
+    const onStall = sinon.spy();
+    const watchdog = createSyncWatchdog({
+      timeoutMs: 1000,
+      getHeight: () => 100,
+      onStall
+    });
+
+    watchdog.start();
+    expect(onStall.called).to.equal(false);
+
+    // Sample once with no progress -> stall declared.
+    clock.tick(1000);
+    expect(onStall.calledOnce).to.equal(true);
+    expect(onStall.firstCall.args[0]).to.equal(100);
+
+    // It stops itself after firing and never fires again.
+    clock.tick(5000);
+    expect(onStall.calledOnce).to.equal(true);
+  });
+
+  it('does not fire while height keeps advancing', () => {
+    const onStall = sinon.spy();
+    let height = 100;
+    const watchdog = createSyncWatchdog({
+      timeoutMs: 1000,
+      getHeight: () => height,
+      onStall
+    });
+
+    watchdog.start();
+
+    for (let i = 0; i < 10; i++) {
+      height += 1; // progress every window
+      clock.tick(1000);
+    }
+
+    expect(onStall.called).to.equal(false);
+  });
+
+  it('fires only after progress stops following earlier progress', () => {
+    const onStall = sinon.spy();
+    let height = 100;
+    const watchdog = createSyncWatchdog({
+      timeoutMs: 1000,
+      getHeight: () => height,
+      onStall
+    });
+
+    watchdog.start();
+
+    // Two windows with progress.
+    height = 150;
+    clock.tick(1000);
+    height = 200;
+    clock.tick(1000);
+    expect(onStall.called).to.equal(false);
+
+    // Now height freezes for a full window -> stall.
+    clock.tick(1000);
+    expect(onStall.calledOnce).to.equal(true);
+    expect(onStall.firstCall.args[0]).to.equal(200);
+  });
+
+  it('treats a height that goes backwards (no forward progress) as a stall', () => {
+    const onStall = sinon.spy();
+    let height = 200;
+    const watchdog = createSyncWatchdog({
+      timeoutMs: 1000,
+      getHeight: () => height,
+      onStall
+    });
+
+    watchdog.start();
+    height = 199; // not greater than last observed -> no progress
+    clock.tick(1000);
+
+    expect(onStall.calledOnce).to.equal(true);
+  });
+
+  it('does not fire after stop()', () => {
+    const onStall = sinon.spy();
+    const watchdog = createSyncWatchdog({
+      timeoutMs: 1000,
+      getHeight: () => 100,
+      onStall
+    });
+
+    watchdog.start();
+    watchdog.stop();
+    clock.tick(10000);
+
+    expect(onStall.called).to.equal(false);
+  });
+
+  it('is disabled when timeoutMs is zero or non-finite', () => {
+    const onStall = sinon.spy();
+    const getHeight = sinon.stub().returns(100);
+
+    [0, -1, NaN, Infinity, undefined].forEach((timeoutMs) => {
+      const watchdog = createSyncWatchdog({ timeoutMs, getHeight, onStall });
+      watchdog.start();
+    });
+
+    clock.tick(100000);
+    expect(onStall.called).to.equal(false);
+    expect(getHeight.called).to.equal(false);
+  });
+
+  it('is idempotent on start() and does not stack timers', () => {
+    const onStall = sinon.spy();
+    const watchdog = createSyncWatchdog({
+      timeoutMs: 1000,
+      getHeight: () => 100,
+      onStall
+    });
+
+    watchdog.start();
+    watchdog.start();
+    watchdog.start();
+
+    clock.tick(1000);
+    expect(onStall.calledOnce).to.equal(true);
+  });
+});

--- a/test/unit/modules/blocks.process.js
+++ b/test/unit/modules/blocks.process.js
@@ -180,4 +180,16 @@ describe('blocks process', function () {
       done();
     });
   });
+
+  it('should forward the shouldStop predicate to verify.processBlock', function (done) {
+    blocks.verify.processBlock = sinon.stub().callsArgWith(2, null);
+    const shouldStop = function () { return false; };
+
+    process.loadBlocksFromPeer({ ip: '127.0.0.1', port: 36667 }, function () {
+      expect(blocks.verify.processBlock.calledOnce).to.equal(true);
+      // processBlock(block, broadcast, cb, saveBlock, shouldStop)
+      expect(blocks.verify.processBlock.firstCall.args[4]).to.equal(shouldStop);
+      done();
+    }, shouldStop);
+  });
 });

--- a/test/unit/modules/blocks.process.js
+++ b/test/unit/modules/blocks.process.js
@@ -116,6 +116,32 @@ describe('blocks process', function () {
     expect(sequence.add.calledOnce).to.equal(true);
   });
 
+  it('should not queue live blocks before the node is ready to sync', function () {
+    loader.isReadyToSync.returns(false);
+
+    process.onReceiveBlock({ id: '2' });
+
+    expect(sequence.add.called).to.equal(false);
+    expect(logger.debug.calledWith(
+        'loader',
+        'Client not yet ready to receive block',
+        '2'
+    )).to.equal(true);
+  });
+
+  it('should not queue live blocks while a round is ticking', function () {
+    rounds.ticking.returns(true);
+
+    process.onReceiveBlock({ id: '2' });
+
+    expect(sequence.add.called).to.equal(false);
+    expect(logger.debug.calledWith(
+        'loader',
+        'Client not yet ready to receive block',
+        '2'
+    )).to.equal(true);
+  });
+
   it('should stop loadBlocksOffset before applying the next block', function (done) {
     process.loadBlocksOffset(1, 0, true, function (err, result) {
       expect(err).to.equal(null);

--- a/test/unit/modules/blocks.verify.js
+++ b/test/unit/modules/blocks.verify.js
@@ -89,3 +89,71 @@ describe('blocks verify - processBlock shouldStop gate', function () {
     }, true);
   });
 });
+
+// The fork-2 branch in checkTransaction() writes to the volatile unconfirmed
+// pool (undoUnconfirmed) before the apply gate. When the run is aborted that
+// pre-apply write must be skipped too, so the abort boundary is explicit for
+// every pre-apply state mutation.
+describe('blocks verify - checkTransaction fork-2 shouldStop gate', function () {
+  let verify;
+  let logger;
+  let db;
+  let blockLogic;
+  let transactionLogic;
+  let transactions;
+  let delegates;
+  let applyBlock;
+
+  const block = { id: '2', height: 2, transactions: [{ id: 't1' }] };
+
+  beforeEach(function () {
+    logger = { trace: sinon.spy(), debug: sinon.spy(), error: sinon.spy(), info: sinon.spy() };
+    db = { query: sinon.stub().resolves([]) };
+    blockLogic = { objectNormalize: (b) => b };
+    transactionLogic = {
+      getId: sinon.stub().returns('t1'),
+      // checkConfirmed errors -> fork-2 path (transaction already confirmed)
+      checkConfirmed: sinon.stub().callsArgWith(1, 'Transaction is already confirmed'),
+      verify: sinon.stub().callsArgWith(2, null)
+    };
+    transactions = {
+      undoUnconfirmed: sinon.stub().callsArgWith(1, null),
+      removeUnconfirmedTransaction: sinon.spy()
+    };
+    delegates = {
+      validateBlockSlot: sinon.stub().callsArgWith(1, null),
+      fork: sinon.spy()
+    };
+    applyBlock = sinon.spy();
+
+    verify = new Verify(logger, blockLogic, transactionLogic, db);
+    sinon.stub(verify, 'verifyBlock').returns({ verified: true, errors: [] });
+    verify.onBind({
+      accounts: { getAccount: sinon.stub().callsArgWith(1, null, {}) },
+      blocks: { isCleaning: { get: () => false }, chain: { applyBlock } },
+      delegates,
+      transactions
+    });
+  });
+
+  it('skips the unconfirmed undo write when the run is aborted', function (done) {
+    verify.processBlock(block, false, function (err) {
+      expect(err).to.equal('Transaction is already confirmed');
+      expect(delegates.fork.calledWith(block, 2)).to.equal(true);
+      expect(transactions.undoUnconfirmed.called).to.equal(false);
+      expect(transactions.removeUnconfirmedTransaction.called).to.equal(false);
+      expect(applyBlock.called).to.equal(false);
+      done();
+    }, true, () => true);
+  });
+
+  it('performs the unconfirmed undo write when the run is not aborted', function (done) {
+    verify.processBlock(block, false, function (err) {
+      expect(err).to.equal('Transaction is already confirmed');
+      expect(transactions.undoUnconfirmed.calledOnce).to.equal(true);
+      expect(transactions.removeUnconfirmedTransaction.calledOnce).to.equal(true);
+      expect(applyBlock.called).to.equal(false);
+      done();
+    }, true, () => false);
+  });
+});

--- a/test/unit/modules/blocks.verify.js
+++ b/test/unit/modules/blocks.verify.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const { expect } = require('chai');
+const sinon = require('sinon');
+
+const Verify = require('../../../modules/blocks/verify.js');
+
+// Focused tests for the `shouldStop` gate added to processBlock(): an aborted
+// sync run must verify but never apply a block, so a run the loader watchdog
+// abandons can never mutate chain state when it resumes.
+describe('blocks verify - processBlock shouldStop gate', function () {
+  let verify;
+  let logger;
+  let db;
+  let blockLogic;
+  let applyBlock;
+  let delegates;
+
+  beforeEach(function () {
+    logger = { trace: sinon.spy(), debug: sinon.spy(), error: sinon.spy(), info: sinon.spy() };
+    db = { query: sinon.stub().resolves([]) }; // checkExists: block id not in db
+    blockLogic = { objectNormalize: (block) => block };
+    applyBlock = sinon.spy();
+    delegates = {
+      validateBlockSlot: sinon.stub().callsArgWith(1, null),
+      fork: sinon.spy()
+    };
+
+    verify = new Verify(logger, blockLogic, {}, db);
+    // Bypass the heavy sanity-check pipeline; we only care about the apply gate.
+    sinon.stub(verify, 'verifyBlock').returns({ verified: true, errors: [] });
+
+    verify.onBind({
+      accounts: {},
+      blocks: {
+        isCleaning: { get: () => false },
+        chain: { applyBlock }
+      },
+      delegates,
+      transactions: {}
+    });
+  });
+
+  function process (shouldStop, cb) {
+    verify.processBlock({ id: '2', height: 2, transactions: [] }, false, cb, true, shouldStop);
+  }
+
+  it('does not apply the block when shouldStop() returns true', function (done) {
+    process(() => true, function (err) {
+      expect(err).to.equal('Sync aborted before applying block');
+      expect(applyBlock.called).to.equal(false);
+      done();
+    });
+  });
+
+  it('applies the block when shouldStop() returns false', function (done) {
+    applyBlock = sinon.spy(function (block, broadcast, cb) {
+      return cb(null);
+    });
+    verify.onBind({
+      accounts: {},
+      blocks: { isCleaning: { get: () => false }, chain: { applyBlock } },
+      delegates,
+      transactions: {}
+    });
+
+    process(() => false, function (err) {
+      expect(err).to.equal(null);
+      expect(applyBlock.calledOnce).to.equal(true);
+      done();
+    });
+  });
+
+  it('applies the block when no shouldStop predicate is supplied (live/forge path)', function (done) {
+    applyBlock = sinon.spy(function (block, broadcast, cb) {
+      return cb(null);
+    });
+    verify.onBind({
+      accounts: {},
+      blocks: { isCleaning: { get: () => false }, chain: { applyBlock } },
+      delegates,
+      transactions: {}
+    });
+
+    verify.processBlock({ id: '2', height: 2, transactions: [] }, false, function (err) {
+      expect(err).to.equal(null);
+      expect(applyBlock.calledOnce).to.equal(true);
+      done();
+    }, true);
+  });
+});


### PR DESCRIPTION
## Description

A syncing node can wedge permanently: it freezes at a height, rejects every incoming live block with `Client not yet ready to receive block`, never starts another sync, and only a manual restart recovers it. The chain it built is valid — this is a **liveness/recovery defect in the sync state machine, not a consensus break**.

### Root cause

A single `__private.sync` run (`modules/loader.js`) is driven by callback-based `async` flows. If any inner step never invokes its callback (e.g. a swallowed callback in the block-processing path), the `async.series` completion handler never runs. That handler is the only place that clears the sync state, so:

1. `__private.syncIntervalId` stays set ⇒ `loader.syncing()` stays `true` forever.
2. `isReadyToReceiveBlock()` (`modules/blocks/process.js`) is `false` while `syncing()` ⇒ **every** live block is discarded.
3. `__private.syncTimer` only starts a new sync when `!syncing()` ⇒ no recovery sync is ever started.
4. The `sequence.add` wrapper task never completes, blocking the main `library.sequence` queue.

Diagnosed from a `dev` build syncing from height 0 that was frozen at height `26,420,804` for 3+ days: `Sync trigger` trace firing every second with zero `Starting sync`/`Finished sync`, `Client not yet ready to receive block` logged continuously, local tip matching the canonical chain byte-for-byte on public nodes (no fork), no stuck DB query, idle event loop.

### Fix

Add a **progress-based sync watchdog** (`helpers/syncWatchdog.js`). While a sync is active it samples blockchain height; if no new block is applied within a bounded window (`constants.syncStallTimeout`, default 5 min), it aborts the stalled run. The check is *"did height advance within the window"*, so a slow-but-progressing sync (a node far behind that keeps applying blocks) is **never** aborted — only a genuinely stalled run is.

Recovery rests on a single invariant: **once a run is aborted it can never *begin* a new state mutation; teardown only waits for a mutation already in flight to drain.**

- **Run-scoped abort.** Each `__private.sync` run owns a local `aborted` flag and a `shouldStop()` predicate (distinct from the shutdown-only `stopRequested`), so a fresh run can never clear an older run's signal.
- **Block apply is gated at the boundary.** `shouldStop()` is threaded `loadBlocksFromNetwork → loadBlocksFromPeer → verify.processBlock`, and `processBlock()` checks it **immediately before `applyBlock()`** — the chain-state mutation. A block parked anywhere in verification (`checkExists` / slot validation / tx checks) bails before applying when it resumes. The fork-2 `undoUnconfirmed` write inside `checkTransaction()` is gated the same way.
- **Unconfirmed phases** (`undoUnconfirmedList` / `applyUnconfirmedList`) are not started after abort (`skipOnStop`).
- **Drain before teardown.** `finishStalled()` releases `loader.syncing()` only once `modules.blocks.isActive` (a block apply mid-write) and the run-local `mutatingState` (an unconfirmed phase mid-write) are both clear. Completion is funnelled through a single `settled`-guarded `finishSync()`, so the watchdog and the natural `async.series` completion are mutually exclusive and a late (abandoned) completion is a harmless no-op. The watchdog abort reports no error to `async.retry`, so recovery comes from the next sync-timer tick rather than an immediate in-sequence retry.

This is **liveness-only**: for non-sync callers (`onReceiveBlock`, `generateBlock`) `shouldStop` is absent, so there is no change to block acceptance, validation, serialization, IDs, signatures, slot timing, rewards, rounds, or activation gating.

## Related issue

Closes #248

## How to test

Targeted unit tests (no DB/Redis required for these suites):

```
npm run test:single -- \
  test/unit/helpers/syncWatchdog.js \
  test/unit/modules/blocks.process.js \
  test/unit/modules/blocks.verify.js
```

Coverage:
- `test/unit/helpers/syncWatchdog.js` — stall detection: fires on no progress, ignores a progressing sync, fires once, disabled at `timeoutMs <= 0`, `stop()` / idempotent `start()`.
- `test/unit/modules/blocks.verify.js` — the apply-boundary gate: `processBlock()` verifies but does not apply when `shouldStop()` is true (applies otherwise / when no predicate is given); the fork-2 `undoUnconfirmed` write is skipped when aborted, performed otherwise.
- `test/unit/modules/blocks.process.js` — `isReadyToReceiveBlock()` gate branches (syncing / not-ready-to-sync / round ticking) and that `loadBlocksFromPeer` forwards `shouldStop` to `verify.processBlock`.

Broader regression run (executed locally, PostgreSQL + Redis up):

```
npm run test:unit:fast    # 861 passing
```

Lint (repo uses flat `eslint.config.js`):

```
npx eslint helpers/syncWatchdog.js modules/loader.js helpers/constants.js \
  modules/blocks/process.js modules/blocks/verify.js \
  test/unit/helpers/syncWatchdog.js test/unit/modules/blocks.process.js \
  test/unit/modules/blocks.verify.js   # clean
```

What was **not** run: `npm run test:api` (requires a running testnet) and a full from-zero mainnet resync. The change is liveness-only and does not touch validation paths, but reviewers may want an API/peer pass before merge.

### Manual reproduction / verification

On a node that exhibits the freeze: `Sync trigger` repeats every second with no `Finished sync`, and `/api/loader/status/sync` reports `syncing: true` with a frozen `height`. With this change, a sync that makes no progress for `syncStallTimeout` logs `Sync watchdog: no block progress, aborting stalled sync to allow recovery`, `loader.syncing()` returns to `false`, live blocks are accepted again, and a fresh sync starts on the next timer tick.

## Risk areas

- **Consensus / protocol:** none — block validation, serialization, IDs, signatures, rounds, rewards, and activation heights are untouched.
- **Concurrency:** an aborted run cannot begin a new state mutation — block apply is gated immediately before `applyBlock()` (and the fork-2 `undoUnconfirmed`), and the unconfirmed phases are gated by `skipOnStop`. Teardown waits for any already-started mutation (`modules.blocks.isActive` / `mutatingState`) to drain. So releasing `loader.syncing()` cannot let an abandoned flow mutate state concurrently with a fresh run.
- **Tuning:** `constants.syncStallTimeout` (default 5 min) is deliberately generous; set to `0` to disable the watchdog.
- **Scope:** only `__private.sync` is guarded; the startup rebuild path (`loadBlockChain`) is out of scope. If a state-mutating phase is itself permanently hung mid-write, `finishStalled()` keeps waiting (it will not force teardown into a possible concurrent write) — that case needs operator intervention.
- **Follow-ups (not in this PR):** the probable root-cause hang is `checkExists` in `verify.processBlock` doing `db.query(...).then(...)` with no `.catch`; adding the rejection handler is a separate root-cause fix. This PR is the liveness safety net.

## Checklist

- [x] English-only repository output.
- [x] No consensus-breaking nondeterminism introduced.
- [x] No security checks weakened (nethash/version/handshake untouched).
- [x] No activation-gated behavior changed.
- [x] Schema/SQL unaffected (no data-shape changes).
- [x] Tests added (watchdog helper) and adjacent gate coverage extended; targeted + fast unit suites run.
- [x] Operator note: new `syncStallTimeout` constant (liveness only, not consensus); `0` disables.

