### PR TITLE
Fix: Compute delegates/get rank and rate over the full delegate list (regression)

### DIFF
--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -805,12 +805,23 @@ Delegates.prototype.shared = {
         return setImmediate(cb, 'Delegate publicKey does not match address');
       }
 
-      modules.delegates.getDelegates(req.body, filter, function (err, data) {
+      // `rank` and `rate` are derived from the full, ordered delegate list, so
+      // ranking must be computed over all delegates. We request the ranked list
+      // (empty filter) and then select the requested delegate, instead of
+      // pushing `filter` into the accounts query: a single-row result is always
+      // ranked first and would report `rank`/`rate` (and outsider productivity)
+      // as 1 for every delegate.
+      modules.delegates.getDelegates(req.body, {}, function (err, data) {
         if (err) {
           return setImmediate(cb, err);
         }
 
-        var delegate = data.delegates[0];
+        var delegate = data.delegates.find(function (delegate) {
+          if (filter.address) {
+            return delegate.address.toUpperCase() === filter.address.toUpperCase();
+          }
+          return delegate.username === filter.username;
+        });
 
         if (delegate) {
           return setImmediate(cb, null, { delegate: delegate });

--- a/test/api/delegates.js
+++ b/test/api/delegates.js
@@ -424,6 +424,79 @@ describe('GET /api/delegates', function () {
   });
 });
 
+describe('GET /api/delegates/get', function () {
+  // A delegate that is NOT ranked first, so the test catches the regression
+  // where `delegates/get` reported rank/rate as 1 for every single-delegate
+  // lookup (because ranking was computed over a one-row, pre-filtered result).
+  var referenceDelegate;
+
+  before(function (done) {
+    node.get('/api/delegates?orderBy=rank:asc', function (err, res) {
+      node.expect(res.body).to.have.property('success').to.be.true;
+      node.expect(res.body).to.have.property('delegates').that.is.an('array');
+      // The list is ordered by rank ascending, so the last entry has the
+      // highest rank number, guaranteeing rank > 1.
+      referenceDelegate = res.body.delegates[res.body.delegates.length - 1];
+      node.expect(referenceDelegate).to.have.property('rank').that.is.above(1);
+      done();
+    });
+  });
+
+  it('using username should return the delegate with its real rank and rate', function (done) {
+    node.get('/api/delegates/get?username=' + encodeURIComponent(referenceDelegate.username), function (err, res) {
+      node.expect(res.body).to.have.property('success').to.be.true;
+      node.expect(res.body).to.have.property('delegate').that.is.an('object');
+      node.expect(res.body.delegate.username).to.equal(referenceDelegate.username);
+      node.expect(res.body.delegate.rank).to.equal(referenceDelegate.rank);
+      // `rate` is a deprecated alias of `rank` and must keep matching it.
+      node.expect(res.body.delegate.rate).to.equal(referenceDelegate.rank);
+      // Regression guard: rank/rate must reflect the real position, not 1.
+      node.expect(res.body.delegate.rank).to.be.above(1);
+      done();
+    });
+  });
+
+  it('using publicKey should return the delegate with its real rank and rate', function (done) {
+    node.get('/api/delegates/get?publicKey=' + referenceDelegate.publicKey, function (err, res) {
+      node.expect(res.body).to.have.property('success').to.be.true;
+      node.expect(res.body).to.have.property('delegate').that.is.an('object');
+      node.expect(res.body.delegate.publicKey).to.equal(referenceDelegate.publicKey);
+      node.expect(res.body.delegate.rank).to.equal(referenceDelegate.rank);
+      node.expect(res.body.delegate.rate).to.equal(referenceDelegate.rank);
+      node.expect(res.body.delegate.rank).to.be.above(1);
+      done();
+    });
+  });
+
+  it('using address should return the delegate with its real rank and rate', function (done) {
+    node.get('/api/delegates/get?address=' + encodeURIComponent(referenceDelegate.address), function (err, res) {
+      node.expect(res.body).to.have.property('success').to.be.true;
+      node.expect(res.body).to.have.property('delegate').that.is.an('object');
+      node.expect(res.body.delegate.address).to.equal(referenceDelegate.address);
+      node.expect(res.body.delegate.rank).to.equal(referenceDelegate.rank);
+      node.expect(res.body.delegate.rate).to.equal(referenceDelegate.rank);
+      node.expect(res.body.delegate.rank).to.be.above(1);
+      done();
+    });
+  });
+
+  it('using no criteria should fail', function (done) {
+    node.get('/api/delegates/get', function (err, res) {
+      node.expect(res.body).to.have.property('success').to.be.false;
+      node.expect(res.body).to.have.property('error');
+      done();
+    });
+  });
+
+  it('using an unknown username should fail', function (done) {
+    node.get('/api/delegates/get?username=anunknowndelegate', function (err, res) {
+      node.expect(res.body).to.have.property('success').to.be.false;
+      node.expect(res.body).to.have.property('error').to.equal('Delegate not found');
+      done();
+    });
+  });
+});
+
 describe('GET /api/delegates/count', function () {
   it('should be ok', function (done) {
     node.get('/api/delegates/count', function (err, res) {

--- a/test/unit/modules/delegates.js
+++ b/test/unit/modules/delegates.js
@@ -158,21 +158,49 @@ describe('delegates', function () {
         });
       });
 
-      // it('should find delegate matching the address', (done) => {
-      //   const body = { address: aDelegate.address }
-      //   delegates.shared.getDelegate({ body }, (err, response) => {
-      //     expect(err).not.to.exist;
-      //     expect(response).to.have.property('delegate');
+      it('should find delegate matching the address', (done) => {
+        const body = { address: aDelegate.address };
+        delegates.shared.getDelegate({ body }, (err, response) => {
+          expect(err).not.to.exist;
+          expect(response).to.have.property('delegate');
 
-      //     const { delegate } = response;
+          const { delegate } = response;
 
-      //     expect(delegate.username).to.equal(aDelegate.username);
-      //     expect(delegate.publicKey).to.equal(aDelegate.publicKey);
-      //     expect(delegate.address).to.equal(aDelegate.address);
+          expect(delegate.username).to.equal(aDelegate.username);
+          expect(delegate.publicKey).to.equal(aDelegate.publicKey);
+          expect(delegate.address).to.equal(aDelegate.address);
 
-      //     done();
-      //   });
-      // });
+          done();
+        });
+      });
+
+      it('should report the real rank and rate, computed over the full delegate list', (done) => {
+        // Take a delegate that is not ranked first from the full ordered list.
+        delegates.getDelegates({}, {}, (err, response) => {
+          expect(err).not.to.exist;
+          expect(response.delegates).to.be.an('array').that.has.length.above(1);
+
+          const expectedDelegate = response.delegates[response.delegates.length - 1];
+          expect(expectedDelegate.rank).to.be.above(1);
+
+          const body = { publicKey: expectedDelegate.publicKey };
+          delegates.shared.getDelegate({ body }, (err, single) => {
+            expect(err).not.to.exist;
+            expect(single).to.have.property('delegate');
+
+            const { delegate } = single;
+
+            // Regression: rank/rate were always 1 because ranking was computed
+            // over a single pre-filtered row instead of the full delegate list.
+            expect(delegate.rank).to.equal(expectedDelegate.rank);
+            expect(delegate.rank).to.be.above(1);
+            // `rate` is a deprecated alias of `rank` and must keep matching it.
+            expect(delegate.rate).to.equal(delegate.rank);
+
+            done();
+          });
+        });
+      });
     });
 
     describe('getNextForgers', () => {


### PR DESCRIPTION
## Description

`GET /api/delegates/get` returned `rank: 1` and `rate: 1` for **every** delegate, regardless of the delegate's real position in the ranking. Regression introduced in `60d7733c` (`feat: find single delegate by the given address`, shipped in `v0.9.0`): the per-delegate `filter` was pushed into the accounts query, so `rank`/`rate` — assigned by array index over the result — were computed against a single pre-filtered row and always resolved to `1`. The same single-row defect also mis-reported `productivity` for outsider delegates (rank > `slots.delegates`).

Comparison on a known delegate:

- Old node (correct): https://bid.adamant.im/api/delegates/get?username=kabadas → `"rate":82,"rank":82`
- Current node (buggy): https://endless.adamant.im/api/delegates/get?username=kabadas → `"rate":1,"rank":1`

### Fix

- **`modules/delegates.js`** — `getDelegate` now requests the full ordered delegate list (empty filter) and selects the requested delegate with `.find(...)`, so `rank`/`rate` are computed over all delegates. This restores the pre-regression behavior while keeping the address-lookup capability added in `60d7733c`. Selection matches `address` (case-insensitive, mirroring `Account.getAll`) or `username`; the existing `publicKey`/`address` mismatch guard is untouched. `getDelegates` and the `GET /api/delegates` list endpoint are unchanged.

### Tests

- **`test/api/delegates.js`** — new `GET /api/delegates/get` suite. The endpoint previously had **no** test coverage, which is how the regression shipped. Verifies `username`/`publicKey`/`address` lookups return the real `rank`, that `rate === rank` (deprecated alias), and `rank > 1` (regression guard), plus no-criteria and unknown-delegate error cases.
- **`test/unit/modules/delegates.js`** — added a rank/rate regression test (selects a non-first delegate and asserts its real rank), and enabled the previously commented-out address-lookup test (now passing thanks to the fix).

## Related issue

Closes #252

## How to test

```
npm run test:single -- test/unit/modules/delegates.js
```

With a local testnet running in parallel:

```
npm run start:testnet
npm run test:single -- test/api/delegates.js --grep "delegates/get"
```

- Unit: `28 passing`, including the new rank/rate test and the enabled address-lookup test.
- API: `8 passing`. Live check — `delegates/get?username=<lowest-ranked>` returned `"rate":101,"rank":101` (its real position), not `1`.

Lint clean on touched files: `npx eslint modules/delegates.js test/api/delegates.js test/unit/modules/delegates.js`. Note: this repo uses a flat `eslint.config.js`, so eslint is run without the legacy `ESLINT_USE_FLAT_CONFIG=false` flag.

Not run: full `npm run test:unit` / `npm run test:api` suites — the change is local to one read-only API handler and both affected test files pass.

## Risk areas

- **Consensus / protocol:** none. This is a read-only public API handler. Block/transaction/round logic, delegate-list ordering for forging (`generateDelegateList`), serialization, IDs, signatures, rewards, and activation gating are all untouched.
- **Behavior change:** `delegates/get` now returns the correct `rank`/`rate` (and correct `productivity` for outsider delegates). It fetches the full delegate list instead of a single pre-filtered row — the same data source used before the regression.

## Checklist

- [x] English-only repository output.
- [x] No consensus-breaking nondeterminism introduced.
- [x] No security checks weakened.
- [x] No activation-gated behavior changed.
- [x] Schema/SQL unaffected.
- [x] Tests added and run (targeted unit + API).
