### PR TITLE
Fix: Prevent delegate voters API from returning all accounts

### DIFF
--- a/logic/account.js
+++ b/logic/account.js
@@ -565,6 +565,8 @@ Account.prototype.get = function (filter, fields, cb) {
  * @return {setImmediateCallback} data with rows | 'Account#getAll error'.
  */
 Account.prototype.getAll = function (filter, fields, cb) {
+  filter = Object.assign({}, filter);
+
   if (typeof(fields) === 'function') {
     cb = fields;
     fields = this.fields.map(function (field) {
@@ -598,6 +600,16 @@ Account.prototype.getAll = function (filter, fields, cb) {
 
   if (typeof filter.address === 'string') {
     query = query.whereRaw('upper("address") = ?', [filter.address.toUpperCase()]);
+  } else if (filter.address && Array.isArray(filter.address.$in)) {
+    var addresses = filter.address.$in.map(function (address) {
+      return String(address).toUpperCase();
+    });
+
+    if (addresses.length) {
+      query = query.whereIn(knex.raw('upper("address")'), addresses);
+    } else {
+      query = query.whereRaw('1 = 0');
+    }
   }
   delete filter.address;
 

--- a/modules/accounts.js
+++ b/modules/accounts.js
@@ -347,6 +347,10 @@ Accounts.prototype.shared = {
 
         if (account.delegates) {
           modules.delegates.getDelegates(req.body, {}, function (err, res) {
+            if (err) {
+              return setImmediate(cb, err);
+            }
+
             var delegates = res.delegates.filter(function (delegate) {
               return account.delegates.indexOf(delegate.publicKey) !== -1;
             });

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -833,25 +833,31 @@ Delegates.prototype.shared = {
   },
 
   getNextForgers: function (req, cb) {
-    var currentBlock = modules.blocks.lastBlock.get();
-    var limit = req.body.limit || 10;
-
-    modules.delegates.generateDelegateList(currentBlock.height, function (err, activeDelegates) {
+    library.schema.validate(req.body, schema.getNextForgers, function (err) {
       if (err) {
-        return setImmediate(cb, err);
+        return setImmediate(cb, err[0].message);
       }
 
-      var currentBlockSlot = slots.getSlotNumber(currentBlock.timestamp);
-      var currentSlot = slots.getSlotNumber();
-      var nextForgers = [];
+      var currentBlock = modules.blocks.lastBlock.get();
+      var limit = req.body.limit || 10;
 
-      for (var i = 1; i <= slots.delegates && i <= limit; i++) {
-        if (activeDelegates[(currentSlot + i) % slots.delegates]) {
-          nextForgers.push(activeDelegates[(currentSlot + i) % slots.delegates]);
+      modules.delegates.generateDelegateList(currentBlock.height, function (err, activeDelegates) {
+        if (err) {
+          return setImmediate(cb, err);
         }
-      }
 
-      return setImmediate(cb, null, { currentBlock: currentBlock.height, currentBlockSlot: currentBlockSlot, currentSlot: currentSlot, delegates: nextForgers });
+        var currentBlockSlot = slots.getSlotNumber(currentBlock.timestamp);
+        var currentSlot = slots.getSlotNumber();
+        var nextForgers = [];
+
+        for (var i = 1; i <= slots.delegates && i <= limit; i++) {
+          if (activeDelegates[(currentSlot + i) % slots.delegates]) {
+            nextForgers.push(activeDelegates[(currentSlot + i) % slots.delegates]);
+          }
+        }
+
+        return setImmediate(cb, null, { currentBlock: currentBlock.height, currentBlockSlot: currentBlockSlot, currentSlot: currentSlot, delegates: nextForgers });
+      });
     });
   },
 

--- a/schema/delegates.js
+++ b/schema/delegates.js
@@ -111,6 +111,17 @@ module.exports = {
       }
     }
   },
+  getNextForgers: {
+    id: 'delegates.getNextForgers',
+    type: 'object',
+    properties: {
+      limit: {
+        type: 'integer',
+        minimum: 1,
+        maximum: constants.activeDelegates
+      }
+    }
+  },
   getForgedByAccount: {
     id: 'delegates.getForgedByAccount',
     type: 'object',

--- a/test/api/delegates.js
+++ b/test/api/delegates.js
@@ -480,6 +480,14 @@ describe('GET /api/delegates/get', function () {
     });
   });
 
+  it('using mismatched publicKey and address should fail', function (done) {
+    node.get('/api/delegates/get?publicKey=' + referenceDelegate.publicKey + '&address=U123456789012345678', function (err, res) {
+      node.expect(res.body).to.have.property('success').to.be.false;
+      node.expect(res.body).to.have.property('error').to.equal('Delegate publicKey does not match address');
+      done();
+    });
+  });
+
   it('using no criteria should fail', function (done) {
     node.get('/api/delegates/get', function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.false;
@@ -509,6 +517,7 @@ describe('GET /api/delegates/count', function () {
 
 describe('GET /api/delegates/voters', function () {
   var account = node.randomAccount();
+  var noVotersAccount = node.randomAccount();
 
   before(function (done) {
     sendADM({
@@ -538,6 +547,16 @@ describe('GET /api/delegates/voters', function () {
     node.get('/api/delegates/voters?' + params, function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.false;
       node.expect(res.body).to.have.property('error');
+      done();
+    });
+  });
+
+  it('using valid publicKey without voters should return an empty list', function (done) {
+    var params = 'publicKey=' + noVotersAccount.publicKey;
+
+    node.get('/api/delegates/voters?' + params, function (err, res) {
+      node.expect(res.body).to.have.property('success').to.be.true;
+      node.expect(res.body).to.have.property('accounts').that.is.an('array').that.has.lengthOf(0);
       done();
     });
   });
@@ -1124,6 +1143,30 @@ describe('GET /api/delegates/getNextForgers', function () {
       node.expect(res.body).to.have.property('currentSlot').that.is.a('number');
       node.expect(res.body).to.have.property('delegates').that.is.an('array');
       node.expect(res.body.delegates).to.have.lengthOf(101);
+      done();
+    });
+  });
+
+  it('using string limit should fail', function (done) {
+    node.get('/api/delegates/getNextForgers?' + 'limit=abc', function (err, res) {
+      node.expect(res.body).to.have.property('success').to.be.false;
+      node.expect(res.body).to.have.property('error').to.equal('Expected type integer but found type string');
+      done();
+    });
+  });
+
+  it('using zero limit should fail', function (done) {
+    node.get('/api/delegates/getNextForgers?' + 'limit=0', function (err, res) {
+      node.expect(res.body).to.have.property('success').to.be.false;
+      node.expect(res.body).to.have.property('error').to.equal('Value 0 is less than minimum 1');
+      done();
+    });
+  });
+
+  it('using limit above active delegates should fail', function (done) {
+    node.get('/api/delegates/getNextForgers?' + 'limit=102', function (err, res) {
+      node.expect(res.body).to.have.property('success').to.be.false;
+      node.expect(res.body).to.have.property('error').to.equal('Value 102 is greater than maximum 101');
       done();
     });
   });

--- a/test/unit/logic/account.js
+++ b/test/unit/logic/account.js
@@ -315,6 +315,31 @@ describe('account', () => {
       });
     });
 
+    it('should search by address list in uppercase', (done) => {
+      const address = validAccount.address;
+      const lowerAddress = nonExistingAccount.address.toLowerCase();
+
+      account.getAll({ address: { $in: [address, lowerAddress] } }, ['username'], () => {
+        const matched = db.query.calledWithMatch(
+            `select "username" from "mem_accounts" as "a" where upper("address") in ('${address}', '${nonExistingAccount.address}');`
+        );
+
+        expect(matched).to.be.true;
+        done();
+      });
+    });
+
+    it('should not drop an empty address list filter', (done) => {
+      account.getAll({ address: { $in: [] } }, ['username'], () => {
+        const matched = db.query.calledWithMatch(
+            'select "username" from "mem_accounts" as "a" where 1 = 0;'
+        );
+
+        expect(matched).to.be.true;
+        done();
+      });
+    });
+
     it('should filter out non existing fields', (done) => {
       const nonExistingFields = [
         'reward',

--- a/test/unit/modules/accounts.js
+++ b/test/unit/modules/accounts.js
@@ -499,6 +499,55 @@ describe('accounts', function () {
           });
         });
       });
+
+      it('should return an empty delegate list for an account without votes', (done) => {
+        const getAccountStub = sinon.stub(accounts, 'getAccount').callsFake((filter, cb) => {
+          cb(null, { address: filter.address, delegates: null });
+        });
+
+        const body = { address: testAccount.address };
+        accounts.shared.getDelegates({ body }, (err, response) => {
+          getAccountStub.restore();
+
+          expect(err).not.to.exist;
+          expect(response).to.eql({ delegates: [] });
+          done();
+        });
+      });
+
+      it('should return account lookup errors', (done) => {
+        const getAccountStub = sinon.stub(accounts, 'getAccount').callsFake((filter, cb) => {
+          cb('Account#get error');
+        });
+
+        const body = { address: testAccount.address };
+        accounts.shared.getDelegates({ body }, (err, response) => {
+          getAccountStub.restore();
+
+          expect(response).not.to.exist;
+          expect(err).to.equal('Account#get error');
+          done();
+        });
+      });
+
+      it('should return delegate listing errors instead of throwing', (done) => {
+        const getAccountStub = sinon.stub(accounts, 'getAccount').callsFake((filter, cb) => {
+          cb(null, { address: filter.address, delegates: [testAccount.publicKey] });
+        });
+        const getDelegatesStub = sinon.stub(modules.delegates, 'getDelegates').callsFake((query, filter, cb) => {
+          cb('Invalid sort field');
+        });
+
+        const body = { address: testAccount.address };
+        accounts.shared.getDelegates({ body }, (err, response) => {
+          getAccountStub.restore();
+          getDelegatesStub.restore();
+
+          expect(response).not.to.exist;
+          expect(err).to.equal('Invalid sort field');
+          done();
+        });
+      });
     });
 
     describe('getDelegatesFee()', () => {

--- a/test/unit/modules/delegates.js
+++ b/test/unit/modules/delegates.js
@@ -270,7 +270,9 @@ describe('delegates', function () {
         const body = { limit: constants.activeDelegates + 1 };
         delegates.shared.getNextForgers({ body }, (err, response) => {
           expect(response).not.to.exist;
-          expect(err).to.equal('Value 102 is greater than maximum 101');
+          expect(err).to.equal(
+              `Value ${constants.activeDelegates + 1} is greater than maximum ${constants.activeDelegates}`
+          );
           done();
         });
       });

--- a/test/unit/modules/delegates.js
+++ b/test/unit/modules/delegates.js
@@ -5,6 +5,7 @@ const { expect } = require('chai');
 const { modulesLoader } = require('../../common/initModule.js');
 const {
   testAccount,
+  nonExistingAccount,
   invalidPublicKey,
   invalidAddress
 } = require('../../common/stubs/account.js');
@@ -174,6 +175,19 @@ describe('delegates', function () {
         });
       });
 
+      it('should reject mismatched public key and address criteria', (done) => {
+        const body = {
+          publicKey: aDelegate.publicKey,
+          address: nonExistingAccount.address
+        };
+
+        delegates.shared.getDelegate({ body }, (err, response) => {
+          expect(response).not.to.exist;
+          expect(err).to.equal('Delegate publicKey does not match address');
+          done();
+        });
+      });
+
       it('should report the real rank and rate, computed over the full delegate list', (done) => {
         // Take a delegate that is not ranked first from the full ordered list.
         delegates.getDelegates({}, {}, (err, response) => {
@@ -230,6 +244,33 @@ describe('delegates', function () {
         delegates.shared.getNextForgers({ body }, (err, response) => {
           expect(err).not.to.exist;
           expect(response.delegates.length).to.equal(1);
+          done();
+        });
+      });
+
+      it('should reject a non-integer limit', (done) => {
+        const body = { limit: 'abc' };
+        delegates.shared.getNextForgers({ body }, (err, response) => {
+          expect(response).not.to.exist;
+          expect(err).to.equal('Expected type integer but found type string');
+          done();
+        });
+      });
+
+      it('should reject a zero limit', (done) => {
+        const body = { limit: 0 };
+        delegates.shared.getNextForgers({ body }, (err, response) => {
+          expect(response).not.to.exist;
+          expect(err).to.equal('Value 0 is less than minimum 1');
+          done();
+        });
+      });
+
+      it('should reject a limit above the active delegate count', (done) => {
+        const body = { limit: constants.activeDelegates + 1 };
+        delegates.shared.getNextForgers({ body }, (err, response) => {
+          expect(response).not.to.exist;
+          expect(err).to.equal('Value 102 is greater than maximum 101');
           done();
         });
       });
@@ -325,6 +366,15 @@ describe('delegates', function () {
             return Number(array[index].balance) <= Number(array[index - 1].balance);
           });
           expect(isSorted).to.be.true;
+          done();
+        });
+      });
+
+      it('should return an empty list when a valid public key has no voters', (done) => {
+        const body = { publicKey: nonExistingAccount.publicKey };
+        delegates.shared.getVoters({ body }, (err, response) => {
+          expect(err).not.to.exist;
+          expect(response).to.have.property('accounts').that.is.an('array').that.is.empty;
           done();
         });
       });


### PR DESCRIPTION
## Description

This PR fixes a delegate API regression where `GET /api/delegates/voters` could return all accounts instead of only voters for the requested delegate.

The root cause is that delegate voters are resolved through `modules.accounts.getAccounts({ address: { $in: addresses } })`, while `logic/account#getAll` only handled a string `address` filter. The unsupported `$in` filter was removed before the SQL query, so an empty effective filter could scan all accounts.

This PR also tightens related delegate API edge cases found during the endpoint audit:

- support address `$in` filters in `Account#getAll`, including uppercase normalization and empty-list handling;
- validate `GET /api/delegates/getNextForgers` `limit` as an integer between `1` and `constants.activeDelegates`;
- propagate `GET /api/accounts/delegates` delegate-listing errors instead of continuing with an invalid result;
- add regression and edge-case coverage for delegate voters, delegate lookup, next forgers, account delegate lookup, and account address list filtering.

## Related issue

Closes #254

## How to test

Executed:

```text
PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run test:single -- test/unit/logic/account.js
PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run test:single -- test/unit/modules/delegates.js
PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run test:single -- test/unit/modules/accounts.js
PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run eslint
git diff --check
```

Results:

- `test/unit/logic/account.js`: 33 passing
- `test/unit/modules/delegates.js`: 33 passing
- `test/unit/modules/accounts.js`: 45 passing
- `npm run eslint`: passed
- `git diff --check`: passed

Not completed:

- `test/api/delegates.js` was updated with HTTP-level regression coverage, but the local API testnet run was not completed because the local test database began rebuilding/syncing from peers and the funded account setup did not become stable during the run. The node was stopped via graceful shutdown.

## Risk areas

- Public API response correctness for delegate voters and next forgers.
- Account query filtering in `logic/account#getAll`.
- No consensus, serialization, transaction validity, reward, fee, delegate ordering, or round-accounting behavior is changed.

## Checklist

- [x] Repository output is English-only.
- [x] Public API validation remains strict.
- [x] No consensus-critical behavior is changed.
- [x] Tests added for regression and edge cases.
- [x] Targeted tests and lint were run.
