### PR TITLE
Fix: Handle DB query rejections in block/sync path to prevent silent stalls

### DIFF
--- a/modules/blocks/utils.js
+++ b/modules/blocks/utils.js
@@ -277,6 +277,11 @@ Utils.prototype.loadBlocksData = function (filter, options, cb) {
       // FIXME: That SQL query have mess logic, need to be refactored
       library.db.query(sql.loadBlocksData(filter), params).then(function (rows) {
         return setImmediate(cb, null, rows);
+      }).catch(function (err) {
+        // A rejection here would otherwise never call back, stalling the
+        // dbSequence task that owns this query.
+        library.logger.error('blocks', `Failed to load blocks data: ${err?.message || err}`, err && err.stack);
+        return setImmediate(cb, 'Blocks#loadBlockData error');
       });
     }).catch(function (err ) {
       library.logger.error('blocks', `Failed to get height by last id ${filter.lastid}: ${err?.message || err}`, err.stack);

--- a/modules/blocks/verify.js
+++ b/modules/blocks/verify.js
@@ -461,6 +461,11 @@ Verify.prototype.processBlock = function (block, broadcast, cb, saveBlock, shoul
         } else {
           return setImmediate(seriesCb);
         }
+      }).catch(function (err) {
+        // Without this handler a rejected query never resolves the series step,
+        // which silently stalls block processing (and can wedge the sync loader).
+        library.logger.error('blocks', `Failed to check block existence for ${block.id}: ${err?.message || err}`, err && err.stack);
+        return setImmediate(seriesCb, 'Blocks#checkExists error');
       });
     },
     validateBlockSlot: function (seriesCb) {

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -558,7 +558,9 @@ __private.loadBlockChain = function () {
       return t.batch(promises);
     }
 
-    library.db.task(updateMemAccounts).then(function (results) {
+    // Returned so a rejection propagates to the outer .catch below instead of
+    // being swallowed (which would silently stall blockchain loading).
+    return library.db.task(updateMemAccounts).then(function (results) {
       if (__private.stopRequested) {
         return finishForShutdown();
       }

--- a/test/unit/modules/blocks.utils.js
+++ b/test/unit/modules/blocks.utils.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const { expect } = require('chai');
+const sinon = require('sinon');
+
+const Utils = require('../../../modules/blocks/utils.js');
+
+// Focused test for the missing `.catch` on the inner loadBlocksData query: a
+// rejected query must call back with an error instead of stalling the
+// dbSequence task that owns it.
+describe('blocks utils - loadBlocksData query rejection', function () {
+  let utils;
+  let logger;
+  let db;
+  let dbSequence;
+
+  beforeEach(function () {
+    logger = { trace: sinon.spy(), debug: sinon.spy(), error: sinon.spy(), info: sinon.spy() };
+    db = { query: sinon.stub() };
+    // getHeightByLastId resolves, the inner loadBlocksData query rejects.
+    db.query.onFirstCall().resolves([{ height: 5 }]);
+    db.query.onSecondCall().rejects(new Error('db connection lost'));
+
+    dbSequence = { add: function (task, cb) { task(cb); } };
+
+    utils = new Utils(logger, {}, {}, db, dbSequence, {});
+  });
+
+  it('calls back with an error when the blocks-data query rejects', function (done) {
+    utils.loadBlocksData({ limit: 1 }, function (err, rows) {
+      expect(err).to.equal('Blocks#loadBlockData error');
+      expect(rows).to.equal(undefined);
+      expect(db.query.calledTwice).to.equal(true);
+      done();
+    });
+  });
+});

--- a/test/unit/modules/blocks.verify.js
+++ b/test/unit/modules/blocks.verify.js
@@ -53,6 +53,16 @@ describe('blocks verify - processBlock shouldStop gate', function () {
     });
   });
 
+  it('fails the series instead of hanging when the checkExists query rejects', function (done) {
+    db.query.rejects(new Error('db connection lost'));
+
+    process(() => false, function (err) {
+      expect(err).to.equal('Blocks#checkExists error');
+      expect(applyBlock.called).to.equal(false);
+      done();
+    });
+  });
+
   it('applies the block when shouldStop() returns false', function (done) {
     applyBlock = sinon.spy(function (block, broadcast, cb) {
       return cb(null);


### PR DESCRIPTION
## Description

Root-cause companion to the sync-stall watchdog (#249). Several `library.db.*(...).then(...)` chains in the block/sync path have **no `.catch`**, so a rejected query (DB hiccup, disconnect, timeout) never runs the `.then` and never invokes the callback the chain owns — silently stalling block processing. That parked-callback behavior (Postgres idle, event loop idle) is the probable trigger of the stuck-sync wedge the watchdog recovers from. This PR removes the source; the watchdog stays the safety net.

### Fixes

- **`modules/blocks/verify.js`** — `processBlock()` `checkExists`: add `.catch` → `Blocks#checkExists error`. A rejection here parked `processBlock` *before* `applyBlock`, matching the observed stall signature.
- **`modules/blocks/utils.js`** — `loadBlocksData()`: add `.catch` to the **inner** `loadBlocksData` query (the outer `getHeightByLastId` query already had one) so a rejection ends the `dbSequence` task instead of hanging it.
- **`modules/loader.js`** — `loadBlockChain()`: `return` the inner `db.task(updateMemAccounts)` so its rejection propagates to the existing outer `.catch` instead of being swallowed (could stall startup).

Scanned the rest of the block subsystem (`process.js`, `chain.js`, `api.js`) — those `db.*` chains already have rejection handlers.

## Related issue

Closes #250 (companion to #248 / #249)

## How to test

```
npm run test:single -- test/unit/modules/blocks.verify.js test/unit/modules/blocks.utils.js
```

- `blocks.verify.js` — a rejected `checkExists` query fails the series with `Blocks#checkExists error` and does not call `applyBlock` (instead of hanging).
- `blocks.utils.js` — a rejected inner `loadBlocksData` query calls back with `Blocks#loadBlockData error` (instead of stalling the `dbSequence` task).

Regression: `npm run test:unit:fast` → 863 passing. Lint clean on all touched files (`npx eslint modules/blocks/verify.js modules/blocks/utils.js modules/loader.js test/unit/modules/blocks.verify.js test/unit/modules/blocks.utils.js`).

Not run: `npm run test:api` (needs a running testnet).

## Risk areas

- **Consensus / protocol:** none — pure error handling; success paths, block validation, serialization, IDs, signatures, rewards, rounds, and activation gating are untouched.
- **Behavior change:** a DB query rejection that previously hung now surfaces as a normal error, so the loader retries another peer / runs its existing error path. For `loadBlockChain` the rejection now reaches the existing outer `.catch` (logs and triggers cleanup) instead of hanging startup.

## Checklist

- [x] English-only repository output.
- [x] No consensus-breaking nondeterminism introduced.
- [x] No security checks weakened.
- [x] No activation-gated behavior changed.
- [x] Schema/SQL unaffected.
- [x] Tests added and run (targeted + `test:unit:fast`).
