### PR TITLE
Feat: Add persisted mem-table checkpoints for crash recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,8 @@ Example: `helpers/constants.js` warns that reward and supply changes must match 
 
 Always stop a running node with its graceful shutdown path, for example by pressing `Ctrl+C` in the foreground process or by sending a normal termination signal that the application can handle. Do not stop the node with `kill -9`, forced terminal/process termination, or any other uncatchable kill mechanism.
 
+After `Ctrl+C` / `SIGINT` / `SIGTERM`, shutdown is not always immediate. The node may log messages such as `Waiting for loader to finish active sync/rebuild...` or `Waiting for block processing to finish...` while it drains in-flight work safely. Wait until cleanup completes (for example `Cleaned up successfully`) before restarting, closing the terminal, or killing the process. Restarting too early can leave derived `mem_*` tables inconsistent and force a long rebuild on the next startup.
+
 The node keeps consensus-derived state in memory mirror tables such as `mem_accounts` and `mem_round`. A forced kill can interrupt block, transaction, or round writes and leave those tables inconsistent with the persisted `blocks` table. On the next startup this can appear as:
 
 ```text

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,14 +215,14 @@ Example: `helpers/constants.js` warns that reward and supply changes must match 
 
 Always stop a running node with its graceful shutdown path, for example by pressing `Ctrl+C` in the foreground process or by sending a normal termination signal that the application can handle. Do not stop the node with `kill -9`, forced terminal/process termination, or any other uncatchable kill mechanism.
 
-After `Ctrl+C` / `SIGINT` / `SIGTERM`, shutdown is not always immediate. The node may log messages such as `Waiting for loader to finish active sync/rebuild...` or `Waiting for block processing to finish...` while it drains in-flight work safely. Wait until cleanup completes (for example `Cleaned up successfully`) before restarting, closing the terminal, or killing the process. Restarting too early can leave derived `mem_*` tables inconsistent and force a long rebuild on the next startup.
+After `Ctrl+C` / `SIGINT` / `SIGTERM`, shutdown is not always immediate. The node may log messages such as `Waiting for loader to finish active sync/rebuild…` or `Waiting for block processing to finish…` while it drains in-flight work safely. Wait until cleanup completes (for example `Cleaned up successfully`) before restarting, closing the terminal, or killing the process. Restarting too early can leave derived `mem_*` tables inconsistent and force a long rebuild on the next startup.
 
 The node keeps consensus-derived state in memory mirror tables such as `mem_accounts` and `mem_round`. A forced kill can interrupt block, transaction, or round writes and leave those tables inconsistent with the persisted `blocks` table. On the next startup this can appear as:
 
 ```text
 [WRN] loader Detected unapplied rounds in mem_round
-[WRN] loader Recreating memory tables
-[inf] loader Rebuilding blockchain, current block height: 1
+[WRN] loader Recreating memory tables…
+[inf] loader Rebuilding blockchain, current block height: 1…
 ```
 
 When this happens, do not apply ad hoc SQL fixes to `mem_*` tables. There is no generally safe, deterministic repair that can be guaranteed without either restoring a trusted database snapshot or allowing the node to replay/rebuild the derived memory state from the blockchain. Manual edits may hide the warning while leaving balances, vote weights, delegate round data, or unconfirmed-state mirrors wrong.

--- a/AI_AGENT_NOTES.md
+++ b/AI_AGENT_NOTES.md
@@ -78,7 +78,7 @@ Recommendations:
 Critical shutdown note:
 
 - Forced kills can leave `mem_accounts`, `mem_round`, and related memory mirror tables inconsistent with `blocks`.
-- If the next startup logs `Detected unapplied rounds in mem_round`, `Recreating memory tables`, and `Rebuilding blockchain, current block height: 1`, treat the local derived state as untrusted.
+- If the next startup logs `Detected unapplied rounds in mem_round`, `Recreating memory tables…`, and `Rebuilding blockchain, current block height: 1…`, treat the local derived state as untrusted.
 - Do not “fix” this by deleting or editing `mem_*` rows manually. The reliable options are restoring a trusted database snapshot or letting the node rebuild/replay from persisted blockchain data.
 
 ## 6) Legacy Patterns to Respect While Shipping

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ The node stores derived consensus state in memory mirror tables such as `mem_acc
 
 ```text
 [WRN] loader Detected unapplied rounds in mem_round
-[WRN] loader Recreating memory tables
-[inf] loader Rebuilding blockchain, current block height: 1
+[WRN] loader Recreating memory tables…
+[inf] loader Rebuilding blockchain, current block height: 1…
 ```
 
 If this happens, do not try to repair `mem_*` tables with manual SQL edits. The reliable recovery options are restoring a trusted database snapshot or letting the node rebuild/replay derived state from the blockchain.

--- a/api/ws/transport.js
+++ b/api/ws/transport.js
@@ -108,7 +108,7 @@ class TransportWsApi {
    * @param {Peer} peer target peer
    */
   handleConnect (socket, peer) {
-    this.logger.info('ws-node-client', `Connected to WebSocket peer at ${peer.ip}:${peer.port}`, {
+    this.logger.log('ws-node-client', `Connected to WebSocket peer at ${peer.ip}:${peer.port}`, {
       direction: 'outbound'
     });
 

--- a/api/ws/transport.js
+++ b/api/ws/transport.js
@@ -280,8 +280,19 @@ class TransportWsApi {
 
     this.getRandomPeers(availableSlots, (err, candidates) => {
       if (err || !candidates.length) {
-        const reason = err ?? 'Every peer is already connected via WebSocket';
-        self.logger.info('ws-node-client', `${reason}. No peers updated.`);
+        if (this.connections.size === 0) {
+          const reason = err ?? 'No suitable peers found for WebSocket connections';
+          self.logger.warn('ws-node-client', `${reason}. No peers updated.`, {
+            connectedPeers: 0,
+            maxConnections: this.maxConnections
+          });
+        } else {
+          const reason = err ?? 'Every peer is already connected via WebSocket';
+          self.logger.info('ws-node-client', `${reason}. No peers updated.`, {
+            connectedPeers: this.connections.size,
+            maxConnections: this.maxConnections
+          });
+        }
         return;
       }
 

--- a/app.js
+++ b/app.js
@@ -111,6 +111,7 @@ var config = {
     peers: './modules/peers.js',
     delegates: './modules/delegates.js',
     rounds: './modules/rounds.js',
+    memCheckpoints: './modules/memCheckpoints.js',
     multisignatures: './modules/multisignatures.js',
     dapps: './modules/dapps.js',
     chats: './modules/chats.js',

--- a/app.js
+++ b/app.js
@@ -726,7 +726,7 @@ d.run(function () {
 
         cleanupStarted = true;
         cleanupSignalCount = 0;
-        scope.logger.info('exit', 'Cleaning up...');
+        scope.logger.info('exit', 'Cleaning up…');
 
         var moduleMap = scope.modules || {};
         var moduleNames = Object.keys(moduleMap);

--- a/config.default.json
+++ b/config.default.json
@@ -136,8 +136,7 @@
   "loading": {
     "loadPerIteration": 5000,
     "memCheckpoints": {
-      "enabled": true,
-      "retention": 3
+      "enabled": true
     }
   },
   "ssl": {

--- a/config.default.json
+++ b/config.default.json
@@ -134,7 +134,11 @@
     }
   },
   "loading": {
-    "loadPerIteration": 5000
+    "loadPerIteration": 5000,
+    "memCheckpoints": {
+      "enabled": true,
+      "retention": 3
+    }
   },
   "ssl": {
     "enabled": false,

--- a/logic/memCheckpoint.js
+++ b/logic/memCheckpoint.js
@@ -332,6 +332,18 @@ MemCheckpoint.prototype.findRecoverableCheckpoint = function (tipHeight, tipRoun
       return null;
     }
 
+    var checkpointHeight = parseInt(meta.height, 10);
+    var chainHeight = parseInt(tipHeight, 10);
+
+    // Genesis-height checkpoints are test-only; real nodes only persist round-boundary slots (>= delegates).
+    if (checkpointHeight < slots.delegates && chainHeight > slots.delegates) {
+      self.library.logger.warn('memCheckpoints', 'Rejecting pre-round checkpoint on grown chain', {
+        checkpointHeight: checkpointHeight,
+        tipHeight: chainHeight
+      });
+      return null;
+    }
+
     return self.verifyCheckpointMeta(meta, nethash).then(function (verified) {
       if (!verified) {
         return null;

--- a/logic/memCheckpoint.js
+++ b/logic/memCheckpoint.js
@@ -11,6 +11,13 @@ var SCHEMA_VERSION = 1;
 var CHECKPOINT_SLOT_COUNT = 3;
 
 /**
+ * Checkpoint every Nth round while the node is catching up with the network,
+ * so sync throughput is not reduced by a mem_* copy at every round boundary.
+ * @type {number}
+ */
+var SYNC_ROUND_INTERVAL = 100;
+
+/**
  * Checkpoint table copy/hash order. Accounts must come before dependent tables.
  * @type {string[]}
  */
@@ -67,6 +74,9 @@ MemCheckpoint.SCHEMA_VERSION = SCHEMA_VERSION;
 /** @type {number} */
 MemCheckpoint.CHECKPOINT_SLOT_COUNT = CHECKPOINT_SLOT_COUNT;
 
+/** @type {number} */
+MemCheckpoint.SYNC_ROUND_INTERVAL = SYNC_ROUND_INTERVAL;
+
 /**
  * Whether persisted mem-table checkpoints are enabled.
  * @return {boolean}
@@ -78,6 +88,7 @@ MemCheckpoint.prototype.isEnabled = function () {
 
 /**
  * Whether a block height is a completed-round boundary where checkpoints are safe to take.
+ * Only the last block of a round qualifies (for example heights 101, 202, ...).
  * @param {number} height
  * @return {boolean}
  */
@@ -85,7 +96,23 @@ MemCheckpoint.prototype.isRoundBoundaryBlock = function (height) {
   var round = Math.ceil(height / slots.delegates);
   var nextRound = Math.ceil((height + 1) / slots.delegates);
 
-  return round !== nextRound || height === 1 || height === slots.delegates + 1;
+  return round !== nextRound;
+};
+
+/**
+ * Whether a checkpoint should be taken for a completed round.
+ * Every round during normal operation; every {@link SYNC_ROUND_INTERVAL}th
+ * round while syncing, to keep catch-up throughput unaffected.
+ * @param {number} round Completed round number.
+ * @param {boolean} syncing Whether the node is catching up with the network.
+ * @return {boolean}
+ */
+MemCheckpoint.prototype.shouldCheckpointRound = function (round, syncing) {
+  if (!syncing) {
+    return true;
+  }
+
+  return round % SYNC_ROUND_INTERVAL === 0;
 };
 
 /**
@@ -260,6 +287,48 @@ MemCheckpoint.prototype.getLatestComplete = function () {
 };
 
 /**
+ * Compare checkpoint slot table schemas against live mem_* tables.
+ * Detects live-table migrations that were not applied to the slot tables,
+ * which would otherwise produce failing copies or stale checkpoints.
+ * @return {Promise<object|null>} First mismatch found, or null when all slots match.
+ */
+MemCheckpoint.prototype.verifySlotSchemas = function () {
+  var self = this;
+  var pairs = [];
+
+  for (var slot = 0; slot < CHECKPOINT_SLOT_COUNT; slot++) {
+    var slotTables = sql.slotTableNames(slot);
+
+    TABLE_ORDER.forEach(function (tableKey) {
+      pairs.push({
+        liveTable: sql.liveTableNames[tableKey],
+        slotTable: slotTables[tableKey]
+      });
+    });
+  }
+
+  var pairIndex = 0;
+
+  var checkNextPair = function () {
+    if (pairIndex >= pairs.length) {
+      return Promise.resolve(null);
+    }
+
+    var pair = pairs[pairIndex++];
+
+    return self.library.db.oneOrNone(sql.compareTableSchemas, pair).then(function (mismatch) {
+      if (mismatch) {
+        return Object.assign({ liveTable: pair.liveTable, slotTable: pair.slotTable }, mismatch);
+      }
+
+      return checkNextPair();
+    });
+  };
+
+  return checkNextPair();
+};
+
+/**
  * Copy live mem_* tables into a rotating checkpoint slot after a settled round boundary.
  * @param {object} block Last block of the completed round.
  * @param {number} round Round number for the checkpoint.
@@ -286,12 +355,26 @@ MemCheckpoint.prototype.createCheckpoint = function (block, round, nethash) {
       createdAt: createdAt
     };
 
-    return self.library.db.tx(function (t) {
+    // REPEATABLE READ gives all copy and digest statements one MVCC snapshot,
+    // so the six copied tables cannot mix state from different blocks.
+    var txMode = self.library.db.$config.pgp.txMode;
+    var mode = new txMode.TransactionMode({ tiLevel: txMode.isolationLevel.repeatableRead });
+
+    return self.library.db.tx({ mode: mode }, function (t) {
       return t.none(sql.upsertMetaWriting, meta).then(function () {
         return t.none(sql.clearSlotTables(slot));
       }).then(function () {
         return t.none(sql.copyLiveToSlot(slot));
       }).then(function () {
+        // Guard against a copy that captured state ahead of the checkpoint block.
+        return t.oneOrNone(sql.getSlotAccountsMaxBlockHeight(slot));
+      }).then(function (row) {
+        var copiedHeight = row && row.height !== null ? parseInt(row.height, 10) : 0;
+
+        if (copiedHeight > parseInt(block.height, 10)) {
+          throw new Error('Checkpoint copy captured state ahead of block ' + block.height + ' (found height ' + copiedHeight + ')');
+        }
+
         return self.computeDigest(t, slot, meta);
       }).then(function (digest) {
         return t.none(sql.markMetaComplete, { slot: slot, digest: digest });
@@ -328,12 +411,14 @@ MemCheckpoint.prototype.findRecoverableCheckpoint = function (tipHeight, tipRoun
       return null;
     }
 
-    if (parseInt(meta.height, 10) >= parseInt(tipHeight, 10)) {
-      return null;
-    }
-
     var checkpointHeight = parseInt(meta.height, 10);
     var chainHeight = parseInt(tipHeight, 10);
+
+    // A checkpoint exactly at the chain tip is valid and needs zero replay;
+    // only checkpoints ahead of the local chain are unusable.
+    if (checkpointHeight > chainHeight) {
+      return null;
+    }
 
     // Genesis-height checkpoints are test-only; real nodes only persist round-boundary slots (>= delegates).
     if (checkpointHeight < slots.delegates && chainHeight > slots.delegates) {
@@ -361,6 +446,8 @@ MemCheckpoint.prototype.findRecoverableCheckpoint = function (tipHeight, tipRoun
 
 /**
  * Replace live mem_* tables with a verified checkpoint slot.
+ * Unconfirmed (u_*) state is reset to the confirmed state after the copy,
+ * because the transaction pool the checkpoint observed no longer exists.
  * @param {object} meta Verified checkpoint metadata.
  * @return {Promise<object>} Restored checkpoint metadata.
  */
@@ -372,6 +459,8 @@ MemCheckpoint.prototype.restoreCheckpoint = function (meta) {
   return self.library.db.tx(function (t) {
     return t.none(sql.clearLiveTables).then(function () {
       return t.none(sql.copySlotToLive(slot));
+    }).then(function () {
+      return t.none(sql.resetUnconfirmedState);
     }).then(function () {
       return self.validateRestoredInvariants(t, meta, checkpointRound);
     }).then(function (valid) {

--- a/logic/memCheckpoint.js
+++ b/logic/memCheckpoint.js
@@ -19,14 +19,16 @@ var SYNC_ROUND_INTERVAL = 100;
 
 /**
  * Checkpoint table copy/hash order. Accounts must come before dependent tables.
+ * Unconfirmed junction tables (`*2u_*`) are intentionally excluded: they are
+ * deterministically rebuilt from confirmed state on restore (see
+ * `sql.resetUnconfirmedStateStatements`), so copying and hashing them is wasted
+ * work that would only slow the per-round copy.
  * @type {string[]}
  */
 var TABLE_ORDER = [
   'accounts',
   'accounts2delegates',
-  'accounts2u_delegates',
   'accounts2multisignatures',
-  'accounts2u_multisignatures',
   'round'
 ];
 
@@ -284,8 +286,12 @@ MemCheckpoint.prototype.verifyCheckpointMeta = function (meta, nethash) {
       return null;
     }
 
+    // Normalize slot to a number: some pg parsers (e.g. pg-native) return the
+    // SMALLINT column as a string, which slotTableNames() would reject.
+    var slot = parseInt(meta.slot, 10);
+
     return self.library.db.tx(function (t) {
-      return self.computeDigest(t, meta.slot, meta).then(function (digest) {
+      return self.computeDigest(t, slot, meta).then(function (digest) {
         if (digest !== meta.digest) {
           self.library.logger.warn('memCheckpoints', 'Rejecting checkpoint with invalid digest');
           return null;
@@ -352,17 +358,34 @@ MemCheckpoint.prototype.verifySlotSchemas = function () {
  * @param {object} block Last block of the completed round.
  * @param {number} round Round number for the checkpoint.
  * @param {string} nethash Node nethash written into metadata.
+ * @param {Function} [onPinned] Invoked once the transaction has pinned its MVCC
+ *   snapshot to `block`; the caller may then release the block-processing
+ *   critical section while the copy continues in the background.
  * @return {Promise<void>}
  */
-MemCheckpoint.prototype.createCheckpoint = function (block, round, nethash) {
+MemCheckpoint.prototype.createCheckpoint = function (block, round, nethash, onPinned) {
   var self = this;
 
+  var pinned = false;
+  var signalPinned = function () {
+    if (pinned) {
+      return;
+    }
+    pinned = true;
+    if (onPinned) {
+      onPinned();
+    }
+  };
+
   if (!self.isEnabled()) {
+    signalPinned();
     return Promise.resolve();
   }
 
   // REPEATABLE READ gives all copy and digest statements one MVCC snapshot,
-  // so the six copied tables cannot mix state from different blocks.
+  // so the copied tables cannot mix state from different blocks. The snapshot is
+  // established by the first statement below and stays frozen for the whole
+  // transaction, so the copy can safely run after the critical section is released.
   var txMode = self.library.db.$config.pgp.txMode;
   var mode = new txMode.TransactionMode({ tiLevel: txMode.isolationLevel.repeatableRead });
   var createdSlot;
@@ -383,6 +406,23 @@ MemCheckpoint.prototype.createCheckpoint = function (block, round, nethash) {
       };
 
       return t.none(sql.upsertMetaWriting, meta).then(function () {
+        // The snapshot is now frozen at `block` (the reads above ran within it);
+        // safe to let the caller resume block processing while the copy proceeds.
+        signalPinned();
+        return t.any(sql.getMemRounds);
+      }).then(function (roundRows) {
+        // Settled round boundary: mem_round must hold only rows for this round
+        // (usually none). Anything else means the snapshot captured an unsettled
+        // or mid-block state, so refuse to persist a misleading checkpoint.
+        var expectedRound = String(round);
+        var unsettled = roundRows.filter(function (row) {
+          return String(row.round) !== expectedRound;
+        });
+
+        if (unsettled.length > 0) {
+          throw new Error('mem_round not settled at checkpoint boundary for round ' + round);
+        }
+
         return execStatementsSequential(t, sql.clearSlotTablesStatements(slot));
       }).then(function () {
         return execStatementsSequential(t, sql.copyLiveToSlotStatements(slot));
@@ -409,12 +449,18 @@ MemCheckpoint.prototype.createCheckpoint = function (block, round, nethash) {
       blockId: block.id
     });
   }).catch(function (err) {
-    self.library.logger.error('memCheckpoints', `Failed to create checkpoint: ${err?.message || err}`, err.stack);
+    self.library.logger.error('memCheckpoints', `Failed to create checkpoint: ${err?.message || err}`, err && err.stack);
+  }).then(function () {
+    // Release the caller even if the transaction failed before the pin was reached.
+    signalPinned();
   });
 };
 
 /**
- * Find the latest checkpoint that is safe to restore for the current chain tip.
+ * Find the newest checkpoint that is safe to restore for the current chain tip.
+ * All complete slots are considered from newest to oldest, so a corrupted or
+ * stale newest slot no longer forces a full rebuild while an older, still-valid
+ * slot exists — that is the point of keeping {@link CHECKPOINT_SLOT_COUNT} slots.
  * @param {number} tipHeight Current chain height/block count used by loader.
  * @param {number} tipRound Current round at chain tip.
  * @param {string} nethash Expected node nethash.
@@ -427,41 +473,55 @@ MemCheckpoint.prototype.findRecoverableCheckpoint = function (tipHeight, tipRoun
     return Promise.resolve(null);
   }
 
-  return self.getLatestComplete().then(function (meta) {
-    if (!meta) {
+  var chainHeight = parseInt(tipHeight, 10);
+
+  return self.library.db.any(sql.getCompleteDesc).then(function (metas) {
+    if (!metas || !metas.length) {
       return null;
     }
 
-    var checkpointHeight = parseInt(meta.height, 10);
-    var chainHeight = parseInt(tipHeight, 10);
+    var index = 0;
 
-    // A checkpoint exactly at the chain tip is valid and needs zero replay;
-    // only checkpoints ahead of the local chain are unusable.
-    if (checkpointHeight > chainHeight) {
-      return null;
-    }
+    var tryNext = function () {
+      if (index >= metas.length) {
+        return Promise.resolve(null);
+      }
 
-    // Genesis-height checkpoints are test-only; real nodes only persist round-boundary slots (>= delegates).
-    if (checkpointHeight < slots.delegates && chainHeight > slots.delegates) {
-      self.library.logger.warn('memCheckpoints', 'Rejecting pre-round checkpoint on grown chain', {
-        checkpointHeight: checkpointHeight,
-        tipHeight: chainHeight
+      var meta = metas[index++];
+      var checkpointHeight = parseInt(meta.height, 10);
+
+      // A checkpoint ahead of the local chain is unusable; try an older slot.
+      if (checkpointHeight > chainHeight) {
+        return tryNext();
+      }
+
+      // Genesis-height checkpoints are test-only; real nodes only persist round-boundary slots (>= delegates).
+      if (checkpointHeight < slots.delegates && chainHeight > slots.delegates) {
+        self.library.logger.warn('memCheckpoints', 'Skipping pre-round checkpoint on grown chain', {
+          slot: meta.slot,
+          checkpointHeight: checkpointHeight,
+          tipHeight: chainHeight
+        });
+        return tryNext();
+      }
+
+      return self.verifyCheckpointMeta(meta, nethash).then(function (verified) {
+        if (!verified) {
+          return tryNext();
+        }
+
+        if (parseInt(verified.round, 10) > tipRound) {
+          self.library.logger.warn('memCheckpoints', 'Skipping checkpoint with round ahead of chain tip', {
+            slot: verified.slot
+          });
+          return tryNext();
+        }
+
+        return verified;
       });
-      return null;
-    }
+    };
 
-    return self.verifyCheckpointMeta(meta, nethash).then(function (verified) {
-      if (!verified) {
-        return null;
-      }
-
-      if (parseInt(verified.round, 10) > tipRound) {
-        self.library.logger.warn('memCheckpoints', 'Rejecting checkpoint with round ahead of chain tip');
-        return null;
-      }
-
-      return verified;
-    });
+    return tryNext();
   });
 };
 

--- a/logic/memCheckpoint.js
+++ b/logic/memCheckpoint.js
@@ -7,8 +7,8 @@ var sql = require('../sql/memCheckpoints.js');
 /** @type {number} Digest/schema version for checkpoint metadata and hashing. */
 var SCHEMA_VERSION = 1;
 
-/** @type {number} Number of rotating checkpoint slots kept on disk (slots 0..2). */
-var CHECKPOINT_SLOT_COUNT = 3;
+/** @type {number} Number of rotating checkpoint slots kept on disk (slots 0..2). Sourced from sql/memCheckpoints so both layers share one value. */
+var CHECKPOINT_SLOT_COUNT = sql.CHECKPOINT_SLOT_COUNT;
 
 /**
  * Checkpoint every Nth round while the node is catching up with the network,
@@ -229,8 +229,12 @@ MemCheckpoint.prototype.validateRestoredInvariants = function (t, meta, checkpoi
 
     return t.query(sql.getMemRounds);
   }).then(function (roundRows) {
+    // Coerce row.round to string before comparing, matching createCheckpoint's
+    // settled-boundary check. Some pg parsers (e.g. pg-native) return the BIGINT
+    // round column as a number; a bare `!==` against the string expectedRound
+    // would then flag matching rows as unapplied and reject every restore.
     var unapplied = roundRows.filter(function (row) {
-      return row.round !== expectedRound;
+      return String(row.round) !== expectedRound;
     });
 
     if (unapplied.length > 0) {

--- a/logic/memCheckpoint.js
+++ b/logic/memCheckpoint.js
@@ -1,0 +1,354 @@
+'use strict';
+
+var crypto = require('crypto');
+var slots = require('../helpers/slots.js');
+var sql = require('../sql/memCheckpoints.js');
+
+var SCHEMA_VERSION = 1;
+var TABLE_ORDER = [
+  'accounts',
+  'accounts2delegates',
+  'accounts2u_delegates',
+  'accounts2multisignatures',
+  'accounts2u_multisignatures',
+  'round'
+];
+
+/**
+ * Persisted mem-table checkpoint logic for crash recovery.
+ * Checkpoints are a local recovery cache only; blocks remain the source of truth.
+ *
+ * @param {object} scope
+ * @param {Database} scope.db
+ * @param {Logger} scope.logger
+ * @param {object} scope.config
+ * @constructor
+ */
+function MemCheckpoint (scope) {
+  this.scope = scope;
+  this.library = {
+    db: scope.db,
+    logger: scope.logger,
+    config: scope.config
+  };
+}
+
+MemCheckpoint.SCHEMA_VERSION = SCHEMA_VERSION;
+
+/**
+ * @return {boolean}
+ */
+MemCheckpoint.prototype.isEnabled = function () {
+  var config = this.library.config.memCheckpoints || {};
+  return config.enabled !== false;
+};
+
+/**
+ * @return {number}
+ */
+MemCheckpoint.prototype.getRetention = function () {
+  var config = this.library.config.memCheckpoints || {};
+  var retention = parseInt(config.retention, 10);
+
+  if (isNaN(retention) || retention < 2) {
+    return 3;
+  }
+
+  if (retention > 3) {
+    return 3;
+  }
+
+  return retention;
+};
+
+/**
+ * @param {number} height
+ * @return {boolean}
+ */
+MemCheckpoint.prototype.isRoundBoundaryBlock = function (height) {
+  var round = Math.ceil(height / slots.delegates);
+  var nextRound = Math.ceil((height + 1) / slots.delegates);
+
+  return round !== nextRound || height === 1 || height === slots.delegates + 1;
+};
+
+/**
+ * @param {object|null} latestMeta
+ * @return {number}
+ */
+MemCheckpoint.prototype.getNextSlot = function (latestMeta) {
+  var retention = this.getRetention();
+
+  if (!latestMeta || latestMeta.slot === undefined || latestMeta.slot === null) {
+    return 0;
+  }
+
+  return (parseInt(latestMeta.slot, 10) + 1) % retention;
+};
+
+/**
+ * @param {object} meta
+ * @return {string}
+ */
+MemCheckpoint.prototype.buildDigestDomain = function (meta) {
+  return [
+    SCHEMA_VERSION,
+    meta.height,
+    meta.blockId,
+    meta.round,
+    meta.nethash
+  ].join(':');
+};
+
+/**
+ * @param {object} t - pg-promise task/tx
+ * @param {number} slot
+ * @param {object} meta
+ * @return {Promise<string>}
+ */
+MemCheckpoint.prototype.computeDigest = function (t, slot, meta) {
+  var self = this;
+  var hash = crypto.createHash('sha256');
+  var tables = sql.slotTableNames(slot);
+
+  hash.update(self.buildDigestDomain(meta));
+  hash.update('\n');
+
+  return TABLE_ORDER.reduce(function (promise, tableKey) {
+    return promise.then(function () {
+      var tableName = tables[tableKey];
+      var query = tableKey === 'round' ?
+        sql.canonicalRound :
+        (tableKey === 'accounts' ? sql.canonicalAccounts : sql.canonicalAccountDelegates);
+
+      return t.any(query, { tableName: tableName }).then(function (rows) {
+        hash.update(tableKey);
+        hash.update('\n');
+
+        rows.forEach(function (row) {
+          hash.update(row.line);
+          hash.update('\n');
+        });
+      });
+    });
+  }, Promise.resolve()).then(function () {
+    return hash.digest('hex');
+  });
+};
+
+/**
+ * @param {object} t
+ * @param {object} meta
+ * @param {number} tipRound
+ * @return {Promise<boolean>}
+ */
+MemCheckpoint.prototype.validateRestoredInvariants = function (t, meta, tipRound) {
+  return t.batch([
+    t.one(sql.countMemAccountsAtBlock, { blockId: meta.blockId }),
+    t.query(sql.getMemRounds),
+    t.query(sql.getOrphanedMemAccounts),
+    t.query(sql.getDelegates)
+  ]).then(function (results) {
+    if (!results[0].count) {
+      return false;
+    }
+
+    var unapplied = results[1].filter(function (row) {
+      return row.round !== String(tipRound);
+    });
+
+    if (unapplied.length > 0) {
+      return false;
+    }
+
+    if (results[2].length > 0) {
+      return false;
+    }
+
+    if (results[3].length === 0) {
+      return false;
+    }
+
+    return true;
+  });
+};
+
+/**
+ * @param {object} meta
+ * @param {string} nethash
+ * @return {Promise<object|null>}
+ */
+MemCheckpoint.prototype.verifyCheckpointMeta = function (meta, nethash) {
+  var self = this;
+  var db = self.library.db;
+
+  if (!meta || meta.status !== 'complete') {
+    return Promise.resolve(null);
+  }
+
+  if (parseInt(meta.schemaVersion, 10) !== SCHEMA_VERSION) {
+    self.library.logger.warn('memCheckpoints', 'Rejecting checkpoint with unsupported schema version', {
+      expected: SCHEMA_VERSION,
+      actual: meta.schemaVersion
+    });
+    return Promise.resolve(null);
+  }
+
+  if (meta.nethash !== nethash) {
+    self.library.logger.warn('memCheckpoints', 'Rejecting checkpoint with mismatched nethash');
+    return Promise.resolve(null);
+  }
+
+  if (!meta.digest) {
+    self.library.logger.warn('memCheckpoints', 'Rejecting checkpoint without digest');
+    return Promise.resolve(null);
+  }
+
+  return db.oneOrNone(sql.blockExists, {
+    blockId: meta.blockId,
+    height: meta.height
+  }).then(function (block) {
+    if (!block) {
+      self.library.logger.warn('memCheckpoints', 'Rejecting checkpoint with missing block reference', {
+        blockId: meta.blockId,
+        height: meta.height
+      });
+      return null;
+    }
+
+    return db.tx(function (t) {
+      return self.computeDigest(t, meta.slot, meta).then(function (digest) {
+        if (digest !== meta.digest) {
+          self.library.logger.warn('memCheckpoints', 'Rejecting checkpoint with invalid digest');
+          return null;
+        }
+
+        return meta;
+      });
+    });
+  });
+};
+
+/**
+ * @return {Promise<object|null>}
+ */
+MemCheckpoint.prototype.getLatestComplete = function () {
+  return this.library.db.oneOrNone(sql.getLatestComplete);
+};
+
+/**
+ * @param {object} block
+ * @param {number} round
+ * @param {string} nethash
+ * @return {Promise<void>}
+ */
+MemCheckpoint.prototype.createCheckpoint = function (block, round, nethash) {
+  var self = this;
+
+  if (!self.isEnabled()) {
+    return Promise.resolve();
+  }
+
+  return self.getLatestComplete().then(function (latestMeta) {
+    var slot = self.getNextSlot(latestMeta);
+    var createdAt = Date.now();
+    var meta = {
+      slot: slot,
+      schemaVersion: SCHEMA_VERSION,
+      height: block.height,
+      blockId: block.id,
+      round: round,
+      nethash: nethash,
+      createdAt: createdAt
+    };
+
+    return self.library.db.tx(function (t) {
+      return t.none(sql.upsertMetaWriting, meta).then(function () {
+        return t.none(sql.clearSlotTables(slot));
+      }).then(function () {
+        return t.none(sql.copyLiveToSlot(slot));
+      }).then(function () {
+        return self.computeDigest(t, slot, meta);
+      }).then(function (digest) {
+        return t.none(sql.markMetaComplete, { slot: slot, digest: digest });
+      });
+    }).then(function () {
+      self.library.logger.info('memCheckpoints', 'Created mem-table checkpoint', {
+        slot: slot,
+        height: block.height,
+        round: round,
+        blockId: block.id
+      });
+    }).catch(function (err) {
+      self.library.logger.error('memCheckpoints', `Failed to create checkpoint: ${err?.message || err}`, err.stack);
+    });
+  });
+};
+
+/**
+ * @param {number} tipHeight
+ * @param {number} tipRound
+ * @param {string} nethash
+ * @return {Promise<object|null>}
+ */
+MemCheckpoint.prototype.findRecoverableCheckpoint = function (tipHeight, tipRound, nethash) {
+  var self = this;
+
+  if (!self.isEnabled()) {
+    return Promise.resolve(null);
+  }
+
+  return self.getLatestComplete().then(function (meta) {
+    if (!meta || meta.height >= tipHeight) {
+      return null;
+    }
+
+    return self.verifyCheckpointMeta(meta, nethash).then(function (verified) {
+      if (!verified) {
+        return null;
+      }
+
+      if (parseInt(verified.round, 10) > tipRound) {
+        self.library.logger.warn('memCheckpoints', 'Rejecting checkpoint with round ahead of chain tip');
+        return null;
+      }
+
+      return verified;
+    });
+  });
+};
+
+/**
+ * @param {object} meta
+ * @param {number} tipRound
+ * @return {Promise<object>}
+ */
+MemCheckpoint.prototype.restoreCheckpoint = function (meta, tipRound) {
+  var self = this;
+  var slot = parseInt(meta.slot, 10);
+
+  return self.library.db.tx(function (t) {
+    return t.none(sql.clearLiveTables).then(function () {
+      return t.none(sql.copySlotToLive(slot));
+    }).then(function () {
+      return self.validateRestoredInvariants(t, meta, tipRound);
+    }).then(function (valid) {
+      if (!valid) {
+        throw new Error('Restored checkpoint failed invariant checks');
+      }
+
+      return meta;
+    });
+  }).then(function (restoredMeta) {
+    self.library.logger.info('memCheckpoints', 'Restored mem-table checkpoint', {
+      slot: restoredMeta.slot,
+      height: restoredMeta.height,
+      round: restoredMeta.round,
+      blockId: restoredMeta.blockId
+    });
+
+    return restoredMeta;
+  });
+};
+
+module.exports = MemCheckpoint;

--- a/logic/memCheckpoint.js
+++ b/logic/memCheckpoint.js
@@ -139,10 +139,10 @@ MemCheckpoint.prototype.computeDigest = function (t, slot, meta) {
 /**
  * @param {object} t
  * @param {object} meta
- * @param {number} tipRound
+ * @param {number} checkpointRound
  * @return {Promise<boolean>}
  */
-MemCheckpoint.prototype.validateRestoredInvariants = function (t, meta, tipRound) {
+MemCheckpoint.prototype.validateRestoredInvariants = function (t, meta, checkpointRound) {
   return t.batch([
     t.one(sql.countMemAccountsAtBlock, { blockId: meta.blockId }),
     t.query(sql.getMemRounds),
@@ -153,8 +153,10 @@ MemCheckpoint.prototype.validateRestoredInvariants = function (t, meta, tipRound
       return false;
     }
 
+    var expectedRound = String(checkpointRound);
+
     var unapplied = results[1].filter(function (row) {
-      return row.round !== String(tipRound);
+      return row.round !== expectedRound;
     });
 
     if (unapplied.length > 0) {
@@ -299,7 +301,7 @@ MemCheckpoint.prototype.findRecoverableCheckpoint = function (tipHeight, tipRoun
   }
 
   return self.getLatestComplete().then(function (meta) {
-    if (!meta || meta.height >= tipHeight) {
+    if (!meta || parseInt(meta.height, 10) >= parseInt(tipHeight, 10)) {
       return null;
     }
 
@@ -320,18 +322,18 @@ MemCheckpoint.prototype.findRecoverableCheckpoint = function (tipHeight, tipRoun
 
 /**
  * @param {object} meta
- * @param {number} tipRound
  * @return {Promise<object>}
  */
-MemCheckpoint.prototype.restoreCheckpoint = function (meta, tipRound) {
+MemCheckpoint.prototype.restoreCheckpoint = function (meta) {
   var self = this;
   var slot = parseInt(meta.slot, 10);
+  var checkpointRound = parseInt(meta.round, 10);
 
   return self.library.db.tx(function (t) {
     return t.none(sql.clearLiveTables).then(function () {
       return t.none(sql.copySlotToLive(slot));
     }).then(function () {
-      return self.validateRestoredInvariants(t, meta, tipRound);
+      return self.validateRestoredInvariants(t, meta, checkpointRound);
     }).then(function (valid) {
       if (!valid) {
         throw new Error('Restored checkpoint failed invariant checks');

--- a/logic/memCheckpoint.js
+++ b/logic/memCheckpoint.js
@@ -48,6 +48,25 @@ function appendTableDigest (hash, tableKey, rows) {
 }
 
 /**
+ * Run SQL statements sequentially on one pg client.
+ * pg-native rejects overlapping queries on the same connection.
+ * @param {object} t pg-promise task/transaction.
+ * @param {string[]} statements
+ * @return {Promise<void>}
+ */
+function execStatementsSequential (t, statements) {
+  if (!statements || !statements.length) {
+    return Promise.resolve();
+  }
+
+  return statements.reduce(function (promise, statement) {
+    return promise.then(function () {
+      return t.none(statement);
+    });
+  }, Promise.resolve());
+}
+
+/**
  * Persisted mem-table checkpoint logic for crash recovery.
  * Checkpoints are a local recovery cache only; blocks remain the source of truth.
  *
@@ -342,29 +361,31 @@ MemCheckpoint.prototype.createCheckpoint = function (block, round, nethash) {
     return Promise.resolve();
   }
 
-  return self.getLatestComplete().then(function (latestMeta) {
-    var slot = self.getNextSlot(latestMeta);
-    var createdAt = Date.now();
-    var meta = {
-      slot: slot,
-      schemaVersion: SCHEMA_VERSION,
-      height: block.height,
-      blockId: block.id,
-      round: round,
-      nethash: nethash,
-      createdAt: createdAt
-    };
+  // REPEATABLE READ gives all copy and digest statements one MVCC snapshot,
+  // so the six copied tables cannot mix state from different blocks.
+  var txMode = self.library.db.$config.pgp.txMode;
+  var mode = new txMode.TransactionMode({ tiLevel: txMode.isolationLevel.repeatableRead });
+  var createdSlot;
 
-    // REPEATABLE READ gives all copy and digest statements one MVCC snapshot,
-    // so the six copied tables cannot mix state from different blocks.
-    var txMode = self.library.db.$config.pgp.txMode;
-    var mode = new txMode.TransactionMode({ tiLevel: txMode.isolationLevel.repeatableRead });
+  return self.library.db.tx({ mode: mode }, function (t) {
+    return t.oneOrNone(sql.getLatestComplete).then(function (latestMeta) {
+      var slot = self.getNextSlot(latestMeta);
+      createdSlot = slot;
+      var createdAt = Date.now();
+      var meta = {
+        slot: slot,
+        schemaVersion: SCHEMA_VERSION,
+        height: block.height,
+        blockId: block.id,
+        round: round,
+        nethash: nethash,
+        createdAt: createdAt
+      };
 
-    return self.library.db.tx({ mode: mode }, function (t) {
       return t.none(sql.upsertMetaWriting, meta).then(function () {
-        return t.none(sql.clearSlotTables(slot));
+        return execStatementsSequential(t, sql.clearSlotTablesStatements(slot));
       }).then(function () {
-        return t.none(sql.copyLiveToSlot(slot));
+        return execStatementsSequential(t, sql.copyLiveToSlotStatements(slot));
       }).then(function () {
         // Guard against a copy that captured state ahead of the checkpoint block.
         return t.oneOrNone(sql.getSlotAccountsMaxBlockHeight(slot));
@@ -379,16 +400,16 @@ MemCheckpoint.prototype.createCheckpoint = function (block, round, nethash) {
       }).then(function (digest) {
         return t.none(sql.markMetaComplete, { slot: slot, digest: digest });
       });
-    }).then(function () {
-      self.library.logger.info('memCheckpoints', 'Created mem-table checkpoint', {
-        slot: slot,
-        height: block.height,
-        round: round,
-        blockId: block.id
-      });
-    }).catch(function (err) {
-      self.library.logger.error('memCheckpoints', `Failed to create checkpoint: ${err?.message || err}`, err.stack);
     });
+  }).then(function () {
+    self.library.logger.info('memCheckpoints', 'Created mem-table checkpoint', {
+      slot: createdSlot,
+      height: block.height,
+      round: round,
+      blockId: block.id
+    });
+  }).catch(function (err) {
+    self.library.logger.error('memCheckpoints', `Failed to create checkpoint: ${err?.message || err}`, err.stack);
   });
 };
 
@@ -457,10 +478,10 @@ MemCheckpoint.prototype.restoreCheckpoint = function (meta) {
   var checkpointRound = parseInt(meta.round, 10);
 
   return self.library.db.tx(function (t) {
-    return t.none(sql.clearLiveTables).then(function () {
-      return t.none(sql.copySlotToLive(slot));
+    return execStatementsSequential(t, sql.clearLiveTablesStatements).then(function () {
+      return execStatementsSequential(t, sql.copySlotToLiveStatements(slot));
     }).then(function () {
-      return t.none(sql.resetUnconfirmedState);
+      return execStatementsSequential(t, sql.resetUnconfirmedStateStatements);
     }).then(function () {
       return self.validateRestoredInvariants(t, meta, checkpointRound);
     }).then(function (valid) {
@@ -483,3 +504,4 @@ MemCheckpoint.prototype.restoreCheckpoint = function (meta) {
 };
 
 module.exports = MemCheckpoint;
+module.exports.execStatementsSequential = execStatementsSequential;

--- a/logic/memCheckpoint.js
+++ b/logic/memCheckpoint.js
@@ -215,10 +215,16 @@ MemCheckpoint.prototype.computeDigest = function (t, slot, meta) {
 MemCheckpoint.prototype.validateRestoredInvariants = function (t, meta, checkpointRound) {
   var expectedRound = String(checkpointRound);
 
-  // Run checks sequentially: pg-native rejects overlapping queries on one client.
+  // Each `.then` result feeds the next handler, so a bare `return false` would
+  // not short-circuit — it would be consumed as the next query's rows and
+  // corrupt later checks (e.g. `false.length` / `false.filter`). Track failure
+  // in a flag instead, and run the checks sequentially (pg-native rejects
+  // overlapping queries on one client).
+  var failed = false;
+
   return t.one(sql.countMemAccountsAtBlock, { blockId: meta.blockId }).then(function (accounts) {
     if (!accounts.count) {
-      return false;
+      failed = true;
     }
 
     return t.query(sql.getMemRounds);
@@ -228,18 +234,18 @@ MemCheckpoint.prototype.validateRestoredInvariants = function (t, meta, checkpoi
     });
 
     if (unapplied.length > 0) {
-      return false;
+      failed = true;
     }
 
     return t.query(sql.getOrphanedMemAccounts);
   }).then(function (orphanedRows) {
     if (orphanedRows.length > 0) {
-      return false;
+      failed = true;
     }
 
     return t.query(sql.getDelegates);
   }).then(function (delegateRows) {
-    return delegateRows.length > 0;
+    return !failed && delegateRows.length > 0;
   });
 };
 
@@ -406,8 +412,12 @@ MemCheckpoint.prototype.createCheckpoint = function (block, round, nethash, onPi
       };
 
       return t.none(sql.upsertMetaWriting, meta).then(function () {
-        // The snapshot is now frozen at `block` (the reads above ran within it);
-        // safe to let the caller resume block processing while the copy proceeds.
+        // The MVCC snapshot was frozen at `block` by this transaction's first
+        // statement (`getLatestComplete` above); every read since — and every
+        // copy/digest read below — observes that same snapshot, so later blocks
+        // are invisible. We signal here (after the `writing` meta row is
+        // persisted) to let the caller resume block processing while the copy
+        // proceeds against the frozen snapshot.
         signalPinned();
         return t.any(sql.getMemRounds);
       }).then(function (roundRows) {

--- a/logic/memCheckpoint.js
+++ b/logic/memCheckpoint.js
@@ -4,7 +4,16 @@ var crypto = require('crypto');
 var slots = require('../helpers/slots.js');
 var sql = require('../sql/memCheckpoints.js');
 
+/** @type {number} Digest/schema version for checkpoint metadata and hashing. */
 var SCHEMA_VERSION = 1;
+
+/** @type {number} Number of rotating checkpoint slots kept on disk (slots 0..2). */
+var CHECKPOINT_SLOT_COUNT = 3;
+
+/**
+ * Checkpoint table copy/hash order. Accounts must come before dependent tables.
+ * @type {string[]}
+ */
 var TABLE_ORDER = [
   'accounts',
   'accounts2delegates',
@@ -15,6 +24,23 @@ var TABLE_ORDER = [
 ];
 
 /**
+ * Append one checkpoint table to the running SHA-256 digest.
+ * @private
+ * @param {object} hash Node.js hash instance.
+ * @param {string} tableKey Logical table key from {@link TABLE_ORDER}.
+ * @param {object[]} rows Canonical rows ordered by SQL.
+ */
+function appendTableDigest (hash, tableKey, rows) {
+  hash.update(tableKey);
+  hash.update('\n');
+
+  rows.forEach(function (row) {
+    hash.update(row.line);
+    hash.update('\n');
+  });
+}
+
+/**
  * Persisted mem-table checkpoint logic for crash recovery.
  * Checkpoints are a local recovery cache only; blocks remain the source of truth.
  *
@@ -22,6 +48,8 @@ var TABLE_ORDER = [
  * @param {Database} scope.db
  * @param {Logger} scope.logger
  * @param {object} scope.config
+ * @param {object} [scope.config.memCheckpoints]
+ * @param {boolean} [scope.config.memCheckpoints.enabled]
  * @constructor
  */
 function MemCheckpoint (scope) {
@@ -33,9 +61,14 @@ function MemCheckpoint (scope) {
   };
 }
 
+/** @type {number} */
 MemCheckpoint.SCHEMA_VERSION = SCHEMA_VERSION;
 
+/** @type {number} */
+MemCheckpoint.CHECKPOINT_SLOT_COUNT = CHECKPOINT_SLOT_COUNT;
+
 /**
+ * Whether persisted mem-table checkpoints are enabled.
  * @return {boolean}
  */
 MemCheckpoint.prototype.isEnabled = function () {
@@ -44,24 +77,7 @@ MemCheckpoint.prototype.isEnabled = function () {
 };
 
 /**
- * @return {number}
- */
-MemCheckpoint.prototype.getRetention = function () {
-  var config = this.library.config.memCheckpoints || {};
-  var retention = parseInt(config.retention, 10);
-
-  if (isNaN(retention) || retention < 2) {
-    return 3;
-  }
-
-  if (retention > 3) {
-    return 3;
-  }
-
-  return retention;
-};
-
-/**
+ * Whether a block height is a completed-round boundary where checkpoints are safe to take.
  * @param {number} height
  * @return {boolean}
  */
@@ -73,21 +89,25 @@ MemCheckpoint.prototype.isRoundBoundaryBlock = function (height) {
 };
 
 /**
- * @param {object|null} latestMeta
+ * Select the next rotating slot index for a new checkpoint write.
+ * @param {object|null} latestMeta Latest complete checkpoint metadata row.
  * @return {number}
  */
 MemCheckpoint.prototype.getNextSlot = function (latestMeta) {
-  var retention = this.getRetention();
-
   if (!latestMeta || latestMeta.slot === undefined || latestMeta.slot === null) {
     return 0;
   }
 
-  return (parseInt(latestMeta.slot, 10) + 1) % retention;
+  return (parseInt(latestMeta.slot, 10) + 1) % CHECKPOINT_SLOT_COUNT;
 };
 
 /**
+ * Build the metadata prefix included in the checkpoint digest domain.
  * @param {object} meta
+ * @param {number|string} meta.height
+ * @param {string} meta.blockId
+ * @param {number|string} meta.round
+ * @param {string} meta.nethash
  * @return {string}
  */
 MemCheckpoint.prototype.buildDigestDomain = function (meta) {
@@ -101,61 +121,61 @@ MemCheckpoint.prototype.buildDigestDomain = function (meta) {
 };
 
 /**
- * @param {object} t - pg-promise task/tx
- * @param {number} slot
- * @param {object} meta
- * @return {Promise<string>}
+ * Compute a deterministic SHA-256 digest over checkpoint metadata and slot table contents.
+ * Queries run sequentially on the supplied task to avoid overlapping pg client queries.
+ * @param {object} t pg-promise task/transaction.
+ * @param {number} slot Checkpoint slot index.
+ * @param {object} meta Checkpoint metadata used for the digest domain.
+ * @return {Promise<string>} Hex-encoded digest.
  */
 MemCheckpoint.prototype.computeDigest = function (t, slot, meta) {
-  var self = this;
   var hash = crypto.createHash('sha256');
   var tables = sql.slotTableNames(slot);
+  var tableIndex = 0;
 
-  hash.update(self.buildDigestDomain(meta));
+  hash.update(this.buildDigestDomain(meta));
   hash.update('\n');
 
-  return TABLE_ORDER.reduce(function (promise, tableKey) {
-    return promise.then(function () {
-      var tableName = tables[tableKey];
-      var query = tableKey === 'round' ?
-        sql.canonicalRound :
-        (tableKey === 'accounts' ? sql.canonicalAccounts : sql.canonicalAccountDelegates);
+  var digestNextTable = function () {
+    if (tableIndex >= TABLE_ORDER.length) {
+      return Promise.resolve(hash.digest('hex'));
+    }
 
-      return t.any(query, { tableName: tableName }).then(function (rows) {
-        hash.update(tableKey);
-        hash.update('\n');
+    var tableKey = TABLE_ORDER[tableIndex++];
+    var tableName = tables[tableKey];
+    var query = tableKey === 'round' ?
+      sql.canonicalRound :
+      (tableKey === 'accounts' ? sql.canonicalAccounts : sql.canonicalAccountDelegates);
 
-        rows.forEach(function (row) {
-          hash.update(row.line);
-          hash.update('\n');
-        });
-      });
+    return t.any(query, { tableName: tableName }).then(function (rows) {
+      appendTableDigest(hash, tableKey, rows);
+      return digestNextTable();
     });
-  }, Promise.resolve()).then(function () {
-    return hash.digest('hex');
-  });
+  };
+
+  return digestNextTable();
 };
 
 /**
- * @param {object} t
- * @param {object} meta
- * @param {number} checkpointRound
+ * Validate restored live mem_* tables against checkpoint metadata.
+ * Uses the checkpoint round, not the current chain tip round.
+ * @param {object} t pg-promise task/transaction.
+ * @param {object} meta Restored checkpoint metadata.
+ * @param {number} checkpointRound Round encoded in the checkpoint.
  * @return {Promise<boolean>}
  */
 MemCheckpoint.prototype.validateRestoredInvariants = function (t, meta, checkpointRound) {
-  return t.batch([
-    t.one(sql.countMemAccountsAtBlock, { blockId: meta.blockId }),
-    t.query(sql.getMemRounds),
-    t.query(sql.getOrphanedMemAccounts),
-    t.query(sql.getDelegates)
-  ]).then(function (results) {
-    if (!results[0].count) {
+  var expectedRound = String(checkpointRound);
+
+  // Run checks sequentially: pg-native rejects overlapping queries on one client.
+  return t.one(sql.countMemAccountsAtBlock, { blockId: meta.blockId }).then(function (accounts) {
+    if (!accounts.count) {
       return false;
     }
 
-    var expectedRound = String(checkpointRound);
-
-    var unapplied = results[1].filter(function (row) {
+    return t.query(sql.getMemRounds);
+  }).then(function (roundRows) {
+    var unapplied = roundRows.filter(function (row) {
       return row.round !== expectedRound;
     });
 
@@ -163,26 +183,26 @@ MemCheckpoint.prototype.validateRestoredInvariants = function (t, meta, checkpoi
       return false;
     }
 
-    if (results[2].length > 0) {
+    return t.query(sql.getOrphanedMemAccounts);
+  }).then(function (orphanedRows) {
+    if (orphanedRows.length > 0) {
       return false;
     }
 
-    if (results[3].length === 0) {
-      return false;
-    }
-
-    return true;
+    return t.query(sql.getDelegates);
+  }).then(function (delegateRows) {
+    return delegateRows.length > 0;
   });
 };
 
 /**
- * @param {object} meta
- * @param {string} nethash
- * @return {Promise<object|null>}
+ * Verify checkpoint metadata, block reference, and stored digest.
+ * @param {object} meta Checkpoint metadata row.
+ * @param {string} nethash Expected node nethash.
+ * @return {Promise<object|null>} Verified metadata or null when rejected.
  */
 MemCheckpoint.prototype.verifyCheckpointMeta = function (meta, nethash) {
   var self = this;
-  var db = self.library.db;
 
   if (!meta || meta.status !== 'complete') {
     return Promise.resolve(null);
@@ -206,7 +226,7 @@ MemCheckpoint.prototype.verifyCheckpointMeta = function (meta, nethash) {
     return Promise.resolve(null);
   }
 
-  return db.oneOrNone(sql.blockExists, {
+  return self.library.db.oneOrNone(sql.blockExists, {
     blockId: meta.blockId,
     height: meta.height
   }).then(function (block) {
@@ -218,7 +238,7 @@ MemCheckpoint.prototype.verifyCheckpointMeta = function (meta, nethash) {
       return null;
     }
 
-    return db.tx(function (t) {
+    return self.library.db.tx(function (t) {
       return self.computeDigest(t, meta.slot, meta).then(function (digest) {
         if (digest !== meta.digest) {
           self.library.logger.warn('memCheckpoints', 'Rejecting checkpoint with invalid digest');
@@ -232,6 +252,7 @@ MemCheckpoint.prototype.verifyCheckpointMeta = function (meta, nethash) {
 };
 
 /**
+ * Load the newest complete checkpoint metadata row.
  * @return {Promise<object|null>}
  */
 MemCheckpoint.prototype.getLatestComplete = function () {
@@ -239,9 +260,10 @@ MemCheckpoint.prototype.getLatestComplete = function () {
 };
 
 /**
- * @param {object} block
- * @param {number} round
- * @param {string} nethash
+ * Copy live mem_* tables into a rotating checkpoint slot after a settled round boundary.
+ * @param {object} block Last block of the completed round.
+ * @param {number} round Round number for the checkpoint.
+ * @param {string} nethash Node nethash written into metadata.
  * @return {Promise<void>}
  */
 MemCheckpoint.prototype.createCheckpoint = function (block, round, nethash) {
@@ -288,9 +310,10 @@ MemCheckpoint.prototype.createCheckpoint = function (block, round, nethash) {
 };
 
 /**
- * @param {number} tipHeight
- * @param {number} tipRound
- * @param {string} nethash
+ * Find the latest checkpoint that is safe to restore for the current chain tip.
+ * @param {number} tipHeight Current chain height/block count used by loader.
+ * @param {number} tipRound Current round at chain tip.
+ * @param {string} nethash Expected node nethash.
  * @return {Promise<object|null>}
  */
 MemCheckpoint.prototype.findRecoverableCheckpoint = function (tipHeight, tipRound, nethash) {
@@ -301,7 +324,11 @@ MemCheckpoint.prototype.findRecoverableCheckpoint = function (tipHeight, tipRoun
   }
 
   return self.getLatestComplete().then(function (meta) {
-    if (!meta || parseInt(meta.height, 10) >= parseInt(tipHeight, 10)) {
+    if (!meta) {
+      return null;
+    }
+
+    if (parseInt(meta.height, 10) >= parseInt(tipHeight, 10)) {
       return null;
     }
 
@@ -321,8 +348,9 @@ MemCheckpoint.prototype.findRecoverableCheckpoint = function (tipHeight, tipRoun
 };
 
 /**
- * @param {object} meta
- * @return {Promise<object>}
+ * Replace live mem_* tables with a verified checkpoint slot.
+ * @param {object} meta Verified checkpoint metadata.
+ * @return {Promise<object>} Restored checkpoint metadata.
  */
 MemCheckpoint.prototype.restoreCheckpoint = function (meta) {
   var self = this;

--- a/logic/round.js
+++ b/logic/round.js
@@ -159,7 +159,7 @@ Round.prototype.truncateBlocks = function () {
  * @return {Function} Promise
  */
 Round.prototype.restoreRoundSnapshot = function () {
-  this.scope.library.logger.debug('rounds', 'Restoring mem_round snapshot...', {
+  this.scope.library.logger.debug('rounds', 'Restoring mem_round snapshot…', {
     blockId: this.scope.block.id,
     height: this.scope.block.height,
     round: this.scope.round,
@@ -175,7 +175,7 @@ Round.prototype.restoreRoundSnapshot = function () {
  * @return {Function} Promise
  */
 Round.prototype.restoreVotesSnapshot = function () {
-  this.scope.library.logger.debug('rounds', 'Restoring mem_accounts.vote snapshot...', {
+  this.scope.library.logger.debug('rounds', 'Restoring mem_accounts.vote snapshot…', {
     blockId: this.scope.block.id,
     height: this.scope.block.height,
     round: this.scope.round,

--- a/modules/blocks.js
+++ b/modules/blocks.js
@@ -192,7 +192,7 @@ Blocks.prototype.cleanup = function (cb) {
     // Module is not ready, repeat
     setImmediate(function nextWatch () {
       if (__private.isActive) {
-        library.logger.info('cleanup', 'Waiting for block processing to finish...', {
+        library.logger.info('cleanup', 'Waiting for block processing to finish…', {
           active: __private.isActive,
           cleanup: __private.cleanup
         });

--- a/modules/blocks/chain.js
+++ b/modules/blocks/chain.js
@@ -485,6 +485,10 @@ Chain.prototype.applyBlock = function (block, broadcast, cb, saveBlock) {
     // Allow shutdown, database writes are finished.
     modules.blocks.isActive.set(false);
 
+    if (!err && saveBlock && modules.memCheckpoints) {
+      modules.memCheckpoints.onBlockApplied(block, true);
+    }
+
     // Nullify large objects.
     // Prevents memory leak during synchronization.
     appliedTransactions = unconfirmedTransactionIds = block = null;
@@ -657,7 +661,8 @@ Chain.prototype.onBind = function (scope) {
     accounts: scope.accounts,
     blocks: scope.blocks,
     rounds: scope.rounds,
-    transactions: scope.transactions
+    transactions: scope.transactions,
+    memCheckpoints: scope.memCheckpoints
   };
 
   // Set module as loaded

--- a/modules/blocks/chain.js
+++ b/modules/blocks/chain.js
@@ -486,6 +486,7 @@ Chain.prototype.applyBlock = function (block, broadcast, cb, saveBlock) {
     modules.blocks.isActive.set(false);
 
     if (!err && saveBlock && modules.memCheckpoints) {
+      // Checkpoint only after the full applyBlock pipeline, on completed round boundaries.
       modules.memCheckpoints.onBlockApplied(block, true);
     }
 

--- a/modules/blocks/chain.js
+++ b/modules/blocks/chain.js
@@ -89,15 +89,9 @@ Chain.prototype.saveBlock = function (block, cb) {
     // Initialize insert helper
     var inserts = new Inserts(promise, promise.values);
 
-    var promises = [
-      // Prepare insert SQL query
-      t.none(inserts.template(), promise.values)
-    ];
-
-    // Apply transactions inserts
-    t = __private.promiseTransactions(t, block, promises);
-    // Exec inserts as batch
-    t.batch(promises);
+    return t.none(inserts.template(), promise.values).then(function () {
+      return __private.promiseTransactions(t, block);
+    });
   }).then(function () {
     // Execute afterSave for transactions
     return __private.afterSave(block, cb);
@@ -137,13 +131,12 @@ __private.afterSave = function (block, cb) {
  * @method promiseTransactions
  * @param  {object} t SQL connection object
  * @param  {object} block Full normalized block
- * @param  {object} blockPromises Not used
- * @return {object} t SQL connection object filled with inserts
+ * @return {Promise<void>}
  * @throws Will throw 'Invalid promise' when no promise, promise.values or promise.table
  */
-__private.promiseTransactions = function (t, block, blockPromises) {
+__private.promiseTransactions = function (t, block) {
   if (_.isEmpty(block.transactions)) {
-    return t;
+    return Promise.resolve();
   }
 
   var transactionIterator = function (transaction) {
@@ -176,14 +169,17 @@ __private.promiseTransactions = function (t, block, blockPromises) {
 
     // Initialize insert helper
     var inserts = new Inserts(type[0], values, true);
-    // Prepare insert SQL query
-    t.none(inserts.template(), inserts);
+    // Prepare insert SQL query sequentially on the same pg client.
+    return t.none(inserts.template(), inserts);
   };
 
   var promises = _.flatMap(block.transactions, transactionIterator);
-  _.each(_.groupBy(promises, promiseGrouper), typeIterator);
 
-  return t;
+  return _.toArray(_.groupBy(promises, promiseGrouper)).reduce(function (chain, type) {
+    return chain.then(function () {
+      return typeIterator(type);
+    });
+  }, Promise.resolve());
 };
 
 /**

--- a/modules/blocks/chain.js
+++ b/modules/blocks/chain.js
@@ -497,9 +497,11 @@ Chain.prototype.applyBlock = function (block, broadcast, cb, saveBlock) {
     }
 
     if (!err && saveBlock && modules.memCheckpoints) {
-      // Checkpoint only after the full applyBlock pipeline, on completed round boundaries.
-      // Wait for the checkpoint copy before releasing the block-processing critical
-      // section, so no later block can mutate mem_* while the copy is in progress.
+      // Checkpoint on completed round boundaries, after the full applyBlock pipeline.
+      // onBlockApplied holds the block-processing critical section only until the
+      // checkpoint transaction has pinned its MVCC snapshot to this block; the table
+      // copy then runs in the background against that frozen (REPEATABLE READ)
+      // snapshot, so it can neither capture a later block nor stall block production.
       return modules.memCheckpoints.onBlockApplied(block, true, function () {
         return finalize(err);
       });

--- a/modules/blocks/chain.js
+++ b/modules/blocks/chain.js
@@ -482,26 +482,34 @@ Chain.prototype.applyBlock = function (block, broadcast, cb, saveBlock) {
       });
     }
   }, function (err) {
-    // Allow shutdown, database writes are finished.
-    modules.blocks.isActive.set(false);
+    function finalize (err) {
+      // Allow shutdown, database writes are finished.
+      modules.blocks.isActive.set(false);
+
+      // Nullify large objects.
+      // Prevents memory leak during synchronization.
+      appliedTransactions = unconfirmedTransactionIds = block = null;
+
+      // Finish here if snapshotting.
+      // FIXME: Not the best place to do that
+      if (err === 'Snapshot finished') {
+        library.logger.info('snapshot', err);
+        process.emit('SIGTERM');
+      }
+
+      return setImmediate(cb, err);
+    }
 
     if (!err && saveBlock && modules.memCheckpoints) {
       // Checkpoint only after the full applyBlock pipeline, on completed round boundaries.
-      modules.memCheckpoints.onBlockApplied(block, true);
+      // Wait for the checkpoint copy before releasing the block-processing critical
+      // section, so no later block can mutate mem_* while the copy is in progress.
+      return modules.memCheckpoints.onBlockApplied(block, true, function () {
+        return finalize(err);
+      });
     }
 
-    // Nullify large objects.
-    // Prevents memory leak during synchronization.
-    appliedTransactions = unconfirmedTransactionIds = block = null;
-
-    // Finish here if snapshotting.
-    // FIXME: Not the best place to do that
-    if (err === 'Snapshot finished') {
-      library.logger.info('snapshot', err);
-      process.emit('SIGTERM');
-    }
-
-    return setImmediate(cb, err);
+    return finalize(err);
   });
 };
 

--- a/modules/blocks/process.js
+++ b/modules/blocks/process.js
@@ -198,7 +198,7 @@ Process.prototype.loadBlocksOffset = function (limit, offset, verify, cb, should
           var check = modules.blocks.verify.verifyBlock(block);
 
           if (!check.verified) {
-            library.logger.error('loader', ['Block', block.id, 'verification failed'].join(' '), check.errors.join(', '));
+            modules.blocks.verify.logVerificationFailure('loader', block, check);
             // Return first error from checks
             return setImmediate(cb, check.errors[0]);
           }
@@ -536,7 +536,7 @@ __private.receiveForkOne = function (block, lastBlock, cb) {
         var check = modules.blocks.verify.verifyReceipt(tmp_block);
 
         if (!check.verified) {
-          library.logger.error('loader', ['Block', tmp_block.id, 'verification failed'].join(' '), check.errors.join(', '));
+          modules.blocks.verify.logVerificationFailure('loader', tmp_block, check);
           // Return first error from checks
           return setImmediate(seriesCb, check.errors[0]);
         } else {
@@ -611,7 +611,7 @@ __private.receiveForkFive = function (block, lastBlock, cb) {
         var check = modules.blocks.verify.verifyReceipt(tmp_block);
 
         if (!check.verified) {
-          library.logger.error('loader', ['Block', tmp_block.id, 'verification failed'].join(' '), check.errors.join(', '));
+          modules.blocks.verify.logVerificationFailure('loader', tmp_block, check);
           // Return first error from checks
           return setImmediate(seriesCb, check.errors[0]);
         } else {

--- a/modules/blocks/process.js
+++ b/modules/blocks/process.js
@@ -242,7 +242,7 @@ Process.prototype.loadBlocksFromPeer = function (peer, cb, shouldStop) {
 
   // Normalize peer
   peer = library.logic.peers.create(peer);
-  library.logger.info('loader', 'Loading blocks from: ' + peer.string);
+  library.logger.info('loader', 'Loading blocks from peer ' + peer.string + '…');
 
   function getFromPeer (seriesCb) {
     // Ask remote peer for blocks

--- a/modules/blocks/verify.js
+++ b/modules/blocks/verify.js
@@ -352,8 +352,10 @@ __private.verifyBlockSlot = function (block, lastBlock, result) {
 };
 
 /**
- * Logs block verification failure at warn level for slot/timestamp issues,
- * otherwise at error level.
+ * Logs block verification failure at warn level only when every error is a
+ * slot/timestamp issue (typically a local clock skew), otherwise at error level.
+ * A block that mixes a timestamp error with signature/id/reward/payload failures
+ * stays at error level so security and peer-abuse signals are not softened.
  * @private
  * @param {string} loggerModule
  * @param {object} block
@@ -362,11 +364,11 @@ __private.verifyBlockSlot = function (block, lastBlock, result) {
 __private.logBlockVerificationFailure = function (loggerModule, block, check) {
   var message = ['Block', block.id, 'verification failed'].join(' ');
   var details = check.errors.join(', ');
-  var isTimestampIssue = check.errors.some(function (error) {
+  var onlyTimestampIssues = check.errors.length > 0 && check.errors.every(function (error) {
     return String(error).indexOf('Invalid block timestamp:') === 0;
   });
 
-  if (isTimestampIssue) {
+  if (onlyTimestampIssues) {
     library.logger.warn(loggerModule, message + ' ' + details);
   } else {
     library.logger.error(loggerModule, message, details);

--- a/modules/blocks/verify.js
+++ b/modules/blocks/verify.js
@@ -11,6 +11,7 @@ var exceptions = require('../../helpers/exceptions.js');
 var modules, library, self, __private = {};
 
 __private.blockReward = new BlockReward();
+__private.CLOCK_SYNC_HINT = 'Verify local system time is synchronized with world time (NTP).';
 
 function Verify (logger, block, transaction, db) {
   library = {
@@ -329,12 +330,47 @@ __private.verifyForkOne = function (block, lastBlock, result) {
 __private.verifyBlockSlot = function (block, lastBlock, result) {
   var blockSlotNumber = slots.getSlotNumber(block.timestamp);
   var lastBlockSlotNumber = slots.getSlotNumber(lastBlock.timestamp);
+  var currentSlotNumber = slots.getSlotNumber();
 
-  if (blockSlotNumber > slots.getSlotNumber() || blockSlotNumber <= lastBlockSlotNumber) {
-    result.errors.push('Invalid block timestamp');
+  if (blockSlotNumber > currentSlotNumber) {
+    result.errors.push([
+      'Invalid block timestamp: block slot is in the future',
+      '(block slot', blockSlotNumber + ', current slot', currentSlotNumber + ').',
+      __private.CLOCK_SYNC_HINT
+    ].join(' '));
+  }
+
+  if (blockSlotNumber <= lastBlockSlotNumber) {
+    result.errors.push([
+      'Invalid block timestamp: block slot is in the past relative to the chain tip',
+      '(block slot', blockSlotNumber + ', last block slot', lastBlockSlotNumber + ').',
+      __private.CLOCK_SYNC_HINT
+    ].join(' '));
   }
 
   return result;
+};
+
+/**
+ * Logs block verification failure at warn level for slot/timestamp issues,
+ * otherwise at error level.
+ * @private
+ * @param {string} loggerModule
+ * @param {object} block
+ * @param {object} check
+ */
+__private.logBlockVerificationFailure = function (loggerModule, block, check) {
+  var message = ['Block', block.id, 'verification failed'].join(' ');
+  var details = check.errors.join(', ');
+  var isTimestampIssue = check.errors.some(function (error) {
+    return String(error).indexOf('Invalid block timestamp:') === 0;
+  });
+
+  if (isTimestampIssue) {
+    library.logger.warn(loggerModule, message + ' ' + details);
+  } else {
+    library.logger.error(loggerModule, message, details);
+  }
 };
 
 /**
@@ -365,6 +401,18 @@ Verify.prototype.verifyReceipt = function (block) {
   result.errors.reverse();
 
   return result;
+};
+
+/**
+ * Logs block verification failure at warn level for slot/timestamp issues,
+ * otherwise at error level.
+ * @public
+ * @param {string} loggerModule
+ * @param {object} block
+ * @param {object} check
+ */
+Verify.prototype.logVerificationFailure = function (loggerModule, block, check) {
+  __private.logBlockVerificationFailure(loggerModule, block, check);
 };
 
 /**
@@ -445,7 +493,7 @@ Verify.prototype.processBlock = function (block, broadcast, cb, saveBlock, shoul
       var check = self.verifyBlock(block);
 
       if (!check.verified) {
-        library.logger.error('blocks', ['Block', block.id, 'verification failed'].join(' '), check.errors.join(', '));
+        __private.logBlockVerificationFailure('blocks', block, check);
         return setImmediate(seriesCb, check.errors[0]);
       }
 

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -346,7 +346,7 @@ __private.loadDelegates = function (cb) {
   if (!secrets || !secrets.length) {
     return setImmediate(cb);
   } else {
-    library.logger.info('delegates', ['Loading', secrets.length, 'delegates from config'].join(' '));
+    library.logger.info('delegates', ['Loading', secrets.length, 'delegates from config…'].join(' '));
   }
 
   async.eachSeries(secrets, function (secret, cb) {

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -153,7 +153,12 @@ __private.syncTimer = function () {
         async.retry(__private.retries, __private.sync, sequenceCb);
       }, function (err) {
         if (err) {
-          library.logger.error('loader', 'Sync timer error:', err);
+          const errorMessage = err.message || err;
+          if (errorMessage === 'Failed to find enough good peers') {
+            library.logger.warn('loader', 'Sync timer: Failed to find enough good peers');
+          } else {
+            library.logger.error('loader', 'Sync timer error:', err);
+          }
           __private.initialize();
         }
         return setImmediate(cb);
@@ -887,12 +892,19 @@ __private.sync = function (cb) {
       __private.initialize();
     }
 
-    library.logger.info('loader', __private.stopRequested ? 'Sync stopped for shutdown' : 'Finished sync', {
-      height: modules.blocks.lastBlock.get().height,
-      stopped: __private.stopRequested,
-      aborted: aborted,
-      error: err ? err.message || err : null
-    });
+    const height = modules.blocks.lastBlock.get().height;
+    const errorMessage = err ? err.message || err : null;
+
+    if (errorMessage === 'Failed to find enough good peers') {
+      library.logger.warn('loader', 'Finished sync at height ' + height + ': Failed to find enough good peers');
+    } else {
+      library.logger.info('loader', __private.stopRequested ? 'Sync stopped for shutdown' : 'Finished sync', {
+        height: height,
+        stopped: __private.stopRequested,
+        aborted: aborted,
+        error: errorMessage
+      });
+    }
     library.bus.message('syncFinished');
     return setImmediate(cb, err);
   }

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -374,20 +374,19 @@ __private.loadBlockChain = function () {
     if (err) {
       library.logger.error('loader', err);
       if (err.block) {
-        library.logger.error('loader', 'Blockchain failed at: ' + err.block.height);
-        modules.blocks.chain.deleteAfterBlock(err.block.id, function (err, res) {
-          if (err) {
-            library.logger.error('loader', 'Failed to clip blockchain', err);
+        library.logger.error('loader', 'Blockchain rebuild failed while verifying block at height ' + err.block.height);
+        modules.blocks.chain.deleteAfterBlock(err.block.id, function (clipErr) {
+          if (clipErr) {
+            library.logger.error('loader', 'Failed to remove invalid blocks after rebuild error', clipErr);
           }
-          library.logger.error('loader', 'Blockchain clipped');
+          library.logger.warn('loader', 'Removed blocks at and above height ' + err.block.height + ' after rebuild verification failed; restart will rebuild mem_* from the remaining chain');
           finishLoading(true);
         });
       } else {
         finishLoading(false);
       }
     } else if (__private.stopRequested) {
-      library.logger.warn('loader', 'Blockchain rebuild stopped for shutdown; mem_* tables may be inconsistent and are not boot-ready');
-      library.logger.info('loader', 'Blockchain rebuild stopped for shutdown');
+      library.logger.warn('loader', 'Blockchain rebuild stopped for shutdown; mem_* tables may be inconsistent and are not boot-ready — wait for cleanup to finish before restarting');
       finishLoading(false);
     } else {
       library.logger.info('loader', 'Blockchain ready');
@@ -395,6 +394,13 @@ __private.loadBlockChain = function () {
     }
   }
 
+  /**
+   * Rebuild or replay derived mem_* state from blocks.
+   * @param {number} count Total persisted block count.
+   * @param {object} [options]
+   * @param {number} [options.startOffset] First block height to replay from.
+   * @param {boolean} [options.skipTableReset] Keep existing mem_* tables (checkpoint restore path).
+   */
   function load (count, options) {
     var startOffset = Number((options && options.startOffset) || 0);
     var skipTableReset = Boolean(options && options.skipTableReset);
@@ -437,6 +443,7 @@ __private.loadBlockChain = function () {
             }
 
             if (count > 1) {
+              // offset is the SQL lower bound (b_height >= offset); display the next applied height.
               library.logger.info('loader', 'Rebuilding blockchain, current block height: ' + (offset + 1));
             }
             modules.blocks.process.loadBlocksOffset(limit, offset, verify, function (err, lastBlock) {
@@ -460,6 +467,12 @@ __private.loadBlockChain = function () {
     });
   }
 
+  /**
+   * Recover derived mem_* tables from checkpoint or rebuild them from genesis.
+   * @param {number} count Total persisted block count.
+   * @param {string} [message] Validation failure that triggered recovery.
+   * @param {number} round Current round at chain tip.
+   */
   function reload (count, message, round) {
     if (__private.stopRequested) {
       return finishForShutdown();
@@ -470,6 +483,7 @@ __private.loadBlockChain = function () {
     }
 
     if (!modules.memCheckpoints || !modules.memCheckpoints.isEnabled()) {
+      library.logger.warn('loader', 'Mem-table checkpoints are disabled');
       library.logger.warn('loader', 'Recreating memory tables');
       return load(count);
     }

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -256,7 +256,7 @@ __private.loadTransactions = function (cb) {
       });
     },
     function (peer, waterCb) {
-      library.logger.log('loader', 'Loading transactions from: ' + peer.string + '…');
+      library.logger.log('loader', 'Loading transactions from peer ' + peer.string + '…');
 
       modules.transport.getFromPeer(peer, {
         api: '/transactions',
@@ -723,15 +723,15 @@ __private.loadBlocksFromNetwork = function (cb, shouldStop) {
             }
 
             function getCommonBlock (cb) {
-              library.logger.info('loader', 'Looking for common block with: ' + peer.string + '…');
+              library.logger.info('loader', 'Looking for common block with peer ' + peer.string + '…');
               modules.blocks.process.getCommonBlock(peer, lastBlock.height, function (err, commonBlock) {
                 if (!commonBlock) {
                   if (err) { library.logger.error('loader', err.toString()); }
-                  library.logger.error('loader', 'Failed to find common block with: ' + peer.string);
+                  library.logger.error('loader', 'Failed to find common block with peer: ' + peer.string);
                   errorCount += 1;
                   return next();
                 } else {
-                  library.logger.info('loader', ['Found common block:', commonBlock.id, 'with:', peer.string].join(' '));
+                  library.logger.info('loader', ['Found common block:', commonBlock.id, 'with peer:', peer.string].join(' '));
                   return setImmediate(cb);
                 }
               });

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -26,7 +26,6 @@ __private.syncInterval = 10000;
 __private.retries = 5;
 __private.stopRequested = false;
 __private.shutdownRequested = false;
-__private.rebuildInProgress = false;
 // Maximum time a single sync run may go without block progress before it is
 // considered stalled and aborted so the loader can recover.
 __private.syncTimeout = constants.syncStallTimeout;
@@ -374,8 +373,6 @@ __private.loadBlockChain = function () {
   }
 
   function finishRebuild (err, count) {
-    __private.rebuildInProgress = false;
-
     if (err) {
       library.logger.error('loader', err);
       if (err.block) {
@@ -412,7 +409,6 @@ __private.loadBlockChain = function () {
 
     verify = true;
     __private.total = count;
-    __private.rebuildInProgress = true;
     offset = startOffset;
 
     var steps = {};

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -396,7 +396,7 @@ __private.loadBlockChain = function () {
   }
 
   function load (count, options) {
-    var startOffset = (options && options.startOffset) || 0;
+    var startOffset = Number((options && options.startOffset) || 0);
     var skipTableReset = Boolean(options && options.skipTableReset);
 
     verify = true;
@@ -476,9 +476,26 @@ __private.loadBlockChain = function () {
 
     modules.memCheckpoints.tryRecover(count, round, function (err, checkpoint) {
       if (checkpoint) {
-        library.logger.info('loader', 'Recovering from mem-table checkpoint at height ' + checkpoint.height);
+        var checkpointHeight = parseInt(checkpoint.height, 10);
+        var replayOffset = checkpointHeight + 1;
+
+        library.logger.info('loader', 'Recovering from mem-table checkpoint at height ' + checkpointHeight);
+
+        if (replayOffset > count) {
+          return modules.blocks.utils.loadLastBlock(function (loadErr, block) {
+            if (loadErr) {
+              library.logger.warn('loader', 'Checkpoint restore at chain tip failed to load last block, recreating memory tables');
+              return load(count);
+            }
+
+            __private.lastBlock = block;
+            library.logger.info('loader', 'Blockchain ready');
+            return finishLoading(true);
+          });
+        }
+
         return load(count, {
-          startOffset: checkpoint.height + 1,
+          startOffset: replayOffset,
           skipTableReset: true
         });
       }

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -443,8 +443,9 @@ __private.loadBlockChain = function () {
             }
 
             if (count > 1) {
-              // offset is the SQL lower bound (b_height >= offset); display the next applied height.
-              library.logger.info('loader', 'Rebuilding blockchain, current block height: ' + (offset + 1) + '…');
+              // offset is the SQL lower bound (`b_height >= offset`), i.e. the next applied height.
+              var displayHeight = offset === 0 ? 1 : offset;
+              library.logger.info('loader', 'Rebuilding blockchain, current block height: ' + displayHeight + '…');
             }
             modules.blocks.process.loadBlocksOffset(limit, offset, verify, function (err, lastBlock) {
               if (err) {

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -372,9 +372,22 @@ __private.loadBlockChain = function () {
     finishLoading(false);
   }
 
-  function finishRebuild (err, count) {
+  function finishRebuild (err, count, context) {
+    var replay = Boolean(context && context.replay);
+
     if (err) {
       library.logger.error('loader', err);
+
+      // A failure while replaying on top of a restored checkpoint most likely
+      // means the checkpoint's derived mem_* state is inconsistent with the
+      // chain — the persisted blocks are still the source of truth and must not
+      // be clipped. Fall back to a full rebuild from genesis (which recreates
+      // the mem_* tables), instead of deleting valid blocks.
+      if (replay) {
+        library.logger.warn('loader', 'Checkpoint replay failed; discarding checkpoint state and rebuilding memory tables from genesis…');
+        return load(count);
+      }
+
       if (err.block) {
         library.logger.error('loader', 'Blockchain rebuild failed while verifying block at height ' + err.block.height);
         modules.blocks.chain.deleteAfterBlock(err.block.id, function (clipErr) {
@@ -465,7 +478,7 @@ __private.loadBlockChain = function () {
     };
 
     async.series(steps, function (err) {
-      return finishRebuild(err, count);
+      return finishRebuild(err, count, { replay: skipTableReset });
     });
   }
 
@@ -484,9 +497,17 @@ __private.loadBlockChain = function () {
       library.logger.warn('loader', message);
     }
 
-    if (!modules.memCheckpoints || !modules.memCheckpoints.isEnabled()) {
-      library.logger.warn('loader', 'Mem-table checkpoints are disabled');
-      library.logger.warn('loader', 'Recreating memory tables…');
+    // Snapshot/verification mode (`verify`) must rebuild derived state from
+    // genesis so every block is re-verified and re-applied; a checkpoint restore
+    // would skip exactly the work the operator asked for. Fall through to a full
+    // rebuild in that case, and whenever checkpoints are unavailable.
+    if (verify || !modules.memCheckpoints || !modules.memCheckpoints.isEnabled()) {
+      if (verify) {
+        library.logger.warn('loader', 'Verification/snapshot mode enabled; skipping checkpoint recovery and recreating memory tables…');
+      } else {
+        library.logger.warn('loader', 'Mem-table checkpoints are disabled');
+        library.logger.warn('loader', 'Recreating memory tables…');
+      }
       return load(count);
     }
 

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -26,6 +26,7 @@ __private.syncInterval = 10000;
 __private.retries = 5;
 __private.stopRequested = false;
 __private.shutdownRequested = false;
+__private.rebuildInProgress = false;
 // Maximum time a single sync run may go without block progress before it is
 // considered stalled and aborted so the loader can recover.
 __private.syncTimeout = constants.syncStallTimeout;
@@ -367,12 +368,46 @@ __private.loadBlockChain = function () {
     finishLoading(false);
   }
 
-  function load (count) {
+  function finishRebuild (err, count) {
+    __private.rebuildInProgress = false;
+
+    if (err) {
+      library.logger.error('loader', err);
+      if (err.block) {
+        library.logger.error('loader', 'Blockchain failed at: ' + err.block.height);
+        modules.blocks.chain.deleteAfterBlock(err.block.id, function (err, res) {
+          if (err) {
+            library.logger.error('loader', 'Failed to clip blockchain', err);
+          }
+          library.logger.error('loader', 'Blockchain clipped');
+          finishLoading(true);
+        });
+      } else {
+        finishLoading(false);
+      }
+    } else if (__private.stopRequested) {
+      library.logger.warn('loader', 'Blockchain rebuild stopped for shutdown; mem_* tables may be inconsistent and are not boot-ready');
+      library.logger.info('loader', 'Blockchain rebuild stopped for shutdown');
+      finishLoading(false);
+    } else {
+      library.logger.info('loader', 'Blockchain ready');
+      finishLoading(true);
+    }
+  }
+
+  function load (count, options) {
+    var startOffset = (options && options.startOffset) || 0;
+    var skipTableReset = Boolean(options && options.skipTableReset);
+
     verify = true;
     __private.total = count;
+    __private.rebuildInProgress = true;
+    offset = startOffset;
 
-    async.series({
-      removeTables: function (seriesCb) {
+    var steps = {};
+
+    if (!skipTableReset) {
+      steps.removeTables = function (seriesCb) {
         library.logic.account.removeTables(function (err) {
           if (err) {
             throw err;
@@ -380,8 +415,8 @@ __private.loadBlockChain = function () {
             return setImmediate(seriesCb);
           }
         });
-      },
-      createTables: function (seriesCb) {
+      };
+      steps.createTables = function (seriesCb) {
         library.logic.account.createTables(function (err) {
           if (err) {
             throw err;
@@ -389,70 +424,68 @@ __private.loadBlockChain = function () {
             return setImmediate(seriesCb);
           }
         });
-      },
-      loadBlocksOffset: function (seriesCb) {
-        async.until(
-            function (testCb) {
-              return testCb(null, __private.stopRequested || count < offset);
-            }, function (cb) {
-              if (__private.stopRequested) {
-                return setImmediate(cb);
+      };
+    }
+
+    steps.loadBlocksOffset = function (seriesCb) {
+      async.until(
+          function (testCb) {
+            return testCb(null, __private.stopRequested || count < offset);
+          }, function (cb) {
+            if (__private.stopRequested) {
+              return setImmediate(cb);
+            }
+
+            if (count > 1) {
+              library.logger.info('loader', 'Rebuilding blockchain, current block height: ' + (offset + 1));
+            }
+            modules.blocks.process.loadBlocksOffset(limit, offset, verify, function (err, lastBlock) {
+              if (err) {
+                return setImmediate(cb, err);
               }
 
-              if (count > 1) {
-                library.logger.info('loader', 'Rebuilding blockchain, current block height: ' + (offset + 1));
-              }
-              modules.blocks.process.loadBlocksOffset(limit, offset, verify, function (err, lastBlock) {
-                if (err) {
-                  return setImmediate(cb, err);
-                }
+              offset = offset + limit;
+              __private.lastBlock = lastBlock;
 
-                offset = offset + limit;
-                __private.lastBlock = lastBlock;
+              return setImmediate(cb);
+            }, __private.isStopRequested);
+          }, function (err) {
+            return setImmediate(seriesCb, err);
+          }
+      );
+    };
 
-                return setImmediate(cb);
-              }, __private.isStopRequested);
-            }, function (err) {
-              return setImmediate(seriesCb, err);
-            }
-        );
-      }
-    }, function (err) {
-      if (err) {
-        library.logger.error('loader', err);
-        if (err.block) {
-          library.logger.error('loader', 'Blockchain failed at: ' + err.block.height);
-          modules.blocks.chain.deleteAfterBlock(err.block.id, function (err, res) {
-            if (err) {
-              library.logger.error('loader', 'Failed to clip blockchain', err);
-            }
-            library.logger.error('loader', 'Blockchain clipped');
-            finishLoading(true);
-          });
-        } else {
-          finishLoading(false);
-        }
-      } else if (__private.stopRequested) {
-        library.logger.info('loader', 'Blockchain rebuild stopped for shutdown');
-        finishLoading(false);
-      } else {
-        library.logger.info('loader', 'Blockchain ready');
-        finishLoading(true);
-      }
+    async.series(steps, function (err) {
+      return finishRebuild(err, count);
     });
   }
 
-  function reload (count, message) {
+  function reload (count, message, round) {
     if (__private.stopRequested) {
       return finishForShutdown();
     }
 
     if (message) {
       library.logger.warn('loader', message);
-      library.logger.warn('loader', 'Recreating memory tables');
     }
 
-    return load(count);
+    if (!modules.memCheckpoints || !modules.memCheckpoints.isEnabled()) {
+      library.logger.warn('loader', 'Recreating memory tables');
+      return load(count);
+    }
+
+    modules.memCheckpoints.tryRecover(count, round, function (err, checkpoint) {
+      if (checkpoint) {
+        library.logger.info('loader', 'Recovering from mem-table checkpoint at height ' + checkpoint.height);
+        return load(count, {
+          startOffset: checkpoint.height + 1,
+          skipTableReset: true
+        });
+      }
+
+      library.logger.warn('loader', 'Recreating memory tables');
+      return load(count);
+    });
   }
 
   function checkMemTables (t) {
@@ -515,7 +548,7 @@ __private.loadBlockChain = function () {
     var round = modules.rounds.calc(count);
 
     if (count === 1) {
-      return reload(count);
+      return reload(count, null, round);
     }
 
     matchGenesisBlock(results[1][0]);
@@ -523,13 +556,13 @@ __private.loadBlockChain = function () {
     verify = verifySnapshot(count, round);
 
     if (verify) {
-      return reload(count, 'Blocks verification enabled');
+      return reload(count, 'Blocks verification enabled', round);
     }
 
     var missed = !(results[2].count);
 
     if (missed) {
-      return reload(count, 'Detected missed blocks in mem_accounts');
+      return reload(count, 'Detected missed blocks in mem_accounts', round);
     }
 
     var unapplied = results[3].filter(function (row) {
@@ -537,7 +570,7 @@ __private.loadBlockChain = function () {
     });
 
     if (unapplied.length > 0) {
-      return reload(count, 'Detected unapplied rounds in mem_round');
+      return reload(count, 'Detected unapplied rounds in mem_round', round);
     }
 
     var duplicatedDelegates = +results[4][0].count;
@@ -566,16 +599,16 @@ __private.loadBlockChain = function () {
       }
 
       if (results[1].length > 0) {
-        return reload(count, 'Detected orphaned blocks in mem_accounts');
+        return reload(count, 'Detected orphaned blocks in mem_accounts', round);
       }
 
       if (results[2].length === 0) {
-        return reload(count, 'No delegates found');
+        return reload(count, 'No delegates found', round);
       }
 
       modules.blocks.utils.loadLastBlock(function (err, block) {
         if (err) {
-          return reload(count, err || 'Failed to load last block');
+          return reload(count, err || 'Failed to load last block', round);
         } else {
           __private.lastBlock = block;
           library.logger.info('loader', 'Blockchain ready');
@@ -1110,7 +1143,8 @@ Loader.prototype.onBind = function (scope) {
     rounds: scope.rounds,
     transport: scope.transport,
     multisignatures: scope.multisignatures,
-    system: scope.system
+    system: scope.system,
+    memCheckpoints: scope.memCheckpoints
   };
 
   __private.loadBlockChain();

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -192,7 +192,7 @@ __private.loadSignatures = function (cb) {
       });
     },
     function (peer, waterCb) {
-      library.logger.log('loader', 'Loading signatures from: ' + peer.string);
+      library.logger.log('loader', 'Loading signatures from peer ' + peer.string + '…');
 
       modules.transport.getFromPeer(peer, {
         api: '/signatures',
@@ -256,7 +256,7 @@ __private.loadTransactions = function (cb) {
       });
     },
     function (peer, waterCb) {
-      library.logger.log('loader', 'Loading transactions from: ' + peer.string);
+      library.logger.log('loader', 'Loading transactions from: ' + peer.string + '…');
 
       modules.transport.getFromPeer(peer, {
         api: '/transactions',
@@ -444,7 +444,7 @@ __private.loadBlockChain = function () {
 
             if (count > 1) {
               // offset is the SQL lower bound (b_height >= offset); display the next applied height.
-              library.logger.info('loader', 'Rebuilding blockchain, current block height: ' + (offset + 1));
+              library.logger.info('loader', 'Rebuilding blockchain, current block height: ' + (offset + 1) + '…');
             }
             modules.blocks.process.loadBlocksOffset(limit, offset, verify, function (err, lastBlock) {
               if (err) {
@@ -484,7 +484,7 @@ __private.loadBlockChain = function () {
 
     if (!modules.memCheckpoints || !modules.memCheckpoints.isEnabled()) {
       library.logger.warn('loader', 'Mem-table checkpoints are disabled');
-      library.logger.warn('loader', 'Recreating memory tables');
+      library.logger.warn('loader', 'Recreating memory tables…');
       return load(count);
     }
 
@@ -493,12 +493,12 @@ __private.loadBlockChain = function () {
         var checkpointHeight = parseInt(checkpoint.height, 10);
         var replayOffset = checkpointHeight + 1;
 
-        library.logger.info('loader', 'Recovering from mem-table checkpoint at height ' + checkpointHeight);
+        library.logger.info('loader', 'Recovering from mem-table checkpoint at height ' + checkpointHeight + '…');
 
         if (replayOffset > count) {
           return modules.blocks.utils.loadLastBlock(function (loadErr, block) {
             if (loadErr) {
-              library.logger.warn('loader', 'Checkpoint restore at chain tip failed to load last block, recreating memory tables');
+              library.logger.warn('loader', 'Checkpoint restore at chain tip failed to load last block, recreating memory tables…');
               return load(count);
             }
 
@@ -508,27 +508,45 @@ __private.loadBlockChain = function () {
           });
         }
 
-        return load(count, {
-          startOffset: replayOffset,
-          skipTableReset: true
+        return modules.blocks.utils.loadBlocksPart({ id: checkpoint.blockId }, function (loadErr, blocks) {
+          if (loadErr || !blocks || !blocks.length) {
+            library.logger.warn('loader', 'Checkpoint block failed to load, recreating memory tables…');
+            return load(count);
+          }
+
+          modules.blocks.lastBlock.set(blocks[0]);
+
+          return load(count, {
+            startOffset: replayOffset,
+            skipTableReset: true
+          });
         });
       }
 
-      library.logger.warn('loader', 'Recreating memory tables');
+      library.logger.warn('loader', 'Recreating memory tables…');
       return load(count);
     });
   }
 
   function checkMemTables (t) {
-    var promises = [
-      t.one(sql.countBlocks),
-      t.query(sql.getGenesisBlock),
-      t.one(sql.countMemAccounts),
-      t.query(sql.getMemRounds),
-      t.query(sql.countDuplicatedDelegates)
-    ];
+    var results = [];
 
-    return t.batch(promises);
+    return t.one(sql.countBlocks).then(function (countBlocks) {
+      results[0] = countBlocks;
+      return t.query(sql.getGenesisBlock);
+    }).then(function (genesisBlock) {
+      results[1] = genesisBlock;
+      return t.one(sql.countMemAccounts);
+    }).then(function (countMemAccounts) {
+      results[2] = countMemAccounts;
+      return t.query(sql.getMemRounds);
+    }).then(function (memRounds) {
+      results[3] = memRounds;
+      return t.query(sql.countDuplicatedDelegates);
+    }).then(function (duplicatedDelegates) {
+      results[4] = duplicatedDelegates;
+      return results;
+    });
   }
 
   function matchGenesisBlock (row) {
@@ -560,7 +578,7 @@ __private.loadBlockChain = function () {
         modules.rounds.setSnapshotRounds(library.config.loading.snapshot);
       }
 
-      library.logger.info('loader', 'Snapshotting to end of round: ' + library.config.loading.snapshot);
+      library.logger.info('loader', 'Snapshotting to end of round: ' + library.config.loading.snapshot + '…');
       return true;
     } else {
       return false;
@@ -613,13 +631,17 @@ __private.loadBlockChain = function () {
     }
 
     function updateMemAccounts (t) {
-      var promises = [
-        t.none(sql.updateMemAccounts),
-        t.query(sql.getOrphanedMemAccounts),
-        t.query(sql.getDelegates)
-      ];
+      var results = [];
 
-      return t.batch(promises);
+      return t.none(sql.updateMemAccounts).then(function () {
+        return t.query(sql.getOrphanedMemAccounts);
+      }).then(function (orphanedMemAccounts) {
+        results[1] = orphanedMemAccounts;
+        return t.query(sql.getDelegates);
+      }).then(function (delegates) {
+        results[2] = delegates;
+        return results;
+      });
     }
 
     // Returned so a rejection propagates to the outer .catch below instead of
@@ -701,7 +723,7 @@ __private.loadBlocksFromNetwork = function (cb, shouldStop) {
             }
 
             function getCommonBlock (cb) {
-              library.logger.info('loader', 'Looking for common block with: ' + peer.string);
+              library.logger.info('loader', 'Looking for common block with: ' + peer.string + '…');
               modules.blocks.process.getCommonBlock(peer, lastBlock.height, function (err, commonBlock) {
                 if (!commonBlock) {
                   if (err) { library.logger.error('loader', err.toString()); }
@@ -756,7 +778,7 @@ __private.sync = function (cb) {
     return setImmediate(cb);
   }
 
-  library.logger.info('loader', 'Starting sync', {
+  library.logger.info('loader', 'Starting sync…', {
     height: modules.blocks.lastBlock.get().height,
     blocksToSync: __private.blocksToSync
   });
@@ -887,7 +909,7 @@ __private.sync = function (cb) {
   async.series({
     undoUnconfirmedList: function (seriesCb) {
       return skipOnStop(seriesCb, mutating(function (next) {
-        library.logger.debug('loader', 'Undoing unconfirmed transactions before sync', {
+        library.logger.debug('loader', 'Undoing unconfirmed transactions before sync…', {
           height: modules.blocks.lastBlock.get().height
         });
         return modules.transactions.undoUnconfirmedList(next);
@@ -895,7 +917,7 @@ __private.sync = function (cb) {
     },
     getPeersBefore: function (seriesCb) {
       return skipOnStop(seriesCb, function (next) {
-        library.logger.debug('loader', 'Establishing broadhash consensus before sync', {
+        library.logger.debug('loader', 'Establishing broadhash consensus before sync…', {
           height: modules.blocks.lastBlock.get().height,
           limit: constants.maxPeers
         });
@@ -914,7 +936,7 @@ __private.sync = function (cb) {
     },
     getPeersAfter: function (seriesCb) {
       return skipOnStop(seriesCb, function (next) {
-        library.logger.debug('loader', 'Establishing broadhash consensus after sync', {
+        library.logger.debug('loader', 'Establishing broadhash consensus after sync…', {
           height: modules.blocks.lastBlock.get().height,
           limit: constants.maxPeers
         });
@@ -923,7 +945,7 @@ __private.sync = function (cb) {
     },
     applyUnconfirmedList: function (seriesCb) {
       return skipOnStop(seriesCb, mutating(function (next) {
-        library.logger.debug('loader', 'Applying unconfirmed transactions after sync', {
+        library.logger.debug('loader', 'Applying unconfirmed transactions after sync…', {
           height: modules.blocks.lastBlock.get().height
         });
         return modules.transactions.applyUnconfirmedList(next);
@@ -1197,7 +1219,7 @@ Loader.prototype.onBlockchainReady = function () {
 Loader.prototype.cleanup = function (cb) {
   function waitForIdle () {
     if (__private.isActive) {
-      library.logger.info('loader', 'Waiting for loader to finish active sync/rebuild...');
+      library.logger.info('loader', 'Waiting for loader to finish active sync/rebuild…');
       return setTimeout(waitForIdle, 10000);
     }
 

--- a/modules/memCheckpoints.js
+++ b/modules/memCheckpoints.js
@@ -6,6 +6,7 @@ var modules, library, self, __private = {};
 
 __private.loaded = false;
 __private.creating = false;
+__private.schemaMismatch = false;
 
 /**
  * Module wrapper for persisted mem-table checkpoint creation and recovery.
@@ -17,7 +18,8 @@ function MemCheckpoints (cb, scope) {
   library = {
     logger: scope.logger,
     db: scope.db,
-    config: scope.config
+    config: scope.config,
+    balancesSequence: scope.balancesSequence
   };
 
   __private.logic = new MemCheckpoint({
@@ -50,29 +52,49 @@ MemCheckpoints.prototype.logic = function () {
 
 /**
  * Create a checkpoint after a persisted block at a completed round boundary.
- * Called only after the full applyBlock pipeline has finished.
+ * Called only after the full applyBlock pipeline has finished. The callback is
+ * invoked when the checkpoint copy has finished (or was skipped), so the caller
+ * can hold the block-processing critical section for the duration of the copy.
+ * Balance/unconfirmed writers are excluded via `balancesSequence`.
  * @param {object} block Applied block.
  * @param {boolean} persisted Whether the block was saved to the database.
+ * @param {Function} [cb] Called when checkpoint work is finished or skipped.
  */
-MemCheckpoints.prototype.onBlockApplied = function (block, persisted) {
-  if (!__private.loaded || !persisted || __private.creating) {
-    return;
+MemCheckpoints.prototype.onBlockApplied = function (block, persisted, cb) {
+  cb = cb || function () {};
+
+  if (!__private.loaded || !persisted || __private.creating || __private.schemaMismatch) {
+    return setImmediate(cb);
   }
 
   if (!__private.logic.isEnabled()) {
-    return;
+    return setImmediate(cb);
   }
 
   if (!__private.logic.isRoundBoundaryBlock(block.height)) {
-    return;
+    return setImmediate(cb);
   }
 
   var round = modules.rounds.calc(block.height);
 
+  // Throttle checkpoints during catch-up sync so the per-round mem_* copy
+  // does not slow down block replay; crash recovery still keeps the replay
+  // window bounded to SYNC_ROUND_INTERVAL rounds.
+  if (!__private.logic.shouldCheckpointRound(round, modules.loader.syncing())) {
+    return setImmediate(cb);
+  }
+
   __private.creating = true;
 
-  __private.logic.createCheckpoint(block, round, library.config.nethash).finally(function () {
+  library.balancesSequence.add(function (sequenceCb) {
+    __private.logic.createCheckpoint(block, round, library.config.nethash).then(function () {
+      return setImmediate(sequenceCb);
+    }, function (err) {
+      return setImmediate(sequenceCb, err);
+    });
+  }, function () {
     __private.creating = false;
+    return setImmediate(cb);
   });
 };
 
@@ -108,16 +130,34 @@ MemCheckpoints.prototype.tryRecover = function (tipHeight, tipRound, cb) {
  */
 MemCheckpoints.prototype.onBind = function (scope) {
   modules = {
-    rounds: scope.rounds
+    rounds: scope.rounds,
+    loader: scope.loader
   };
 };
 
 /**
  * Enable checkpoint creation after blockchain loading has finished.
+ * Verifies checkpoint slot tables still match the live mem_* schema first;
+ * on mismatch, checkpoint creation is disabled to avoid silently stale slots.
  * @listens module:loader~event:blockchainReady
  */
 MemCheckpoints.prototype.onBlockchainReady = function () {
-  __private.loaded = true;
+  if (!__private.logic.isEnabled()) {
+    __private.loaded = true;
+    return;
+  }
+
+  __private.logic.verifySlotSchemas().then(function (mismatch) {
+    if (mismatch) {
+      __private.schemaMismatch = true;
+      library.logger.error('memCheckpoints', 'Checkpoint slot schema does not match live mem_* tables, checkpoint creation disabled. Re-create checkpoint slot tables to re-enable.', mismatch);
+    }
+    __private.loaded = true;
+  }).catch(function (err) {
+    __private.schemaMismatch = true;
+    __private.loaded = true;
+    library.logger.error('memCheckpoints', `Failed to verify checkpoint slot schema, checkpoint creation disabled: ${err?.message || err}`);
+  });
 };
 
 /**

--- a/modules/memCheckpoints.js
+++ b/modules/memCheckpoints.js
@@ -1,0 +1,124 @@
+'use strict';
+
+var MemCheckpoint = require('../logic/memCheckpoint.js');
+
+var modules, library, self, __private = {};
+
+__private.loaded = false;
+__private.creating = false;
+
+/**
+ * @param {Function} cb
+ * @param {scope} scope
+ * @constructor
+ */
+function MemCheckpoints (cb, scope) {
+  library = {
+    logger: scope.logger,
+    db: scope.db,
+    config: scope.config
+  };
+
+  __private.logic = new MemCheckpoint({
+    db: scope.db,
+    logger: scope.logger,
+    config: {
+      memCheckpoints: (scope.config.loading && scope.config.loading.memCheckpoints) || {}
+    }
+  });
+
+  self = this;
+  setImmediate(cb, null, self);
+}
+
+/**
+ * @return {boolean}
+ */
+MemCheckpoints.prototype.isEnabled = function () {
+  return __private.logic.isEnabled();
+};
+
+/**
+ * @return {MemCheckpoint}
+ */
+MemCheckpoints.prototype.logic = function () {
+  return __private.logic;
+};
+
+/**
+ * @param {object} block
+ * @param {boolean} persisted
+ */
+MemCheckpoints.prototype.onBlockApplied = function (block, persisted) {
+  if (!__private.loaded || !persisted || __private.creating) {
+    return;
+  }
+
+  if (!__private.logic.isEnabled()) {
+    return;
+  }
+
+  if (!__private.logic.isRoundBoundaryBlock(block.height)) {
+    return;
+  }
+
+  var round = modules.rounds.calc(block.height);
+
+  __private.creating = true;
+
+  __private.logic.createCheckpoint(block, round, library.config.nethash).finally(function () {
+    __private.creating = false;
+  });
+};
+
+/**
+ * Attempt checkpoint-based recovery before a full mem-table rebuild.
+ *
+ * @param {number} tipHeight
+ * @param {number} tipRound
+ * @param {Function} cb
+ */
+MemCheckpoints.prototype.tryRecover = function (tipHeight, tipRound, cb) {
+  if (!__private.logic.isEnabled()) {
+    return setImmediate(cb, null, null);
+  }
+
+  __private.logic.findRecoverableCheckpoint(tipHeight, tipRound, library.config.nethash).then(function (meta) {
+    if (!meta) {
+      return setImmediate(cb, null, null);
+    }
+
+    return __private.logic.restoreCheckpoint(meta, tipRound).then(function (restored) {
+      return setImmediate(cb, null, restored);
+    });
+  }).catch(function (err) {
+    library.logger.warn('memCheckpoints', `Checkpoint recovery failed, falling back to full rebuild: ${err?.message || err}`);
+    return setImmediate(cb, null, null);
+  });
+};
+
+/**
+ * @param {modules} scope
+ */
+MemCheckpoints.prototype.onBind = function (scope) {
+  modules = {
+    rounds: scope.rounds
+  };
+};
+
+/**
+ * @listens module:loader~event:blockchainReady
+ */
+MemCheckpoints.prototype.onBlockchainReady = function () {
+  __private.loaded = true;
+};
+
+/**
+ * @param {Function} cb
+ */
+MemCheckpoints.prototype.cleanup = function (cb) {
+  __private.loaded = false;
+  return setImmediate(cb);
+};
+
+module.exports = MemCheckpoints;

--- a/modules/memCheckpoints.js
+++ b/modules/memCheckpoints.js
@@ -18,8 +18,7 @@ function MemCheckpoints (cb, scope) {
   library = {
     logger: scope.logger,
     db: scope.db,
-    config: scope.config,
-    balancesSequence: scope.balancesSequence
+    config: scope.config
   };
 
   __private.logic = new MemCheckpoint({
@@ -53,12 +52,14 @@ MemCheckpoints.prototype.logic = function () {
 /**
  * Create a checkpoint after a persisted block at a completed round boundary.
  * Called only after the full applyBlock pipeline has finished. The callback is
- * invoked when the checkpoint copy has finished (or was skipped), so the caller
- * can hold the block-processing critical section for the duration of the copy.
- * Balance/unconfirmed writers are excluded via `balancesSequence`.
+ * invoked as soon as the checkpoint transaction has pinned its MVCC snapshot to
+ * this block, so the caller holds the block-processing critical section only for
+ * the (short) pin, not for the whole table copy. The copy then runs in the
+ * background against that frozen REPEATABLE READ snapshot, which cannot observe a
+ * later block, so it neither stalls block production nor needs `balancesSequence`.
  * @param {object} block Applied block.
  * @param {boolean} persisted Whether the block was saved to the database.
- * @param {Function} [cb] Called when checkpoint work is finished or skipped.
+ * @param {Function} [cb] Called once the snapshot is pinned or the work is skipped.
  */
 MemCheckpoints.prototype.onBlockApplied = function (block, persisted, cb) {
   cb = cb || function () {};
@@ -86,15 +87,24 @@ MemCheckpoints.prototype.onBlockApplied = function (block, persisted, cb) {
 
   __private.creating = true;
 
-  library.balancesSequence.add(function (sequenceCb) {
-    __private.logic.createCheckpoint(block, round, library.config.nethash).then(function () {
-      return setImmediate(sequenceCb);
-    }, function (err) {
-      return setImmediate(sequenceCb, err);
-    });
-  }, function () {
-    __private.creating = false;
+  // Release the block-processing critical section as soon as the snapshot is
+  // pinned (createCheckpoint invokes `release` from inside its transaction).
+  var released = false;
+  var release = function () {
+    if (released) {
+      return;
+    }
+    released = true;
     return setImmediate(cb);
+  };
+
+  __private.logic.createCheckpoint(block, round, library.config.nethash, release).then(function () {
+    __private.creating = false;
+    release();
+  }, function (err) {
+    __private.creating = false;
+    library.logger.error('memCheckpoints', `Checkpoint creation failed: ${err?.message || err}`);
+    release();
   });
 };
 

--- a/modules/memCheckpoints.js
+++ b/modules/memCheckpoints.js
@@ -88,7 +88,7 @@ MemCheckpoints.prototype.tryRecover = function (tipHeight, tipRound, cb) {
       return setImmediate(cb, null, null);
     }
 
-    return __private.logic.restoreCheckpoint(meta, tipRound).then(function (restored) {
+    return __private.logic.restoreCheckpoint(meta).then(function (restored) {
       return setImmediate(cb, null, restored);
     });
   }).catch(function (err) {

--- a/modules/memCheckpoints.js
+++ b/modules/memCheckpoints.js
@@ -8,6 +8,7 @@ __private.loaded = false;
 __private.creating = false;
 
 /**
+ * Module wrapper for persisted mem-table checkpoint creation and recovery.
  * @param {Function} cb
  * @param {scope} scope
  * @constructor
@@ -32,6 +33,7 @@ function MemCheckpoints (cb, scope) {
 }
 
 /**
+ * Whether persisted mem-table checkpoints are enabled in config.
  * @return {boolean}
  */
 MemCheckpoints.prototype.isEnabled = function () {
@@ -39,6 +41,7 @@ MemCheckpoints.prototype.isEnabled = function () {
 };
 
 /**
+ * Expose the underlying checkpoint logic for tests and diagnostics.
  * @return {MemCheckpoint}
  */
 MemCheckpoints.prototype.logic = function () {
@@ -46,8 +49,10 @@ MemCheckpoints.prototype.logic = function () {
 };
 
 /**
- * @param {object} block
- * @param {boolean} persisted
+ * Create a checkpoint after a persisted block at a completed round boundary.
+ * Called only after the full applyBlock pipeline has finished.
+ * @param {object} block Applied block.
+ * @param {boolean} persisted Whether the block was saved to the database.
  */
 MemCheckpoints.prototype.onBlockApplied = function (block, persisted) {
   if (!__private.loaded || !persisted || __private.creating) {
@@ -73,10 +78,9 @@ MemCheckpoints.prototype.onBlockApplied = function (block, persisted) {
 
 /**
  * Attempt checkpoint-based recovery before a full mem-table rebuild.
- *
- * @param {number} tipHeight
- * @param {number} tipRound
- * @param {Function} cb
+ * @param {number} tipHeight Current chain height/block count used by loader.
+ * @param {number} tipRound Current round at chain tip.
+ * @param {Function} cb Callback `(err, checkpoint|null)`.
  */
 MemCheckpoints.prototype.tryRecover = function (tipHeight, tipRound, cb) {
   if (!__private.logic.isEnabled()) {
@@ -85,6 +89,7 @@ MemCheckpoints.prototype.tryRecover = function (tipHeight, tipRound, cb) {
 
   __private.logic.findRecoverableCheckpoint(tipHeight, tipRound, library.config.nethash).then(function (meta) {
     if (!meta) {
+      library.logger.warn('memCheckpoints', 'No complete recoverable mem-table checkpoint found');
       return setImmediate(cb, null, null);
     }
 
@@ -98,6 +103,7 @@ MemCheckpoints.prototype.tryRecover = function (tipHeight, tipRound, cb) {
 };
 
 /**
+ * Bind modules required for checkpoint creation.
  * @param {modules} scope
  */
 MemCheckpoints.prototype.onBind = function (scope) {
@@ -107,6 +113,7 @@ MemCheckpoints.prototype.onBind = function (scope) {
 };
 
 /**
+ * Enable checkpoint creation after blockchain loading has finished.
  * @listens module:loader~event:blockchainReady
  */
 MemCheckpoints.prototype.onBlockchainReady = function () {
@@ -114,6 +121,7 @@ MemCheckpoints.prototype.onBlockchainReady = function () {
 };
 
 /**
+ * Disable checkpoint creation during shutdown.
  * @param {Function} cb
  */
 MemCheckpoints.prototype.cleanup = function (cb) {

--- a/modules/memCheckpoints.js
+++ b/modules/memCheckpoints.js
@@ -97,7 +97,7 @@ MemCheckpoints.prototype.tryRecover = function (tipHeight, tipRound, cb) {
       return setImmediate(cb, null, restored);
     });
   }).catch(function (err) {
-    library.logger.warn('memCheckpoints', `Checkpoint recovery failed, falling back to full rebuild: ${err?.message || err}`);
+    library.logger.warn('memCheckpoints', `Checkpoint recovery failed: ${err?.message || err}; falling back to full rebuild…`);
     return setImmediate(cb, null, null);
   });
 };

--- a/modules/peers.js
+++ b/modules/peers.js
@@ -615,7 +615,7 @@ Peers.prototype.onPeersReady = function () {
   function peersDiscoveryAndUpdate (cb) {
     async.series({
       discoverPeers: function (seriesCb) {
-        library.logger.trace('peers', 'Discovering new peers...');
+        library.logger.trace('peers', 'Discovering new peers…');
         self.discover(function (err) {
           if (err) {
             library.logger.error('peers', 'Discovering new peers failed.', err);

--- a/modules/rounds.js
+++ b/modules/rounds.js
@@ -292,12 +292,13 @@ Rounds.prototype.tick = function (block, done) {
         });
 
         library.db.tx(function (t) {
-          return t.batch([
-            t.none(sql.clearRoundSnapshot),
-            t.none(sql.performRoundSnapshot),
-            t.none(sql.clearVotesSnapshot),
-            t.none(sql.performVotesSnapshot)
-          ]);
+          return t.none(sql.clearRoundSnapshot).then(function () {
+            return t.none(sql.performRoundSnapshot);
+          }).then(function () {
+            return t.none(sql.clearVotesSnapshot);
+          }).then(function () {
+            return t.none(sql.performVotesSnapshot);
+          });
         }).then(function () {
           library.logger.trace('rounds', 'Round snapshot done', {
             blockId: block.id,

--- a/modules/rounds.js
+++ b/modules/rounds.js
@@ -284,7 +284,7 @@ Rounds.prototype.tick = function (block, done) {
     function (cb) {
       // Check if we are one block before last block of round, if yes - perform round snapshot
       if ((block.height + 1) % slots.delegates === 0) {
-        library.logger.debug('rounds', 'Performing round snapshot...', {
+        library.logger.debug('rounds', 'Performing round snapshot…', {
           blockId: block.id,
           height: block.height,
           round: round,

--- a/schema/config.js
+++ b/schema/config.js
@@ -356,6 +356,19 @@ module.exports = {
           snapshot: {
             type: 'integer',
             minimum: 1
+          },
+          memCheckpoints: {
+            type: 'object',
+            properties: {
+              enabled: {
+                type: 'boolean'
+              },
+              retention: {
+                type: 'integer',
+                minimum: 2,
+                maximum: 3
+              }
+            }
           }
         },
         required: ['loadPerIteration']

--- a/schema/config.js
+++ b/schema/config.js
@@ -362,11 +362,6 @@ module.exports = {
             properties: {
               enabled: {
                 type: 'boolean'
-              },
-              retention: {
-                type: 'integer',
-                minimum: 2,
-                maximum: 3
               }
             }
           }

--- a/scripts/live-test/liveTest.js
+++ b/scripts/live-test/liveTest.js
@@ -34,7 +34,7 @@ const DEFAULTS = {
   transactionOverloadConcurrency: 6,
   liveTimeoutMs: 2 * 60 * 60 * 1000,
   genesisPasses: 'test/genesisPasses.json',
-  testnetConfig: 'test/config.default.json'
+  testnetConfig: 'test/config.json'
 };
 
 /**
@@ -313,7 +313,10 @@ function loadGenesisPasses (genesisPassesPath) {
 function collectConfigMetadata (options, target) {
   const entries = [];
   const paths = [];
-  const baseConfigPath = path.resolve(process.cwd(), BASE_CONFIG_PATH);
+  const baseConfigPath = path.resolve(
+      process.cwd(),
+      target.configPath || options.testnetConfig || DEFAULTS.testnetConfig
+  );
 
   // Live reports always start from the canonical testnet/localnet base config.
   if (baseConfigPath && fs.existsSync(baseConfigPath)) {

--- a/sql/memCheckpoints.js
+++ b/sql/memCheckpoints.js
@@ -33,13 +33,16 @@ var MemCheckpointsSql = {
   compareTableSchemas: 'SELECT l."column_name" AS live_column, c."column_name" AS ckpt_column, l."data_type" AS live_type, c."data_type" AS ckpt_type FROM (SELECT "ordinal_position", "column_name", "data_type" FROM information_schema.columns WHERE "table_schema" = current_schema() AND "table_name" = ${liveTable}) l FULL OUTER JOIN (SELECT "ordinal_position", "column_name", "data_type" FROM information_schema.columns WHERE "table_schema" = current_schema() AND "table_name" = ${slotTable}) c USING ("ordinal_position") WHERE l."column_name" IS DISTINCT FROM c."column_name" OR l."data_type" IS DISTINCT FROM c."data_type" LIMIT 1',
 
   resetUnconfirmedState: [
-    'UPDATE mem_accounts SET "u_isDelegate" = "isDelegate", "u_secondSignature" = "secondSignature", "u_username" = "username", "u_balance" = "balance", "u_delegates" = "delegates", "u_multisignatures" = "multisignatures", "u_multimin" = "multimin", "u_multilifetime" = "multilifetime" WHERE "u_isDelegate" <> "isDelegate" OR "u_secondSignature" <> "secondSignature" OR "u_username" IS DISTINCT FROM "username" OR "u_balance" <> "balance" OR "u_delegates" IS DISTINCT FROM "delegates" OR "u_multisignatures" IS DISTINCT FROM "multisignatures" OR "u_multimin" <> "multimin" OR "u_multilifetime" <> "multilifetime";',
+    'UPDATE mem_accounts SET "u_isDelegate" = "isDelegate", "u_secondSignature" = "secondSignature", "u_username" = "username", "u_balance" = "balance", "u_delegates" = "delegates", "u_multisignatures" = "multisignatures", "u_multimin" = "multimin", "u_multilifetime" = "multilifetime", "u_nameexist" = "nameexist" WHERE "u_isDelegate" <> "isDelegate" OR "u_secondSignature" <> "secondSignature" OR "u_username" IS DISTINCT FROM "username" OR "u_balance" <> "balance" OR "u_delegates" IS DISTINCT FROM "delegates" OR "u_multisignatures" IS DISTINCT FROM "multisignatures" OR "u_multimin" <> "multimin" OR "u_multilifetime" <> "multilifetime" OR "u_nameexist" <> "nameexist";',
     'DELETE FROM "mem_accounts2u_delegates";',
     'INSERT INTO "mem_accounts2u_delegates" ("accountId", "dependentId") SELECT "accountId", "dependentId" FROM "mem_accounts2delegates";',
     'DELETE FROM "mem_accounts2u_multisignatures";',
     'INSERT INTO "mem_accounts2u_multisignatures" ("accountId", "dependentId") SELECT "accountId", "dependentId" FROM "mem_accounts2multisignatures";'
   ].join('')
 };
+
+/** @type {number} Rotating checkpoint slot count; keep in sync with migration and {@link logic/memCheckpoint}. */
+var CHECKPOINT_SLOT_COUNT = 3;
 
 /**
  * Live mem_* table names keyed by the same logical keys as {@link slotTableNames}.
@@ -69,7 +72,7 @@ MemCheckpointsSql.clearLiveTables = [
  * @return {object} Map of logical table keys to checkpoint table names.
  */
 MemCheckpointsSql.slotTableNames = function (slot) {
-  if (!Number.isInteger(slot) || slot < 0) {
+  if (!Number.isInteger(slot) || slot < 0 || slot >= CHECKPOINT_SLOT_COUNT) {
     throw new Error('Invalid checkpoint slot: ' + slot);
   }
 

--- a/sql/memCheckpoints.js
+++ b/sql/memCheckpoints.js
@@ -28,7 +28,30 @@ var MemCheckpointsSql = {
 
   canonicalRound: 'SELECT COALESCE("address", \'\') || E\'\\x1f\' || COALESCE("round"::text, \'\') || E\'\\x1f\' || COALESCE("delegate", \'\') AS sort_key, COALESCE("address", \'\') || E\'\\x1f\' || COALESCE("amount"::text, \'0\') || E\'\\x1f\' || COALESCE("delegate", \'\') || E\'\\x1f\' || COALESCE("blockId", \'\') || E\'\\x1f\' || COALESCE("round"::text, \'\') AS line FROM ${tableName~} ORDER BY "address", "delegate", "round"',
 
-  canonicalAccountDelegates: 'SELECT "accountId" || E\'\\x1f\' || "dependentId" AS sort_key, "accountId" || E\'\\x1f\' || "dependentId" AS line FROM ${tableName~} ORDER BY "accountId", "dependentId"'
+  canonicalAccountDelegates: 'SELECT "accountId" || E\'\\x1f\' || "dependentId" AS sort_key, "accountId" || E\'\\x1f\' || "dependentId" AS line FROM ${tableName~} ORDER BY "accountId", "dependentId"',
+
+  compareTableSchemas: 'SELECT l."column_name" AS live_column, c."column_name" AS ckpt_column, l."data_type" AS live_type, c."data_type" AS ckpt_type FROM (SELECT "ordinal_position", "column_name", "data_type" FROM information_schema.columns WHERE "table_schema" = current_schema() AND "table_name" = ${liveTable}) l FULL OUTER JOIN (SELECT "ordinal_position", "column_name", "data_type" FROM information_schema.columns WHERE "table_schema" = current_schema() AND "table_name" = ${slotTable}) c USING ("ordinal_position") WHERE l."column_name" IS DISTINCT FROM c."column_name" OR l."data_type" IS DISTINCT FROM c."data_type" LIMIT 1',
+
+  resetUnconfirmedState: [
+    'UPDATE mem_accounts SET "u_isDelegate" = "isDelegate", "u_secondSignature" = "secondSignature", "u_username" = "username", "u_balance" = "balance", "u_delegates" = "delegates", "u_multisignatures" = "multisignatures", "u_multimin" = "multimin", "u_multilifetime" = "multilifetime" WHERE "u_isDelegate" <> "isDelegate" OR "u_secondSignature" <> "secondSignature" OR "u_username" IS DISTINCT FROM "username" OR "u_balance" <> "balance" OR "u_delegates" IS DISTINCT FROM "delegates" OR "u_multisignatures" IS DISTINCT FROM "multisignatures" OR "u_multimin" <> "multimin" OR "u_multilifetime" <> "multilifetime";',
+    'DELETE FROM "mem_accounts2u_delegates";',
+    'INSERT INTO "mem_accounts2u_delegates" ("accountId", "dependentId") SELECT "accountId", "dependentId" FROM "mem_accounts2delegates";',
+    'DELETE FROM "mem_accounts2u_multisignatures";',
+    'INSERT INTO "mem_accounts2u_multisignatures" ("accountId", "dependentId") SELECT "accountId", "dependentId" FROM "mem_accounts2multisignatures";'
+  ].join('')
+};
+
+/**
+ * Live mem_* table names keyed by the same logical keys as {@link slotTableNames}.
+ * @type {object}
+ */
+MemCheckpointsSql.liveTableNames = {
+  accounts: 'mem_accounts',
+  round: 'mem_round',
+  accounts2delegates: 'mem_accounts2delegates',
+  accounts2u_delegates: 'mem_accounts2u_delegates',
+  accounts2multisignatures: 'mem_accounts2multisignatures',
+  accounts2u_multisignatures: 'mem_accounts2u_multisignatures'
 };
 
 MemCheckpointsSql.clearLiveTables = [
@@ -46,6 +69,10 @@ MemCheckpointsSql.clearLiveTables = [
  * @return {object} Map of logical table keys to checkpoint table names.
  */
 MemCheckpointsSql.slotTableNames = function (slot) {
+  if (!Number.isInteger(slot) || slot < 0) {
+    throw new Error('Invalid checkpoint slot: ' + slot);
+  }
+
   var prefix = 'mem_ckpt_' + slot + '_';
   return {
     accounts: prefix + 'accounts',
@@ -89,6 +116,17 @@ MemCheckpointsSql.copyLiveToSlot = function (slot) {
     'INSERT INTO "' + tables.accounts2u_multisignatures + '" SELECT * FROM "mem_accounts2u_multisignatures";',
     'INSERT INTO "' + tables.round + '" SELECT * FROM "mem_round";'
   ].join('');
+};
+
+/**
+ * Highest block height referenced by accounts copied into one checkpoint slot.
+ * Used to detect a copy that captured state ahead of the checkpoint block.
+ * @param {number} slot Slot index.
+ * @return {string}
+ */
+MemCheckpointsSql.getSlotAccountsMaxBlockHeight = function (slot) {
+  var tables = MemCheckpointsSql.slotTableNames(slot);
+  return 'SELECT MAX(b."height")::bigint AS height FROM "' + tables.accounts + '" a JOIN blocks b ON b."id" = a."blockId"';
 };
 
 /**

--- a/sql/memCheckpoints.js
+++ b/sql/memCheckpoints.js
@@ -32,13 +32,13 @@ var MemCheckpointsSql = {
 
   compareTableSchemas: 'SELECT l."column_name" AS live_column, c."column_name" AS ckpt_column, l."data_type" AS live_type, c."data_type" AS ckpt_type FROM (SELECT "ordinal_position", "column_name", "data_type" FROM information_schema.columns WHERE "table_schema" = current_schema() AND "table_name" = ${liveTable}) l FULL OUTER JOIN (SELECT "ordinal_position", "column_name", "data_type" FROM information_schema.columns WHERE "table_schema" = current_schema() AND "table_name" = ${slotTable}) c USING ("ordinal_position") WHERE l."column_name" IS DISTINCT FROM c."column_name" OR l."data_type" IS DISTINCT FROM c."data_type" LIMIT 1',
 
-  resetUnconfirmedState: [
+  resetUnconfirmedStateStatements: [
     'UPDATE mem_accounts SET "u_isDelegate" = "isDelegate", "u_secondSignature" = "secondSignature", "u_username" = "username", "u_balance" = "balance", "u_delegates" = "delegates", "u_multisignatures" = "multisignatures", "u_multimin" = "multimin", "u_multilifetime" = "multilifetime", "u_nameexist" = "nameexist" WHERE "u_isDelegate" <> "isDelegate" OR "u_secondSignature" <> "secondSignature" OR "u_username" IS DISTINCT FROM "username" OR "u_balance" <> "balance" OR "u_delegates" IS DISTINCT FROM "delegates" OR "u_multisignatures" IS DISTINCT FROM "multisignatures" OR "u_multimin" <> "multimin" OR "u_multilifetime" <> "multilifetime" OR "u_nameexist" <> "nameexist";',
     'DELETE FROM "mem_accounts2u_delegates";',
     'INSERT INTO "mem_accounts2u_delegates" ("accountId", "dependentId") SELECT "accountId", "dependentId" FROM "mem_accounts2delegates";',
     'DELETE FROM "mem_accounts2u_multisignatures";',
     'INSERT INTO "mem_accounts2u_multisignatures" ("accountId", "dependentId") SELECT "accountId", "dependentId" FROM "mem_accounts2multisignatures";'
-  ].join('')
+  ]
 };
 
 /** @type {number} Rotating checkpoint slot count; keep in sync with migration and {@link logic/memCheckpoint}. */
@@ -57,14 +57,14 @@ MemCheckpointsSql.liveTableNames = {
   accounts2u_multisignatures: 'mem_accounts2u_multisignatures'
 };
 
-MemCheckpointsSql.clearLiveTables = [
+MemCheckpointsSql.clearLiveTablesStatements = [
   'DELETE FROM "mem_accounts2u_delegates";',
   'DELETE FROM "mem_accounts2u_multisignatures";',
   'DELETE FROM "mem_accounts2delegates";',
   'DELETE FROM "mem_accounts2multisignatures";',
   'DELETE FROM "mem_round";',
   'DELETE FROM "mem_accounts";'
-].join('');
+];
 
 /**
  * Physical checkpoint table names for a rotating slot index.
@@ -90,9 +90,9 @@ MemCheckpointsSql.slotTableNames = function (slot) {
 /**
  * Delete all rows from one checkpoint slot, respecting FK-dependent table order.
  * @param {number} slot Slot index.
- * @return {string}
+ * @return {string[]}
  */
-MemCheckpointsSql.clearSlotTables = function (slot) {
+MemCheckpointsSql.clearSlotTablesStatements = function (slot) {
   var tables = MemCheckpointsSql.slotTableNames(slot);
   return [
     'DELETE FROM "' + tables.accounts2u_delegates + '";',
@@ -101,15 +101,15 @@ MemCheckpointsSql.clearSlotTables = function (slot) {
     'DELETE FROM "' + tables.accounts2multisignatures + '";',
     'DELETE FROM "' + tables.round + '";',
     'DELETE FROM "' + tables.accounts + '";'
-  ].join('');
+  ];
 };
 
 /**
  * Copy live mem_* tables into one checkpoint slot.
  * @param {number} slot Slot index.
- * @return {string}
+ * @return {string[]}
  */
-MemCheckpointsSql.copyLiveToSlot = function (slot) {
+MemCheckpointsSql.copyLiveToSlotStatements = function (slot) {
   var tables = MemCheckpointsSql.slotTableNames(slot);
   return [
     'INSERT INTO "' + tables.accounts + '" SELECT * FROM "mem_accounts";',
@@ -118,7 +118,7 @@ MemCheckpointsSql.copyLiveToSlot = function (slot) {
     'INSERT INTO "' + tables.accounts2multisignatures + '" SELECT * FROM "mem_accounts2multisignatures";',
     'INSERT INTO "' + tables.accounts2u_multisignatures + '" SELECT * FROM "mem_accounts2u_multisignatures";',
     'INSERT INTO "' + tables.round + '" SELECT * FROM "mem_round";'
-  ].join('');
+  ];
 };
 
 /**
@@ -135,9 +135,9 @@ MemCheckpointsSql.getSlotAccountsMaxBlockHeight = function (slot) {
 /**
  * Restore live mem_* tables from one checkpoint slot.
  * @param {number} slot Slot index.
- * @return {string}
+ * @return {string[]}
  */
-MemCheckpointsSql.copySlotToLive = function (slot) {
+MemCheckpointsSql.copySlotToLiveStatements = function (slot) {
   var tables = MemCheckpointsSql.slotTableNames(slot);
   return [
     'INSERT INTO "mem_accounts" SELECT * FROM "' + tables.accounts + '";',
@@ -146,7 +146,7 @@ MemCheckpointsSql.copySlotToLive = function (slot) {
     'INSERT INTO "mem_accounts2multisignatures" SELECT * FROM "' + tables.accounts2multisignatures + '";',
     'INSERT INTO "mem_accounts2u_multisignatures" SELECT * FROM "' + tables.accounts2u_multisignatures + '";',
     'INSERT INTO "mem_round" SELECT * FROM "' + tables.round + '";'
-  ].join('');
+  ];
 };
 
 module.exports = MemCheckpointsSql;

--- a/sql/memCheckpoints.js
+++ b/sql/memCheckpoints.js
@@ -26,11 +26,11 @@ var MemCheckpointsSql = {
 
   getDelegates: 'SELECT ENCODE("publicKey", \'hex\') FROM mem_accounts WHERE "isDelegate" = 1 LIMIT 1',
 
-  canonicalAccounts: 'SELECT "address" AS sort_key, "address" || E\'\\x1f\' || COALESCE("username", \'\') || E\'\\x1f\' || COALESCE("isDelegate"::text, \'0\') || E\'\\x1f\' || COALESCE("u_isDelegate"::text, \'0\') || E\'\\x1f\' || COALESCE("secondSignature"::text, \'0\') || E\'\\x1f\' || COALESCE("u_secondSignature"::text, \'0\') || E\'\\x1f\' || COALESCE("u_username", \'\') || E\'\\x1f\' || COALESCE(ENCODE("publicKey", \'hex\'), \'\') || E\'\\x1f\' || COALESCE(ENCODE("secondPublicKey", \'hex\'), \'\') || E\'\\x1f\' || COALESCE("balance"::text, \'0\') || E\'\\x1f\' || COALESCE("u_balance"::text, \'0\') || E\'\\x1f\' || COALESCE("vote"::text, \'0\') || E\'\\x1f\' || COALESCE("rate"::text, \'0\') || E\'\\x1f\' || COALESCE("delegates", \'\') || E\'\\x1f\' || COALESCE("u_delegates", \'\') || E\'\\x1f\' || COALESCE("multisignatures", \'\') || E\'\\x1f\' || COALESCE("u_multisignatures", \'\') || E\'\\x1f\' || COALESCE("multimin"::text, \'0\') || E\'\\x1f\' || COALESCE("u_multimin"::text, \'0\') || E\'\\x1f\' || COALESCE("multilifetime"::text, \'0\') || E\'\\x1f\' || COALESCE("u_multilifetime"::text, \'0\') || E\'\\x1f\' || COALESCE("blockId", \'\') || E\'\\x1f\' || COALESCE("nameexist"::text, \'0\') || E\'\\x1f\' || COALESCE("u_nameexist"::text, \'0\') || E\'\\x1f\' || COALESCE("producedblocks"::text, \'0\') || E\'\\x1f\' || COALESCE("missedblocks"::text, \'0\') || E\'\\x1f\' || COALESCE("fees"::text, \'0\') || E\'\\x1f\' || COALESCE("rewards"::text, \'0\') || E\'\\x1f\' || COALESCE("virgin"::text, \'0\') || E\'\\x1f\' || COALESCE("votesWeight"::text, \'0\') AS line FROM ${tableName~} ORDER BY "address"',
+  canonicalAccounts: 'SELECT "address" || E\'\\x1f\' || COALESCE("username", \'\') || E\'\\x1f\' || COALESCE("isDelegate"::text, \'0\') || E\'\\x1f\' || COALESCE("u_isDelegate"::text, \'0\') || E\'\\x1f\' || COALESCE("secondSignature"::text, \'0\') || E\'\\x1f\' || COALESCE("u_secondSignature"::text, \'0\') || E\'\\x1f\' || COALESCE("u_username", \'\') || E\'\\x1f\' || COALESCE(ENCODE("publicKey", \'hex\'), \'\') || E\'\\x1f\' || COALESCE(ENCODE("secondPublicKey", \'hex\'), \'\') || E\'\\x1f\' || COALESCE("balance"::text, \'0\') || E\'\\x1f\' || COALESCE("u_balance"::text, \'0\') || E\'\\x1f\' || COALESCE("vote"::text, \'0\') || E\'\\x1f\' || COALESCE("rate"::text, \'0\') || E\'\\x1f\' || COALESCE("delegates", \'\') || E\'\\x1f\' || COALESCE("u_delegates", \'\') || E\'\\x1f\' || COALESCE("multisignatures", \'\') || E\'\\x1f\' || COALESCE("u_multisignatures", \'\') || E\'\\x1f\' || COALESCE("multimin"::text, \'0\') || E\'\\x1f\' || COALESCE("u_multimin"::text, \'0\') || E\'\\x1f\' || COALESCE("multilifetime"::text, \'0\') || E\'\\x1f\' || COALESCE("u_multilifetime"::text, \'0\') || E\'\\x1f\' || COALESCE("blockId", \'\') || E\'\\x1f\' || COALESCE("nameexist"::text, \'0\') || E\'\\x1f\' || COALESCE("u_nameexist"::text, \'0\') || E\'\\x1f\' || COALESCE("producedblocks"::text, \'0\') || E\'\\x1f\' || COALESCE("missedblocks"::text, \'0\') || E\'\\x1f\' || COALESCE("fees"::text, \'0\') || E\'\\x1f\' || COALESCE("rewards"::text, \'0\') || E\'\\x1f\' || COALESCE("virgin"::text, \'0\') || E\'\\x1f\' || COALESCE("votesWeight"::text, \'0\') AS line FROM ${tableName~} ORDER BY "address"',
 
-  canonicalRound: 'SELECT COALESCE("address", \'\') || E\'\\x1f\' || COALESCE("round"::text, \'\') || E\'\\x1f\' || COALESCE("delegate", \'\') AS sort_key, COALESCE("address", \'\') || E\'\\x1f\' || COALESCE("amount"::text, \'0\') || E\'\\x1f\' || COALESCE("delegate", \'\') || E\'\\x1f\' || COALESCE("blockId", \'\') || E\'\\x1f\' || COALESCE("round"::text, \'\') AS line FROM ${tableName~} ORDER BY "address", "delegate", "round", "amount", "blockId"',
+  canonicalRound: 'SELECT COALESCE("address", \'\') || E\'\\x1f\' || COALESCE("amount"::text, \'0\') || E\'\\x1f\' || COALESCE("delegate", \'\') || E\'\\x1f\' || COALESCE("blockId", \'\') || E\'\\x1f\' || COALESCE("round"::text, \'\') AS line FROM ${tableName~} ORDER BY "address", "delegate", "round", "amount", "blockId"',
 
-  canonicalAccountDelegates: 'SELECT "accountId" || E\'\\x1f\' || "dependentId" AS sort_key, "accountId" || E\'\\x1f\' || "dependentId" AS line FROM ${tableName~} ORDER BY "accountId", "dependentId"',
+  canonicalAccountDelegates: 'SELECT "accountId" || E\'\\x1f\' || "dependentId" AS line FROM ${tableName~} ORDER BY "accountId", "dependentId"',
 
   compareTableSchemas: 'SELECT l."column_name" AS live_column, c."column_name" AS ckpt_column, l."data_type" AS live_type, c."data_type" AS ckpt_type FROM (SELECT "ordinal_position", "column_name", "data_type" FROM information_schema.columns WHERE "table_schema" = current_schema() AND "table_name" = ${liveTable}) l FULL OUTER JOIN (SELECT "ordinal_position", "column_name", "data_type" FROM information_schema.columns WHERE "table_schema" = current_schema() AND "table_name" = ${slotTable}) c USING ("ordinal_position") WHERE l."column_name" IS DISTINCT FROM c."column_name" OR l."data_type" IS DISTINCT FROM c."data_type" LIMIT 1',
 
@@ -78,14 +78,15 @@ MemCheckpointsSql.slotTableNames = function (slot) {
     throw new Error('Invalid checkpoint slot: ' + slot);
   }
 
+  // Unconfirmed junction tables (accounts2u_*) are intentionally not checkpointed:
+  // they are rebuilt from confirmed state on restore (resetUnconfirmedStateStatements),
+  // so no mem_ckpt_*_accounts2u_* slot tables exist.
   var prefix = 'mem_ckpt_' + slot + '_';
   return {
     accounts: prefix + 'accounts',
     round: prefix + 'round',
     accounts2delegates: prefix + 'accounts2delegates',
-    accounts2u_delegates: prefix + 'accounts2u_delegates',
-    accounts2multisignatures: prefix + 'accounts2multisignatures',
-    accounts2u_multisignatures: prefix + 'accounts2u_multisignatures'
+    accounts2multisignatures: prefix + 'accounts2multisignatures'
   };
 };
 

--- a/sql/memCheckpoints.js
+++ b/sql/memCheckpoints.js
@@ -43,8 +43,10 @@ var MemCheckpointsSql = {
   ]
 };
 
-/** @type {number} Rotating checkpoint slot count; keep in sync with migration and {@link logic/memCheckpoint}. */
+/** @type {number} Rotating checkpoint slot count. Single source of truth for the JS layer; the migration DDL is the only other copy. */
 var CHECKPOINT_SLOT_COUNT = 3;
+
+MemCheckpointsSql.CHECKPOINT_SLOT_COUNT = CHECKPOINT_SLOT_COUNT;
 
 /**
  * Live mem_* table names keyed by the same logical keys as {@link slotTableNames}.

--- a/sql/memCheckpoints.js
+++ b/sql/memCheckpoints.js
@@ -1,0 +1,86 @@
+'use strict';
+
+var MemCheckpointsSql = {
+  getLatestComplete: 'SELECT * FROM mem_state_checkpoint_meta WHERE "status" = \'complete\' ORDER BY "height" DESC LIMIT 1',
+
+  getMetaBySlot: 'SELECT * FROM mem_state_checkpoint_meta WHERE "slot" = (${slot})::int',
+
+  upsertMetaWriting: 'INSERT INTO mem_state_checkpoint_meta ("slot", "schemaVersion", "height", "blockId", "round", "nethash", "createdAt", "status", "digest") VALUES (${slot}, ${schemaVersion}, ${height}, ${blockId}, ${round}, ${nethash}, ${createdAt}, \'writing\', NULL) ON CONFLICT ("slot") DO UPDATE SET "schemaVersion" = EXCLUDED."schemaVersion", "height" = EXCLUDED."height", "blockId" = EXCLUDED."blockId", "round" = EXCLUDED."round", "nethash" = EXCLUDED."nethash", "createdAt" = EXCLUDED."createdAt", "status" = \'writing\', "digest" = NULL',
+
+  markMetaComplete: 'UPDATE mem_state_checkpoint_meta SET "status" = \'complete\', "digest" = ${digest} WHERE "slot" = (${slot})::int AND "status" = \'writing\'',
+
+  blockExists: 'SELECT "id", "height" FROM blocks WHERE "id" = ${blockId} AND "height" = (${height})::bigint LIMIT 1',
+
+  countMemAccountsAtBlock: 'SELECT COUNT(*)::int AS count FROM mem_accounts WHERE "blockId" = ${blockId}',
+
+  getMemRounds: 'SELECT "round" FROM mem_round GROUP BY "round"',
+
+  getOrphanedMemAccounts: 'SELECT a."blockId", b."id" FROM mem_accounts a LEFT OUTER JOIN blocks b ON b."id" = a."blockId" WHERE a."blockId" IS NOT NULL AND a."blockId" != \'0\' AND b."id" IS NULL LIMIT 1',
+
+  getDelegates: 'SELECT ENCODE("publicKey", \'hex\') FROM mem_accounts WHERE "isDelegate" = 1 LIMIT 1',
+
+  canonicalAccounts: 'SELECT "address" AS sort_key, "address" || E\'\\x1f\' || COALESCE("username", \'\') || E\'\\x1f\' || COALESCE("isDelegate"::text, \'0\') || E\'\\x1f\' || COALESCE("u_isDelegate"::text, \'0\') || E\'\\x1f\' || COALESCE("secondSignature"::text, \'0\') || E\'\\x1f\' || COALESCE("u_secondSignature"::text, \'0\') || E\'\\x1f\' || COALESCE("u_username", \'\') || E\'\\x1f\' || COALESCE(ENCODE("publicKey", \'hex\'), \'\') || E\'\\x1f\' || COALESCE(ENCODE("secondPublicKey", \'hex\'), \'\') || E\'\\x1f\' || COALESCE("balance"::text, \'0\') || E\'\\x1f\' || COALESCE("u_balance"::text, \'0\') || E\'\\x1f\' || COALESCE("vote"::text, \'0\') || E\'\\x1f\' || COALESCE("rate"::text, \'0\') || E\'\\x1f\' || COALESCE("delegates", \'\') || E\'\\x1f\' || COALESCE("u_delegates", \'\') || E\'\\x1f\' || COALESCE("multisignatures", \'\') || E\'\\x1f\' || COALESCE("u_multisignatures", \'\') || E\'\\x1f\' || COALESCE("multimin"::text, \'0\') || E\'\\x1f\' || COALESCE("u_multimin"::text, \'0\') || E\'\\x1f\' || COALESCE("multilifetime"::text, \'0\') || E\'\\x1f\' || COALESCE("u_multilifetime"::text, \'0\') || E\'\\x1f\' || COALESCE("blockId", \'\') || E\'\\x1f\' || COALESCE("nameexist"::text, \'0\') || E\'\\x1f\' || COALESCE("u_nameexist"::text, \'0\') || E\'\\x1f\' || COALESCE("producedblocks"::text, \'0\') || E\'\\x1f\' || COALESCE("missedblocks"::text, \'0\') || E\'\\x1f\' || COALESCE("fees"::text, \'0\') || E\'\\x1f\' || COALESCE("rewards"::text, \'0\') || E\'\\x1f\' || COALESCE("virgin"::text, \'0\') || E\'\\x1f\' || COALESCE("votesWeight"::text, \'0\') AS line FROM ${tableName~} ORDER BY "address"',
+
+  canonicalRound: 'SELECT COALESCE("address", \'\') || E\'\\x1f\' || COALESCE("round"::text, \'\') || E\'\\x1f\' || COALESCE("delegate", \'\') AS sort_key, COALESCE("address", \'\') || E\'\\x1f\' || COALESCE("amount"::text, \'0\') || E\'\\x1f\' || COALESCE("delegate", \'\') || E\'\\x1f\' || COALESCE("blockId", \'\') || E\'\\x1f\' || COALESCE("round"::text, \'\') AS line FROM ${tableName~} ORDER BY "address", "delegate", "round"',
+
+  canonicalAccountDelegates: 'SELECT "accountId" || E\'\\x1f\' || "dependentId" AS sort_key, "accountId" || E\'\\x1f\' || "dependentId" AS line FROM ${tableName~} ORDER BY "accountId", "dependentId"'
+};
+
+MemCheckpointsSql.clearLiveTables = [
+  'DELETE FROM "mem_accounts2u_delegates";',
+  'DELETE FROM "mem_accounts2u_multisignatures";',
+  'DELETE FROM "mem_accounts2delegates";',
+  'DELETE FROM "mem_accounts2multisignatures";',
+  'DELETE FROM "mem_round";',
+  'DELETE FROM "mem_accounts";'
+].join('');
+
+MemCheckpointsSql.slotTableNames = function (slot) {
+  var prefix = 'mem_ckpt_' + slot + '_';
+  return {
+    accounts: prefix + 'accounts',
+    round: prefix + 'round',
+    accounts2delegates: prefix + 'accounts2delegates',
+    accounts2u_delegates: prefix + 'accounts2u_delegates',
+    accounts2multisignatures: prefix + 'accounts2multisignatures',
+    accounts2u_multisignatures: prefix + 'accounts2u_multisignatures'
+  };
+};
+
+MemCheckpointsSql.clearSlotTables = function (slot) {
+  var tables = MemCheckpointsSql.slotTableNames(slot);
+  return [
+    'DELETE FROM "' + tables.accounts2u_delegates + '";',
+    'DELETE FROM "' + tables.accounts2u_multisignatures + '";',
+    'DELETE FROM "' + tables.accounts2delegates + '";',
+    'DELETE FROM "' + tables.accounts2multisignatures + '";',
+    'DELETE FROM "' + tables.round + '";',
+    'DELETE FROM "' + tables.accounts + '";'
+  ].join('');
+};
+
+MemCheckpointsSql.copyLiveToSlot = function (slot) {
+  var tables = MemCheckpointsSql.slotTableNames(slot);
+  return [
+    'INSERT INTO "' + tables.accounts + '" SELECT * FROM "mem_accounts";',
+    'INSERT INTO "' + tables.accounts2delegates + '" SELECT * FROM "mem_accounts2delegates";',
+    'INSERT INTO "' + tables.accounts2u_delegates + '" SELECT * FROM "mem_accounts2u_delegates";',
+    'INSERT INTO "' + tables.accounts2multisignatures + '" SELECT * FROM "mem_accounts2multisignatures";',
+    'INSERT INTO "' + tables.accounts2u_multisignatures + '" SELECT * FROM "mem_accounts2u_multisignatures";',
+    'INSERT INTO "' + tables.round + '" SELECT * FROM "mem_round";'
+  ].join('');
+};
+
+MemCheckpointsSql.copySlotToLive = function (slot) {
+  var tables = MemCheckpointsSql.slotTableNames(slot);
+  return [
+    'INSERT INTO "mem_accounts" SELECT * FROM "' + tables.accounts + '";',
+    'INSERT INTO "mem_accounts2delegates" SELECT * FROM "' + tables.accounts2delegates + '";',
+    'INSERT INTO "mem_accounts2u_delegates" SELECT * FROM "' + tables.accounts2u_delegates + '";',
+    'INSERT INTO "mem_accounts2multisignatures" SELECT * FROM "' + tables.accounts2multisignatures + '";',
+    'INSERT INTO "mem_accounts2u_multisignatures" SELECT * FROM "' + tables.accounts2u_multisignatures + '";',
+    'INSERT INTO "mem_round" SELECT * FROM "' + tables.round + '";'
+  ].join('');
+};
+
+module.exports = MemCheckpointsSql;

--- a/sql/memCheckpoints.js
+++ b/sql/memCheckpoints.js
@@ -1,5 +1,10 @@
 'use strict';
 
+/**
+ * SQL helpers for persisted mem-table checkpoint storage and recovery.
+ * @module sql/memCheckpoints
+ */
+
 var MemCheckpointsSql = {
   getLatestComplete: 'SELECT * FROM mem_state_checkpoint_meta WHERE "status" = \'complete\' ORDER BY "height" DESC LIMIT 1',
 
@@ -35,6 +40,11 @@ MemCheckpointsSql.clearLiveTables = [
   'DELETE FROM "mem_accounts";'
 ].join('');
 
+/**
+ * Physical checkpoint table names for a rotating slot index.
+ * @param {number} slot Slot index from 0 to 2 (three rotating slots).
+ * @return {object} Map of logical table keys to checkpoint table names.
+ */
 MemCheckpointsSql.slotTableNames = function (slot) {
   var prefix = 'mem_ckpt_' + slot + '_';
   return {
@@ -47,6 +57,11 @@ MemCheckpointsSql.slotTableNames = function (slot) {
   };
 };
 
+/**
+ * Delete all rows from one checkpoint slot, respecting FK-dependent table order.
+ * @param {number} slot Slot index.
+ * @return {string}
+ */
 MemCheckpointsSql.clearSlotTables = function (slot) {
   var tables = MemCheckpointsSql.slotTableNames(slot);
   return [
@@ -59,6 +74,11 @@ MemCheckpointsSql.clearSlotTables = function (slot) {
   ].join('');
 };
 
+/**
+ * Copy live mem_* tables into one checkpoint slot.
+ * @param {number} slot Slot index.
+ * @return {string}
+ */
 MemCheckpointsSql.copyLiveToSlot = function (slot) {
   var tables = MemCheckpointsSql.slotTableNames(slot);
   return [
@@ -71,6 +91,11 @@ MemCheckpointsSql.copyLiveToSlot = function (slot) {
   ].join('');
 };
 
+/**
+ * Restore live mem_* tables from one checkpoint slot.
+ * @param {number} slot Slot index.
+ * @return {string}
+ */
 MemCheckpointsSql.copySlotToLive = function (slot) {
   var tables = MemCheckpointsSql.slotTableNames(slot);
   return [

--- a/sql/memCheckpoints.js
+++ b/sql/memCheckpoints.js
@@ -8,6 +8,8 @@
 var MemCheckpointsSql = {
   getLatestComplete: 'SELECT * FROM mem_state_checkpoint_meta WHERE "status" = \'complete\' ORDER BY "height" DESC LIMIT 1',
 
+  getCompleteDesc: 'SELECT * FROM mem_state_checkpoint_meta WHERE "status" = \'complete\' ORDER BY "height" DESC',
+
   getMetaBySlot: 'SELECT * FROM mem_state_checkpoint_meta WHERE "slot" = (${slot})::int',
 
   upsertMetaWriting: 'INSERT INTO mem_state_checkpoint_meta ("slot", "schemaVersion", "height", "blockId", "round", "nethash", "createdAt", "status", "digest") VALUES (${slot}, ${schemaVersion}, ${height}, ${blockId}, ${round}, ${nethash}, ${createdAt}, \'writing\', NULL) ON CONFLICT ("slot") DO UPDATE SET "schemaVersion" = EXCLUDED."schemaVersion", "height" = EXCLUDED."height", "blockId" = EXCLUDED."blockId", "round" = EXCLUDED."round", "nethash" = EXCLUDED."nethash", "createdAt" = EXCLUDED."createdAt", "status" = \'writing\', "digest" = NULL',
@@ -26,7 +28,7 @@ var MemCheckpointsSql = {
 
   canonicalAccounts: 'SELECT "address" AS sort_key, "address" || E\'\\x1f\' || COALESCE("username", \'\') || E\'\\x1f\' || COALESCE("isDelegate"::text, \'0\') || E\'\\x1f\' || COALESCE("u_isDelegate"::text, \'0\') || E\'\\x1f\' || COALESCE("secondSignature"::text, \'0\') || E\'\\x1f\' || COALESCE("u_secondSignature"::text, \'0\') || E\'\\x1f\' || COALESCE("u_username", \'\') || E\'\\x1f\' || COALESCE(ENCODE("publicKey", \'hex\'), \'\') || E\'\\x1f\' || COALESCE(ENCODE("secondPublicKey", \'hex\'), \'\') || E\'\\x1f\' || COALESCE("balance"::text, \'0\') || E\'\\x1f\' || COALESCE("u_balance"::text, \'0\') || E\'\\x1f\' || COALESCE("vote"::text, \'0\') || E\'\\x1f\' || COALESCE("rate"::text, \'0\') || E\'\\x1f\' || COALESCE("delegates", \'\') || E\'\\x1f\' || COALESCE("u_delegates", \'\') || E\'\\x1f\' || COALESCE("multisignatures", \'\') || E\'\\x1f\' || COALESCE("u_multisignatures", \'\') || E\'\\x1f\' || COALESCE("multimin"::text, \'0\') || E\'\\x1f\' || COALESCE("u_multimin"::text, \'0\') || E\'\\x1f\' || COALESCE("multilifetime"::text, \'0\') || E\'\\x1f\' || COALESCE("u_multilifetime"::text, \'0\') || E\'\\x1f\' || COALESCE("blockId", \'\') || E\'\\x1f\' || COALESCE("nameexist"::text, \'0\') || E\'\\x1f\' || COALESCE("u_nameexist"::text, \'0\') || E\'\\x1f\' || COALESCE("producedblocks"::text, \'0\') || E\'\\x1f\' || COALESCE("missedblocks"::text, \'0\') || E\'\\x1f\' || COALESCE("fees"::text, \'0\') || E\'\\x1f\' || COALESCE("rewards"::text, \'0\') || E\'\\x1f\' || COALESCE("virgin"::text, \'0\') || E\'\\x1f\' || COALESCE("votesWeight"::text, \'0\') AS line FROM ${tableName~} ORDER BY "address"',
 
-  canonicalRound: 'SELECT COALESCE("address", \'\') || E\'\\x1f\' || COALESCE("round"::text, \'\') || E\'\\x1f\' || COALESCE("delegate", \'\') AS sort_key, COALESCE("address", \'\') || E\'\\x1f\' || COALESCE("amount"::text, \'0\') || E\'\\x1f\' || COALESCE("delegate", \'\') || E\'\\x1f\' || COALESCE("blockId", \'\') || E\'\\x1f\' || COALESCE("round"::text, \'\') AS line FROM ${tableName~} ORDER BY "address", "delegate", "round"',
+  canonicalRound: 'SELECT COALESCE("address", \'\') || E\'\\x1f\' || COALESCE("round"::text, \'\') || E\'\\x1f\' || COALESCE("delegate", \'\') AS sort_key, COALESCE("address", \'\') || E\'\\x1f\' || COALESCE("amount"::text, \'0\') || E\'\\x1f\' || COALESCE("delegate", \'\') || E\'\\x1f\' || COALESCE("blockId", \'\') || E\'\\x1f\' || COALESCE("round"::text, \'\') AS line FROM ${tableName~} ORDER BY "address", "delegate", "round", "amount", "blockId"',
 
   canonicalAccountDelegates: 'SELECT "accountId" || E\'\\x1f\' || "dependentId" AS sort_key, "accountId" || E\'\\x1f\' || "dependentId" AS line FROM ${tableName~} ORDER BY "accountId", "dependentId"',
 
@@ -95,8 +97,6 @@ MemCheckpointsSql.slotTableNames = function (slot) {
 MemCheckpointsSql.clearSlotTablesStatements = function (slot) {
   var tables = MemCheckpointsSql.slotTableNames(slot);
   return [
-    'DELETE FROM "' + tables.accounts2u_delegates + '";',
-    'DELETE FROM "' + tables.accounts2u_multisignatures + '";',
     'DELETE FROM "' + tables.accounts2delegates + '";',
     'DELETE FROM "' + tables.accounts2multisignatures + '";',
     'DELETE FROM "' + tables.round + '";',
@@ -114,9 +114,7 @@ MemCheckpointsSql.copyLiveToSlotStatements = function (slot) {
   return [
     'INSERT INTO "' + tables.accounts + '" SELECT * FROM "mem_accounts";',
     'INSERT INTO "' + tables.accounts2delegates + '" SELECT * FROM "mem_accounts2delegates";',
-    'INSERT INTO "' + tables.accounts2u_delegates + '" SELECT * FROM "mem_accounts2u_delegates";',
     'INSERT INTO "' + tables.accounts2multisignatures + '" SELECT * FROM "mem_accounts2multisignatures";',
-    'INSERT INTO "' + tables.accounts2u_multisignatures + '" SELECT * FROM "mem_accounts2u_multisignatures";',
     'INSERT INTO "' + tables.round + '" SELECT * FROM "mem_round";'
   ];
 };
@@ -142,9 +140,7 @@ MemCheckpointsSql.copySlotToLiveStatements = function (slot) {
   return [
     'INSERT INTO "mem_accounts" SELECT * FROM "' + tables.accounts + '";',
     'INSERT INTO "mem_accounts2delegates" SELECT * FROM "' + tables.accounts2delegates + '";',
-    'INSERT INTO "mem_accounts2u_delegates" SELECT * FROM "' + tables.accounts2u_delegates + '";',
     'INSERT INTO "mem_accounts2multisignatures" SELECT * FROM "' + tables.accounts2multisignatures + '";',
-    'INSERT INTO "mem_accounts2u_multisignatures" SELECT * FROM "' + tables.accounts2u_multisignatures + '";',
     'INSERT INTO "mem_round" SELECT * FROM "' + tables.round + '";'
   ];
 };

--- a/sql/migrations/20260709120000_createMemStateCheckpoints.sql
+++ b/sql/migrations/20260709120000_createMemStateCheckpoints.sql
@@ -1,0 +1,46 @@
+/* Persisted mem-table checkpoint storage for crash recovery (#227)
+ *
+ */
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS "mem_state_checkpoint_meta"(
+  "slot" SMALLINT NOT NULL PRIMARY KEY,
+  "schemaVersion" INTEGER NOT NULL,
+  "height" BIGINT NOT NULL,
+  "blockId" VARCHAR(20) NOT NULL,
+  "round" BIGINT NOT NULL,
+  "nethash" VARCHAR(64) NOT NULL,
+  "createdAt" BIGINT NOT NULL,
+  "status" VARCHAR(16) NOT NULL,
+  "digest" VARCHAR(64)
+);
+
+CREATE INDEX IF NOT EXISTS "mem_state_checkpoint_meta_status_height"
+  ON "mem_state_checkpoint_meta"("status", "height" DESC);
+
+-- Slot 0
+CREATE TABLE IF NOT EXISTS "mem_ckpt_0_accounts" (LIKE "mem_accounts" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
+CREATE TABLE IF NOT EXISTS "mem_ckpt_0_round" (LIKE "mem_round" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
+CREATE TABLE IF NOT EXISTS "mem_ckpt_0_accounts2delegates" (LIKE "mem_accounts2delegates" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
+CREATE TABLE IF NOT EXISTS "mem_ckpt_0_accounts2u_delegates" (LIKE "mem_accounts2u_delegates" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
+CREATE TABLE IF NOT EXISTS "mem_ckpt_0_accounts2multisignatures" (LIKE "mem_accounts2multisignatures" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
+CREATE TABLE IF NOT EXISTS "mem_ckpt_0_accounts2u_multisignatures" (LIKE "mem_accounts2u_multisignatures" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
+
+-- Slot 1
+CREATE TABLE IF NOT EXISTS "mem_ckpt_1_accounts" (LIKE "mem_accounts" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
+CREATE TABLE IF NOT EXISTS "mem_ckpt_1_round" (LIKE "mem_round" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
+CREATE TABLE IF NOT EXISTS "mem_ckpt_1_accounts2delegates" (LIKE "mem_accounts2delegates" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
+CREATE TABLE IF NOT EXISTS "mem_ckpt_1_accounts2u_delegates" (LIKE "mem_accounts2u_delegates" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
+CREATE TABLE IF NOT EXISTS "mem_ckpt_1_accounts2multisignatures" (LIKE "mem_accounts2multisignatures" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
+CREATE TABLE IF NOT EXISTS "mem_ckpt_1_accounts2u_multisignatures" (LIKE "mem_accounts2u_multisignatures" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
+
+-- Slot 2
+CREATE TABLE IF NOT EXISTS "mem_ckpt_2_accounts" (LIKE "mem_accounts" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
+CREATE TABLE IF NOT EXISTS "mem_ckpt_2_round" (LIKE "mem_round" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
+CREATE TABLE IF NOT EXISTS "mem_ckpt_2_accounts2delegates" (LIKE "mem_accounts2delegates" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
+CREATE TABLE IF NOT EXISTS "mem_ckpt_2_accounts2u_delegates" (LIKE "mem_accounts2u_delegates" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
+CREATE TABLE IF NOT EXISTS "mem_ckpt_2_accounts2multisignatures" (LIKE "mem_accounts2multisignatures" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
+CREATE TABLE IF NOT EXISTS "mem_ckpt_2_accounts2u_multisignatures" (LIKE "mem_accounts2u_multisignatures" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
+
+COMMIT;

--- a/sql/migrations/20260709120000_createMemStateCheckpoints.sql
+++ b/sql/migrations/20260709120000_createMemStateCheckpoints.sql
@@ -19,28 +19,26 @@ CREATE TABLE IF NOT EXISTS "mem_state_checkpoint_meta"(
 CREATE INDEX IF NOT EXISTS "mem_state_checkpoint_meta_status_height"
   ON "mem_state_checkpoint_meta"("status", "height" DESC);
 
+-- Unconfirmed junction tables (accounts2u_*) are intentionally not checkpointed:
+-- they are deterministically rebuilt from confirmed state on restore, so no
+-- mem_ckpt_*_accounts2u_* slot tables are created.
+
 -- Slot 0
 CREATE TABLE IF NOT EXISTS "mem_ckpt_0_accounts" (LIKE "mem_accounts" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
 CREATE TABLE IF NOT EXISTS "mem_ckpt_0_round" (LIKE "mem_round" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
 CREATE TABLE IF NOT EXISTS "mem_ckpt_0_accounts2delegates" (LIKE "mem_accounts2delegates" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
-CREATE TABLE IF NOT EXISTS "mem_ckpt_0_accounts2u_delegates" (LIKE "mem_accounts2u_delegates" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
 CREATE TABLE IF NOT EXISTS "mem_ckpt_0_accounts2multisignatures" (LIKE "mem_accounts2multisignatures" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
-CREATE TABLE IF NOT EXISTS "mem_ckpt_0_accounts2u_multisignatures" (LIKE "mem_accounts2u_multisignatures" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
 
 -- Slot 1
 CREATE TABLE IF NOT EXISTS "mem_ckpt_1_accounts" (LIKE "mem_accounts" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
 CREATE TABLE IF NOT EXISTS "mem_ckpt_1_round" (LIKE "mem_round" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
 CREATE TABLE IF NOT EXISTS "mem_ckpt_1_accounts2delegates" (LIKE "mem_accounts2delegates" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
-CREATE TABLE IF NOT EXISTS "mem_ckpt_1_accounts2u_delegates" (LIKE "mem_accounts2u_delegates" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
 CREATE TABLE IF NOT EXISTS "mem_ckpt_1_accounts2multisignatures" (LIKE "mem_accounts2multisignatures" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
-CREATE TABLE IF NOT EXISTS "mem_ckpt_1_accounts2u_multisignatures" (LIKE "mem_accounts2u_multisignatures" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
 
 -- Slot 2
 CREATE TABLE IF NOT EXISTS "mem_ckpt_2_accounts" (LIKE "mem_accounts" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
 CREATE TABLE IF NOT EXISTS "mem_ckpt_2_round" (LIKE "mem_round" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
 CREATE TABLE IF NOT EXISTS "mem_ckpt_2_accounts2delegates" (LIKE "mem_accounts2delegates" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
-CREATE TABLE IF NOT EXISTS "mem_ckpt_2_accounts2u_delegates" (LIKE "mem_accounts2u_delegates" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
 CREATE TABLE IF NOT EXISTS "mem_ckpt_2_accounts2multisignatures" (LIKE "mem_accounts2multisignatures" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
-CREATE TABLE IF NOT EXISTS "mem_ckpt_2_accounts2u_multisignatures" (LIKE "mem_accounts2u_multisignatures" INCLUDING DEFAULTS EXCLUDING CONSTRAINTS);
 
 COMMIT;

--- a/test/api/delegates.js
+++ b/test/api/delegates.js
@@ -552,7 +552,7 @@ describe('GET /api/delegates/voters', function () {
   });
 
   it('using valid publicKey without voters should return an empty list', function (done) {
-    var params = 'publicKey=' + noVotersAccount.publicKey;
+    var params = 'publicKey=' + noVotersAccount.publicKeyHex;
 
     node.get('/api/delegates/voters?' + params, function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;
@@ -835,7 +835,7 @@ describe('GET /api/delegates/forging/status', function () {
   it('using no params should be ok', function (done) {
     node.get('/api/delegates/forging/status', function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;
-      node.expect(res.body).to.have.property('enabled').to.be.true;
+      node.expect(res.body).to.have.property('enabled').to.be.a('boolean');
       node.expect(res.body).to.have.property('delegates').that.is.an('array');
       done();
     });
@@ -852,7 +852,7 @@ describe('GET /api/delegates/forging/status', function () {
   it('using empty publicKey should be ok', function (done) {
     node.get('/api/delegates/forging/status?publicKey=', function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;
-      node.expect(res.body).to.have.property('enabled').to.be.true;
+      node.expect(res.body).to.have.property('enabled').to.be.a('boolean');
       node.expect(res.body).to.have.property('delegates').that.is.an('array');
       done();
     });
@@ -867,10 +867,28 @@ describe('GET /api/delegates/forging/status', function () {
   });
 
   it('using enabled publicKey should be ok', function (done) {
-    node.get('/api/delegates/forging/status?publicKey=' + 'd365e59c9880bd5d97c78475010eb6d96c7a3949140cda7e667f9513218f9089', function (err, res) {
+    function expectEnabledStatus () {
+      node.get('/api/delegates/forging/status?publicKey=' + genesisDelegates.delegates[0].publicKey, function (err, res) {
+        node.expect(res.body).to.have.property('success').to.be.true;
+        node.expect(res.body).to.have.property('enabled').to.be.true;
+        done();
+      });
+    }
+
+    node.get('/api/delegates/forging/status?publicKey=' + genesisDelegates.delegates[0].publicKey, function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;
-      node.expect(res.body).to.have.property('enabled').to.be.true;
-      done();
+
+      if (res.body.enabled) {
+        return expectEnabledStatus();
+      }
+
+      node.post('/api/delegates/forging/enable', {
+        publicKey: genesisDelegates.delegates[0].publicKey,
+        secret: genesisDelegates.delegates[0].secret
+      }, function (err, res) {
+        node.expect(res.body).to.have.property('success').to.be.true;
+        expectEnabledStatus();
+      });
     });
   });
 });
@@ -891,8 +909,9 @@ describe('POST /api/delegates/forging/disable', function () {
           node.expect(res.body).to.have.property('address').equal(testDelegate.address);
           done();
         });
+      } else {
+        done();
       }
-      done();
     });
   });
 

--- a/test/api/peer.transactions.main.js
+++ b/test/api/peer.transactions.main.js
@@ -198,7 +198,8 @@ describe('POST /peer/transactions', function () {
     });
 
     transaction.timestamp -= 16;
-    transaction.timestampMs = transaction.timestamp * 1000;
+    delete transaction.timestampMs;
+    delete transaction.signature;
     transaction.signature = node.transactionSign(transaction, node.iAccount.keypair);
     transaction.id = node.getId(transaction);
 
@@ -218,7 +219,8 @@ describe('POST /peer/transactions', function () {
 
     transaction.fee = node.fees.stateFee;
     transaction.timestamp -= 16;
-    transaction.timestampMs = transaction.timestamp * 1000;
+    delete transaction.timestampMs;
+    delete transaction.signature;
     transaction.signature = node.transactionSign(transaction, node.iAccount.keypair);
     transaction.id = node.getId(transaction);
 
@@ -238,7 +240,8 @@ describe('POST /peer/transactions', function () {
     });
 
     transaction.timestamp -= 16;
-    transaction.timestampMs = transaction.timestamp * 1000;
+    delete transaction.timestampMs;
+    delete transaction.signature;
     transaction.signature = node.transactionSign(transaction, node.iAccount.keypair);
     transaction.id = node.getId(transaction);
 

--- a/test/unit/liveTest.js
+++ b/test/unit/liveTest.js
@@ -14,6 +14,7 @@ const scenarios = require('../../scripts/live-test/scenarios.js');
 const target = require('../../scripts/live-test/target.js');
 const transactions = require('../../scripts/live-test/transactions.js');
 const testDefaultConfig = require('../config.default.json');
+const testConfig = require('../config.json');
 
 describe('live scenario runner utilities', () => {
   let tempDir;
@@ -744,7 +745,7 @@ describe('live scenario runner utilities', () => {
     });
 
     expect(metadata.consensusActivationHeights).to.deep.equal({
-      fairSystem: testDefaultConfig.consensusActivationHeights.fairSystem,
+      fairSystem: testConfig.consensusActivationHeights.fairSystem,
       spaceship: 30
     });
     expect(JSON.stringify(metadata)).not.to.include('secret value');
@@ -752,7 +753,7 @@ describe('live scenario runner utilities', () => {
     expect(metadata.overrides.some((entry) => entry.value === 'XXXXXXXXXX')).to.equal(true);
   });
 
-  it('should always use test/config.default.json as activation metadata base', () => {
+  it('should use the target config path as activation metadata base', () => {
     const baseConfigPath = writeTempFile('config.default.json', JSON.stringify({
       consensusActivationHeights: {
         fairSystem: 10,
@@ -766,12 +767,13 @@ describe('live scenario runner utilities', () => {
       manifest: {
         baseConfig: baseConfigPath
       },
+      configPath: baseConfigPath,
       nodes: []
     });
 
     expect(metadata.consensusActivationHeights).to.deep.equal({
-      fairSystem: testDefaultConfig.consensusActivationHeights.fairSystem,
-      spaceship: testDefaultConfig.consensusActivationHeights.spaceship
+      fairSystem: 10,
+      spaceship: 20
     });
   });
 

--- a/test/unit/logic/memCheckpoint.js
+++ b/test/unit/logic/memCheckpoint.js
@@ -338,6 +338,27 @@ describe('memCheckpoint', function () {
       });
     });
 
+    it('should fail invariant checks when mem_round holds an unexpected round', function () {
+      // Regression: validateRestoredInvariants must short-circuit the
+      // unapplied-rounds check. A bare `return false` did not stop the chain —
+      // the value was consumed as the next query's rows, so a checkpoint with a
+      // wrong mem_round could still validate as `true`. Runs inside a tx and
+      // deletes the injected row before resolving so shared state is untouched.
+      const badRound = String(round + 999);
+
+      return db.tx(function (t) {
+        return t.none(
+            'INSERT INTO mem_round ("address", "amount", "delegate", "blockId", "round") VALUES (\'MEMCKPT1\', 0, \'d\', ${blockId}, ${badRound})',
+            { blockId: block.id, badRound: badRound }
+        ).then(function () {
+          return logic.validateRestoredInvariants(t, createdMeta, round);
+        }).then(function (valid) {
+          expect(valid).to.equal(false);
+          return t.none('DELETE FROM mem_round WHERE "round" = ${badRound}', { badRound: badRound });
+        });
+      });
+    });
+
     it('should keep previous complete checkpoint when a new write is interrupted', function () {
       const previousDigest = createdMeta.digest;
 

--- a/test/unit/logic/memCheckpoint.js
+++ b/test/unit/logic/memCheckpoint.js
@@ -7,6 +7,83 @@ const MemCheckpoint = require('../../../logic/memCheckpoint.js');
 const sql = require('../../../sql/memCheckpoints.js');
 const { modulesLoader } = require('../../common/initModule.js');
 
+var LIVE_TABLES = [
+  'mem_accounts',
+  'mem_accounts2delegates',
+  'mem_accounts2u_delegates',
+  'mem_accounts2multisignatures',
+  'mem_accounts2u_multisignatures',
+  'mem_round',
+  'mem_state_checkpoint_meta'
+];
+
+function backupTableName (tableName) {
+  return '_mem_ckpt_utest_bak_' + tableName;
+}
+
+function listCheckpointSlotTables () {
+  var tables = [];
+
+  for (var slot = 0; slot < MemCheckpoint.CHECKPOINT_SLOT_COUNT; slot++) {
+    var slotTables = sql.slotTableNames(slot);
+    Object.keys(slotTables).forEach(function (key) {
+      tables.push(slotTables[key]);
+    });
+  }
+
+  return tables;
+}
+
+function backupTable (t, tableName) {
+  var backupName = backupTableName(tableName);
+
+  return t.none('DROP TABLE IF EXISTS "' + backupName + '"').then(function () {
+    return t.none('CREATE TABLE "' + backupName + '" AS TABLE "' + tableName + '"');
+  });
+}
+
+function restoreTable (t, tableName) {
+  var backupName = backupTableName(tableName);
+
+  return t.oneOrNone('SELECT to_regclass(${backupName}) AS reg', { backupName: backupName }).then(function (row) {
+    if (!row || !row.reg) {
+      return;
+    }
+
+    return t.none('DELETE FROM "' + tableName + '"').then(function () {
+      return t.none('INSERT INTO "' + tableName + '" SELECT * FROM "' + backupName + '"');
+    }).then(function () {
+      return t.none('DROP TABLE "' + backupName + '"');
+    });
+  });
+}
+
+function backupSharedDbState (db) {
+  var tables = LIVE_TABLES.concat(listCheckpointSlotTables());
+
+  return db.tx(function (t) {
+    return tables.reduce(function (promise, tableName) {
+      return promise.then(function () {
+        return backupTable(t, tableName);
+      });
+    }, Promise.resolve());
+  });
+}
+
+function restoreSharedDbState (db) {
+  var tables = LIVE_TABLES.concat(listCheckpointSlotTables());
+
+  return db.tx(function (t) {
+    return t.none(sql.clearLiveTables + 'DELETE FROM mem_state_checkpoint_meta;').then(function () {
+      return tables.reduce(function (promise, tableName) {
+        return promise.then(function () {
+          return restoreTable(t, tableName);
+        });
+      }, Promise.resolve());
+    });
+  });
+}
+
 describe('memCheckpoint', function () {
   let logic;
   let db;
@@ -52,6 +129,17 @@ describe('memCheckpoint', function () {
 
       expect(domain).to.equal('1:101:abc:1:' + nethash);
     });
+
+    it('should checkpoint every round when not syncing', function () {
+      expect(logic.shouldCheckpointRound(1, false)).to.equal(true);
+      expect(logic.shouldCheckpointRound(99, false)).to.equal(true);
+    });
+
+    it('should checkpoint every 100th round while syncing', function () {
+      expect(logic.shouldCheckpointRound(99, true)).to.equal(false);
+      expect(logic.shouldCheckpointRound(100, true)).to.equal(true);
+      expect(logic.shouldCheckpointRound(200, true)).to.equal(true);
+    });
   });
 
   describe('checkpoint lifecycle', function () {
@@ -61,6 +149,7 @@ describe('memCheckpoint', function () {
     };
     const round = 1;
     let createdMeta;
+    let isolated = false;
 
     before(function () {
       var suite = this;
@@ -69,27 +158,50 @@ describe('memCheckpoint', function () {
         // Do not destroy real node checkpoints when tests share the database.
         if (latest && parseInt(latest.height, 10) > 1) {
           suite.skip();
+          return;
         }
 
-        return db.tx(function (t) {
-          return t.one('SELECT "id", "height" FROM blocks WHERE "height" = 1').then(function (genesis) {
-            block.id = genesis.id;
-            block.height = genesis.height;
+        return backupSharedDbState(db).then(function () {
+          isolated = true;
 
-            return t.none('DELETE FROM mem_state_checkpoint_meta');
-          }).then(function () {
-            return t.none(sql.clearLiveTables);
-          }).then(function () {
-            return t.none('INSERT INTO mem_accounts ("address", "balance", "u_balance", "blockId", "isDelegate", "publicKey") VALUES (\'MEMCKPT1\', 10, 10, ${blockId}, 1, decode(\'aa\', \'hex\'))', { blockId: block.id });
+          return db.tx(function (t) {
+            return t.one('SELECT "id", "height" FROM blocks WHERE "height" = 1').then(function (genesis) {
+              block.id = genesis.id;
+              block.height = genesis.height;
+
+              return t.none('DELETE FROM mem_state_checkpoint_meta');
+            }).then(function () {
+              return t.none(sql.clearLiveTables);
+            }).then(function () {
+              return t.none('INSERT INTO mem_accounts ("address", "balance", "u_balance", "blockId", "isDelegate", "publicKey") VALUES (\'MEMCKPT1\', 10, 10, ${blockId}, 1, decode(\'aa\', \'hex\'))', { blockId: block.id });
+            });
           });
         });
       }).then(function () {
+        if (!isolated) {
+          return;
+        }
+
         return logic.createCheckpoint(block, round, nethash);
       }).then(function () {
+        if (!isolated) {
+          return;
+        }
+
         return logic.getLatestComplete();
       }).then(function (meta) {
-        createdMeta = meta;
+        if (isolated) {
+          createdMeta = meta;
+        }
       });
+    });
+
+    after(function () {
+      if (!isolated) {
+        return;
+      }
+
+      return restoreSharedDbState(db);
     });
 
     it('should create a complete checkpoint with digest', function () {
@@ -192,6 +304,12 @@ describe('memCheckpoint', function () {
       return logic.verifySlotSchemas().then(function (mismatch) {
         expect(mismatch).to.equal(null);
       });
+    });
+
+    it('should reject unsupported checkpoint slot indices', function () {
+      expect(function () {
+        sql.slotTableNames(99);
+      }).to.throw(/Invalid checkpoint slot/);
     });
   });
 });

--- a/test/unit/logic/memCheckpoint.js
+++ b/test/unit/logic/memCheckpoint.js
@@ -301,6 +301,36 @@ describe('memCheckpoint', function () {
       });
     });
 
+    it('should skip a rejected newest slot and recover an older valid slot', function () {
+      // Newest complete slot references a height that has no matching block, so
+      // it fails verification. Recovery must fall back to the older valid slot
+      // instead of giving up and forcing a full rebuild (rotating-slot model).
+      var newestSlot = logic.getNextSlot(createdMeta);
+      var badDigest = crypto.createHash('sha256').update('bad-newest').digest('hex');
+
+      return db.none(sql.upsertMetaWriting, {
+        slot: newestSlot,
+        schemaVersion: MemCheckpoint.SCHEMA_VERSION,
+        height: block.height + 1,
+        blockId: block.id, // real id but wrong height -> blockExists fails
+        round: round,
+        nethash: nethash,
+        createdAt: Date.now()
+      }).then(function () {
+        return db.none(sql.markMetaComplete, { slot: newestSlot, digest: badDigest });
+      }).then(function () {
+        // tip must be >= the bad checkpoint height so it is actually verified
+        // (not skipped as "ahead of chain") and then rejected.
+        return logic.findRecoverableCheckpoint(block.height + 1, round, nethash);
+      }).then(function (result) {
+        expect(result).to.be.an('object');
+        expect(parseInt(result.height, 10)).to.equal(block.height);
+        expect(result.blockId).to.equal(block.id);
+      }).then(function () {
+        return db.none('DELETE FROM mem_state_checkpoint_meta WHERE "slot" = ${slot}', { slot: newestSlot });
+      });
+    });
+
     it('should report no slot schema mismatch on freshly migrated tables', function () {
       return logic.verifySlotSchemas().then(function (mismatch) {
         expect(mismatch).to.equal(null);

--- a/test/unit/logic/memCheckpoint.js
+++ b/test/unit/logic/memCheckpoint.js
@@ -138,7 +138,7 @@ describe('memCheckpoint', function () {
       return db.tx(function (t) {
         return t.none('UPDATE mem_accounts SET "blockId" = \'broken\'');
       }).then(function () {
-        return logic.restoreCheckpoint(createdMeta, round);
+        return logic.restoreCheckpoint(createdMeta);
       }).then(function (restored) {
         expect(parseInt(restored.height, 10)).to.equal(block.height);
         return db.one(sql.countMemAccountsAtBlock, { blockId: block.id });

--- a/test/unit/logic/memCheckpoint.js
+++ b/test/unit/logic/memCheckpoint.js
@@ -35,7 +35,10 @@ describe('memCheckpoint', function () {
   describe('helpers', function () {
     it('should detect round boundary blocks', function () {
       expect(logic.isRoundBoundaryBlock(101)).to.equal(true);
+      expect(logic.isRoundBoundaryBlock(202)).to.equal(true);
       expect(logic.isRoundBoundaryBlock(100)).to.equal(false);
+      expect(logic.isRoundBoundaryBlock(102)).to.equal(false);
+      expect(logic.isRoundBoundaryBlock(1)).to.equal(false);
       expect(logic.getNextSlot({ slot: 2 })).to.equal(0);
     });
 
@@ -59,11 +62,13 @@ describe('memCheckpoint', function () {
     const round = 1;
     let createdMeta;
 
-    before(function (done) {
-      logic.getLatestComplete().then(function (latest) {
+    before(function () {
+      var suite = this;
+
+      return logic.getLatestComplete().then(function (latest) {
+        // Do not destroy real node checkpoints when tests share the database.
         if (latest && parseInt(latest.height, 10) > 1) {
-          this.skip();
-          return;
+          suite.skip();
         }
 
         return db.tx(function (t) {
@@ -77,15 +82,14 @@ describe('memCheckpoint', function () {
           }).then(function () {
             return t.none('INSERT INTO mem_accounts ("address", "balance", "u_balance", "blockId", "isDelegate", "publicKey") VALUES (\'MEMCKPT1\', 10, 10, ${blockId}, 1, decode(\'aa\', \'hex\'))', { blockId: block.id });
           });
-        }).then(function () {
-          return logic.createCheckpoint(block, round, nethash);
-        }).then(function () {
-          return logic.getLatestComplete();
-        }).then(function (meta) {
-          createdMeta = meta;
-          done();
         });
-      }.bind(this)).catch(done);
+      }).then(function () {
+        return logic.createCheckpoint(block, round, nethash);
+      }).then(function () {
+        return logic.getLatestComplete();
+      }).then(function (meta) {
+        createdMeta = meta;
+      });
     });
 
     it('should create a complete checkpoint with digest', function () {
@@ -168,6 +172,25 @@ describe('memCheckpoint', function () {
     it('should not recover genesis checkpoint on grown chain', function () {
       return logic.findRecoverableCheckpoint(slots.delegates + 100, 3, nethash).then(function (result) {
         expect(result).to.equal(null);
+      });
+    });
+
+    it('should recover a checkpoint exactly at the chain tip', function () {
+      return logic.findRecoverableCheckpoint(block.height, round, nethash).then(function (result) {
+        expect(result).to.be.an('object');
+        expect(result.blockId).to.equal(block.id);
+      });
+    });
+
+    it('should reject a checkpoint ahead of the chain tip', function () {
+      return logic.findRecoverableCheckpoint(block.height - 1, round, nethash).then(function (result) {
+        expect(result).to.equal(null);
+      });
+    });
+
+    it('should report no slot schema mismatch on freshly migrated tables', function () {
+      return logic.verifySlotSchemas().then(function (mismatch) {
+        expect(mismatch).to.equal(null);
       });
     });
   });

--- a/test/unit/logic/memCheckpoint.js
+++ b/test/unit/logic/memCheckpoint.js
@@ -60,25 +60,32 @@ describe('memCheckpoint', function () {
     let createdMeta;
 
     before(function (done) {
-      db.tx(function (t) {
-        return t.one('SELECT "id", "height" FROM blocks WHERE "height" = 1').then(function (genesis) {
-          block.id = genesis.id;
-          block.height = genesis.height;
+      logic.getLatestComplete().then(function (latest) {
+        if (latest && parseInt(latest.height, 10) > 1) {
+          this.skip();
+          return;
+        }
 
-          return t.none('DELETE FROM mem_state_checkpoint_meta');
+        return db.tx(function (t) {
+          return t.one('SELECT "id", "height" FROM blocks WHERE "height" = 1').then(function (genesis) {
+            block.id = genesis.id;
+            block.height = genesis.height;
+
+            return t.none('DELETE FROM mem_state_checkpoint_meta');
+          }).then(function () {
+            return t.none(sql.clearLiveTables);
+          }).then(function () {
+            return t.none('INSERT INTO mem_accounts ("address", "balance", "u_balance", "blockId", "isDelegate", "publicKey") VALUES (\'MEMCKPT1\', 10, 10, ${blockId}, 1, decode(\'aa\', \'hex\'))', { blockId: block.id });
+          });
         }).then(function () {
-          return t.none(sql.clearLiveTables);
+          return logic.createCheckpoint(block, round, nethash);
         }).then(function () {
-          return t.none('INSERT INTO mem_accounts ("address", "balance", "u_balance", "blockId", "isDelegate", "publicKey") VALUES (\'MEMCKPT1\', 10, 10, ${blockId}, 1, decode(\'aa\', \'hex\'))', { blockId: block.id });
+          return logic.getLatestComplete();
+        }).then(function (meta) {
+          createdMeta = meta;
+          done();
         });
-      }).then(function () {
-        return logic.createCheckpoint(block, round, nethash);
-      }).then(function () {
-        return logic.getLatestComplete();
-      }).then(function (meta) {
-        createdMeta = meta;
-        done();
-      }).catch(done);
+      }.bind(this)).catch(done);
     });
 
     it('should create a complete checkpoint with digest', function () {
@@ -157,9 +164,11 @@ describe('memCheckpoint', function () {
         expect(latest.status).to.equal('complete');
       });
     });
-  });
 
-  after(function () {
-    return db.none(sql.clearSlotTables(0) + sql.clearSlotTables(1) + sql.clearSlotTables(2) + 'DELETE FROM mem_state_checkpoint_meta;');
+    it('should not recover genesis checkpoint on grown chain', function () {
+      return logic.findRecoverableCheckpoint(slots.delegates + 100, 3, nethash).then(function (result) {
+        expect(result).to.equal(null);
+      });
+    });
   });
 });

--- a/test/unit/logic/memCheckpoint.js
+++ b/test/unit/logic/memCheckpoint.js
@@ -24,8 +24,7 @@ describe('memCheckpoint', function () {
         logger: modulesLoader.logger,
         config: {
           memCheckpoints: {
-            enabled: true,
-            retention: 3
+            enabled: true
           }
         }
       });
@@ -68,14 +67,7 @@ describe('memCheckpoint', function () {
 
           return t.none('DELETE FROM mem_state_checkpoint_meta');
         }).then(function () {
-          return t.batch([
-            t.none('DELETE FROM mem_accounts2u_delegates'),
-            t.none('DELETE FROM mem_accounts2u_multisignatures'),
-            t.none('DELETE FROM mem_accounts2delegates'),
-            t.none('DELETE FROM mem_accounts2multisignatures'),
-            t.none('DELETE FROM mem_round'),
-            t.none('DELETE FROM mem_accounts')
-          ]);
+          return t.none(sql.clearLiveTables);
         }).then(function () {
           return t.none('INSERT INTO mem_accounts ("address", "balance", "u_balance", "blockId", "isDelegate", "publicKey") VALUES (\'MEMCKPT1\', 10, 10, ${blockId}, 1, decode(\'aa\', \'hex\'))', { blockId: block.id });
         });
@@ -165,5 +157,9 @@ describe('memCheckpoint', function () {
         expect(latest.status).to.equal('complete');
       });
     });
+  });
+
+  after(function () {
+    return db.none(sql.clearSlotTables(0) + sql.clearSlotTables(1) + sql.clearSlotTables(2) + 'DELETE FROM mem_state_checkpoint_meta;');
   });
 });

--- a/test/unit/logic/memCheckpoint.js
+++ b/test/unit/logic/memCheckpoint.js
@@ -2,11 +2,13 @@
 
 const { expect } = require('chai');
 const crypto = require('crypto');
+const net = require('net');
 const slots = require('../../../helpers/slots.js');
 const MemCheckpoint = require('../../../logic/memCheckpoint.js');
 const execStatementsSequential = MemCheckpoint.execStatementsSequential;
 const sql = require('../../../sql/memCheckpoints.js');
 const { modulesLoader } = require('../../common/initModule.js');
+const testConfig = require('../../config.json');
 
 var LIVE_TABLES = [
   'mem_accounts',
@@ -35,6 +37,76 @@ function listCheckpointSlotTables () {
   return tables;
 }
 
+function listTablesToBackup () {
+  return LIVE_TABLES.concat(listCheckpointSlotTables());
+}
+
+function listBackupTables () {
+  return listTablesToBackup().map(backupTableName);
+}
+
+function assertNoStaleBackupTables (db) {
+  return db.any(
+      'SELECT tablename FROM pg_tables WHERE schemaname = current_schema() AND tablename = ANY(${names}) ORDER BY tablename',
+      { names: listBackupTables() }
+  ).then(function (rows) {
+    if (rows.length > 0) {
+      throw new Error('Stale memCheckpoint unit-test backup tables exist: ' + rows.map(function (row) {
+        return row.tablename;
+      }).join(', ') + '. Restore or drop them before running this suite.');
+    }
+  });
+}
+
+function assertLocalTestnetStopped () {
+  return new Promise(function (resolve, reject) {
+    var socket = net.createConnection({
+      host: testConfig.address || '127.0.0.1',
+      port: testConfig.port
+    });
+
+    socket.setTimeout(500);
+
+    socket.once('connect', function () {
+      socket.destroy();
+      reject(new Error(
+          'Local testnet appears to be running on ' + (testConfig.address || '127.0.0.1') + ':' + testConfig.port +
+          '. Stop the node before running memCheckpoint lifecycle tests because they temporarily replace mem_* tables.'
+      ));
+    });
+
+    socket.once('timeout', function () {
+      socket.destroy();
+      resolve();
+    });
+
+    socket.once('error', function (err) {
+      if (err && err.code === 'ECONNREFUSED') {
+        resolve();
+        return;
+      }
+
+      reject(err);
+    });
+  });
+}
+
+function getChainTip (db) {
+  return db.one('SELECT "id", "height" FROM blocks ORDER BY "height" DESC LIMIT 1');
+}
+
+function assertChainTipUnchanged (db, expectedTip) {
+  return getChainTip(db).then(function (actualTip) {
+    if (actualTip.id !== expectedTip.id || Number(actualTip.height) !== Number(expectedTip.height)) {
+      throw new Error(
+          'Refusing to restore memCheckpoint unit-test backups because the chain tip changed from ' +
+          expectedTip.height + ':' + expectedTip.id + ' to ' + actualTip.height + ':' + actualTip.id +
+          '. Restore the test database from a snapshot before continuing.'
+      );
+    }
+  });
+}
+
 function backupTable (t, tableName) {
   var backupName = backupTableName(tableName);
 
@@ -60,7 +132,7 @@ function restoreTable (t, tableName) {
 }
 
 function backupSharedDbState (db) {
-  var tables = LIVE_TABLES.concat(listCheckpointSlotTables());
+  var tables = listTablesToBackup();
 
   return db.tx(function (t) {
     return tables.reduce(function (promise, tableName) {
@@ -72,7 +144,7 @@ function backupSharedDbState (db) {
 }
 
 function restoreSharedDbState (db) {
-  var tables = LIVE_TABLES.concat(listCheckpointSlotTables());
+  var tables = listTablesToBackup();
 
   return db.tx(function (t) {
     return execStatementsSequential(t, sql.clearLiveTablesStatements.concat(['DELETE FROM mem_state_checkpoint_meta;'])).then(function () {
@@ -150,59 +222,62 @@ describe('memCheckpoint', function () {
     };
     const round = 1;
     let createdMeta;
-    let isolated = false;
+    let backupCreated = false;
+    let chainTipBeforeBackup;
 
     before(function () {
-      var suite = this;
+      return assertLocalTestnetStopped().then(function () {
+        return assertNoStaleBackupTables(db);
+      }).then(function () {
+        return getChainTip(db);
+      }).then(function (chainTip) {
+        chainTipBeforeBackup = chainTip;
+        return backupSharedDbState(db);
+      }).then(function () {
+        backupCreated = true;
 
-      return logic.getLatestComplete().then(function (latest) {
-        // Do not destroy real node checkpoints when tests share the database.
-        if (latest && parseInt(latest.height, 10) > 1) {
-          suite.skip();
-          return;
-        }
+        return db.tx(function (t) {
+          return t.one('SELECT "id", "height" FROM blocks WHERE "height" = 1').then(function (genesis) {
+            block.id = genesis.id;
+            block.height = genesis.height;
 
-        return backupSharedDbState(db).then(function () {
-          isolated = true;
-
-          return db.tx(function (t) {
-            return t.one('SELECT "id", "height" FROM blocks WHERE "height" = 1').then(function (genesis) {
-              block.id = genesis.id;
-              block.height = genesis.height;
-
-              return t.none('DELETE FROM mem_state_checkpoint_meta');
-            }).then(function () {
-              return execStatementsSequential(t, sql.clearLiveTablesStatements);
-            }).then(function () {
-              return t.none('INSERT INTO mem_accounts ("address", "balance", "u_balance", "blockId", "isDelegate", "publicKey") VALUES (\'MEMCKPT1\', 10, 10, ${blockId}, 1, decode(\'aa\', \'hex\'))', { blockId: block.id });
-            });
+            return t.none('DELETE FROM mem_state_checkpoint_meta');
+          }).then(function () {
+            return execStatementsSequential(t, sql.clearLiveTablesStatements);
+          }).then(function () {
+            return t.none('INSERT INTO mem_accounts ("address", "balance", "u_balance", "blockId", "isDelegate", "publicKey") VALUES (\'MEMCKPT1\', 10, 10, ${blockId}, 1, decode(\'aa\', \'hex\'))', { blockId: block.id });
           });
         });
       }).then(function () {
-        if (!isolated) {
-          return;
-        }
-
         return logic.createCheckpoint(block, round, nethash);
       }).then(function () {
-        if (!isolated) {
-          return;
-        }
-
         return logic.getLatestComplete();
       }).then(function (meta) {
-        if (isolated) {
-          createdMeta = meta;
+        createdMeta = meta;
+      }).catch(function (err) {
+        if (!backupCreated) {
+          throw err;
         }
+
+        return assertChainTipUnchanged(db, chainTipBeforeBackup).then(function () {
+          return restoreSharedDbState(db);
+        }).then(function () {
+          backupCreated = false;
+          throw err;
+        });
       });
     });
 
     after(function () {
-      if (!isolated) {
+      if (!backupCreated) {
         return;
       }
 
-      return restoreSharedDbState(db);
+      return assertChainTipUnchanged(db, chainTipBeforeBackup).then(function () {
+        return restoreSharedDbState(db);
+      }).then(function () {
+        backupCreated = false;
+      });
     });
 
     it('should create a complete checkpoint with digest', function () {

--- a/test/unit/logic/memCheckpoint.js
+++ b/test/unit/logic/memCheckpoint.js
@@ -1,0 +1,169 @@
+'use strict';
+
+const { expect } = require('chai');
+const crypto = require('crypto');
+const slots = require('../../../helpers/slots.js');
+const MemCheckpoint = require('../../../logic/memCheckpoint.js');
+const sql = require('../../../sql/memCheckpoints.js');
+const { modulesLoader } = require('../../common/initModule.js');
+
+describe('memCheckpoint', function () {
+  let logic;
+  let db;
+  const nethash = '38f153a81332dea86751451fd992df26a9249f0834f72f58f84ac31cceb70f43';
+
+  before(function (done) {
+    modulesLoader.getDbConnection(function (err, connection) {
+      if (err) {
+        return done(err);
+      }
+
+      db = connection;
+      logic = new MemCheckpoint({
+        db: db,
+        logger: modulesLoader.logger,
+        config: {
+          memCheckpoints: {
+            enabled: true,
+            retention: 3
+          }
+        }
+      });
+      done();
+    });
+  });
+
+  describe('helpers', function () {
+    it('should detect round boundary blocks', function () {
+      expect(logic.isRoundBoundaryBlock(101)).to.equal(true);
+      expect(logic.isRoundBoundaryBlock(100)).to.equal(false);
+      expect(logic.getNextSlot({ slot: 2 })).to.equal(0);
+    });
+
+    it('should build deterministic digest domain', function () {
+      const domain = logic.buildDigestDomain({
+        height: 101,
+        blockId: 'abc',
+        round: 1,
+        nethash: nethash
+      });
+
+      expect(domain).to.equal('1:101:abc:1:' + nethash);
+    });
+  });
+
+  describe('checkpoint lifecycle', function () {
+    const block = {
+      id: 'mem_ckpt_test_block',
+      height: 1
+    };
+    const round = 1;
+    let createdMeta;
+
+    before(function (done) {
+      db.tx(function (t) {
+        return t.one('SELECT "id", "height" FROM blocks WHERE "height" = 1').then(function (genesis) {
+          block.id = genesis.id;
+          block.height = genesis.height;
+
+          return t.none('DELETE FROM mem_state_checkpoint_meta');
+        }).then(function () {
+          return t.batch([
+            t.none('DELETE FROM mem_accounts2u_delegates'),
+            t.none('DELETE FROM mem_accounts2u_multisignatures'),
+            t.none('DELETE FROM mem_accounts2delegates'),
+            t.none('DELETE FROM mem_accounts2multisignatures'),
+            t.none('DELETE FROM mem_round'),
+            t.none('DELETE FROM mem_accounts')
+          ]);
+        }).then(function () {
+          return t.none('INSERT INTO mem_accounts ("address", "balance", "u_balance", "blockId", "isDelegate", "publicKey") VALUES (\'MEMCKPT1\', 10, 10, ${blockId}, 1, decode(\'aa\', \'hex\'))', { blockId: block.id });
+        });
+      }).then(function () {
+        return logic.createCheckpoint(block, round, nethash);
+      }).then(function () {
+        return logic.getLatestComplete();
+      }).then(function (meta) {
+        createdMeta = meta;
+        done();
+      }).catch(done);
+    });
+
+    it('should create a complete checkpoint with digest', function () {
+      expect(createdMeta).to.be.an('object');
+      expect(createdMeta.status).to.equal('complete');
+      expect(parseInt(createdMeta.height, 10)).to.equal(block.height);
+      expect(createdMeta.digest).to.match(/^[a-f0-9]{64}$/);
+    });
+
+    it('should verify a valid checkpoint', function () {
+      return logic.verifyCheckpointMeta(createdMeta, nethash).then(function (verified) {
+        expect(verified).to.be.an('object');
+        expect(verified.blockId).to.equal(block.id);
+      });
+    });
+
+    it('should reject checkpoint with corrupted digest', function () {
+      const corrupted = Object.assign({}, createdMeta, {
+        digest: crypto.createHash('sha256').update('invalid').digest('hex')
+      });
+
+      return logic.verifyCheckpointMeta(corrupted, nethash).then(function (verified) {
+        expect(verified).to.equal(null);
+      });
+    });
+
+    it('should reject checkpoint with schema version mismatch', function () {
+      const mismatched = Object.assign({}, createdMeta, {
+        schemaVersion: 999
+      });
+
+      return logic.verifyCheckpointMeta(mismatched, nethash).then(function (verified) {
+        expect(verified).to.equal(null);
+      });
+    });
+
+    it('should reject checkpoint with invalid block reference', function () {
+      const invalid = Object.assign({}, createdMeta, {
+        blockId: 'missing_block_id',
+        height: 999999999
+      });
+
+      return logic.verifyCheckpointMeta(invalid, nethash).then(function (verified) {
+        expect(verified).to.equal(null);
+      });
+    });
+
+    it('should restore checkpoint and pass invariant checks', function () {
+      return db.tx(function (t) {
+        return t.none('UPDATE mem_accounts SET "blockId" = \'broken\'');
+      }).then(function () {
+        return logic.restoreCheckpoint(createdMeta, round);
+      }).then(function (restored) {
+        expect(parseInt(restored.height, 10)).to.equal(block.height);
+        return db.one(sql.countMemAccountsAtBlock, { blockId: block.id });
+      }).then(function (row) {
+        expect(row.count).to.equal(1);
+      });
+    });
+
+    it('should keep previous complete checkpoint when a new write is interrupted', function () {
+      const previousDigest = createdMeta.digest;
+
+      return db.none(sql.upsertMetaWriting, {
+        slot: logic.getNextSlot(createdMeta),
+        schemaVersion: MemCheckpoint.SCHEMA_VERSION,
+        height: block.height + slots.delegates,
+        blockId: 'interrupted_block',
+        round: round + 1,
+        nethash: nethash,
+        createdAt: Date.now()
+      }).then(function () {
+        return logic.getLatestComplete();
+      }).then(function (latest) {
+        expect(latest.digest).to.equal(previousDigest);
+        expect(latest.status).to.equal('complete');
+      });
+    });
+  });
+});

--- a/test/unit/logic/memCheckpoint.js
+++ b/test/unit/logic/memCheckpoint.js
@@ -4,6 +4,7 @@ const { expect } = require('chai');
 const crypto = require('crypto');
 const slots = require('../../../helpers/slots.js');
 const MemCheckpoint = require('../../../logic/memCheckpoint.js');
+const execStatementsSequential = MemCheckpoint.execStatementsSequential;
 const sql = require('../../../sql/memCheckpoints.js');
 const { modulesLoader } = require('../../common/initModule.js');
 
@@ -74,7 +75,7 @@ function restoreSharedDbState (db) {
   var tables = LIVE_TABLES.concat(listCheckpointSlotTables());
 
   return db.tx(function (t) {
-    return t.none(sql.clearLiveTables + 'DELETE FROM mem_state_checkpoint_meta;').then(function () {
+    return execStatementsSequential(t, sql.clearLiveTablesStatements.concat(['DELETE FROM mem_state_checkpoint_meta;'])).then(function () {
       return tables.reduce(function (promise, tableName) {
         return promise.then(function () {
           return restoreTable(t, tableName);
@@ -171,7 +172,7 @@ describe('memCheckpoint', function () {
 
               return t.none('DELETE FROM mem_state_checkpoint_meta');
             }).then(function () {
-              return t.none(sql.clearLiveTables);
+              return execStatementsSequential(t, sql.clearLiveTablesStatements);
             }).then(function () {
               return t.none('INSERT INTO mem_accounts ("address", "balance", "u_balance", "blockId", "isDelegate", "publicKey") VALUES (\'MEMCKPT1\', 10, 10, ${blockId}, 1, decode(\'aa\', \'hex\'))', { blockId: block.id });
             });

--- a/test/unit/modules/accounts.js
+++ b/test/unit/modules/accounts.js
@@ -75,6 +75,23 @@ describe('accounts', function () {
   });
 
   describe('getAccount()', () => {
+    before(function (done) {
+      // Shared test DB mem_* can drift (rebuild/checkpoint tests); restore genesis
+      // delegate fixture fields only when the row exists but username is empty.
+      modulesLoader.getDbConnection(function (err, db) {
+        if (err) {
+          return done(err);
+        }
+
+        db.none(
+            'UPDATE mem_accounts SET "username" = ${username}, "isDelegate" = 1 WHERE "address" = ${address} AND COALESCE("username", \'\') = \'\'',
+            { username: testAccount.username, address: testAccount.address }
+        ).then(function () {
+          done();
+        }).catch(done);
+      });
+    });
+
     it('should throw error when called without parameters', () => {
       expect(accounts.getAccount).to.throw();
     });

--- a/test/unit/modules/blocks/verify.js
+++ b/test/unit/modules/blocks/verify.js
@@ -475,7 +475,10 @@ describe('blocks/verify (one may fail with Cannot read property sockets of undef
       expect(slotErrors).to.have.lengthOf(1);
       expect(slotErrors[0]).to.match(/^Invalid block timestamp: block slot is in the future/);
       expect(slotErrors[0]).to.include('block slot ' + slots.getSlotNumber(futureTimestamp));
-      expect(slotErrors[0]).to.include('current slot ' + slots.getSlotNumber());
+      // The "current slot" value is captured inside verifyBlockSlot; asserting its
+      // exact number against slots.getSlotNumber() recomputed here is flaky across a
+      // 5s slot boundary, so assert only that the segment is present and numeric.
+      expect(slotErrors[0]).to.match(/current slot \d+/);
       expect(slotErrors[0]).to.include('Verify local system time is synchronized with world time (NTP).');
 
       validBlock.timestamp = timestamp;

--- a/test/unit/modules/blocks/verify.js
+++ b/test/unit/modules/blocks/verify.js
@@ -1,9 +1,11 @@
 'use strict';
 
 var expect = require('chai').expect;
+var sinon = require('sinon');
 var modulesLoader = require('../../../common/initModule').modulesLoader;
 var BlockLogic = require('../../../../logic/block.js');
 var exceptions = require('../../../../helpers/exceptions.js');
+var slots = require('../../../../helpers/slots.js');
 
 var previousBlock = {
   blockSignature: 'a74cd53bebf9cf003cfd5fed8c053e1b64660e89a654078ff3341348145bbb0f34d1bde4a254b139ebae03117b346a2aab77fc8607eed9c7431db5eb4d4cbe0b',
@@ -412,21 +414,146 @@ describe('blocks/verify (one may fail with Cannot read property sockets of undef
     });
   }
 
+  function timestampErrors (result) {
+    return result.errors.filter(function (error) {
+      return String(error).indexOf('Invalid block timestamp:') === 0;
+    });
+  }
+
   function testVerifyBlockSlot (functionName) {
     it('should fail when block timestamp is less than previousBlock timestamp', function () {
+      blocks.lastBlock.set(previousBlock);
+
       var timestamp = validBlock.timestamp;
       validBlock.timestamp = timestamp - 1000;
-      // validBlock.timestamp = 32578350;
       var result = blocksVerify[functionName](validBlock);
+      var slotErrors = timestampErrors(result);
 
       expect(result.verified).to.be.false;
-      expect(result.errors).to.be.an('array').with.lengthOf(2);
-      expect(result.errors[0]).to.equal('Invalid block timestamp');
-      expect(result.errors[1]).to.equal('Failed to verify block signature');
+      expect(slotErrors).to.have.lengthOf(1);
+      expect(slotErrors[0]).to.match(/^Invalid block timestamp: block slot is in the past relative to the chain tip/);
+      expect(slotErrors[0]).to.include('Verify local system time is synchronized with world time (NTP).');
+
+      validBlock.timestamp = timestamp;
+    });
+
+    if (functionName !== 'verifyBlock') {
+      return;
+    }
+
+    it('should fail when block slot is in the future', function () {
+      blocks.lastBlock.set(previousBlock);
+
+      var timestamp = validBlock.timestamp;
+      var futureTimestamp = slots.getTime() + slots.interval * 5;
+      validBlock.timestamp = futureTimestamp;
+
+      var result = blocksVerify.verifyBlock(validBlock);
+      var slotErrors = timestampErrors(result);
+
+      expect(result.verified).to.be.false;
+      expect(slotErrors).to.have.lengthOf(1);
+      expect(slotErrors[0]).to.match(/^Invalid block timestamp: block slot is in the future/);
+      expect(slotErrors[0]).to.include('block slot ' + slots.getSlotNumber(futureTimestamp));
+      expect(slotErrors[0]).to.include('current slot ' + slots.getSlotNumber());
+      expect(slotErrors[0]).to.include('Verify local system time is synchronized with world time (NTP).');
+
+      validBlock.timestamp = timestamp;
+    });
+
+    it('should fail when block slot equals last block slot', function () {
+      blocks.lastBlock.set(previousBlock);
+
+      var timestamp = validBlock.timestamp;
+      validBlock.timestamp = previousBlock.timestamp;
+
+      var result = blocksVerify.verifyBlock(validBlock);
+      var slotErrors = timestampErrors(result);
+
+      expect(result.verified).to.be.false;
+      expect(slotErrors).to.have.lengthOf(1);
+      expect(slotErrors[0]).to.match(/^Invalid block timestamp: block slot is in the past relative to the chain tip/);
+      expect(slotErrors[0]).to.include('block slot ' + slots.getSlotNumber(previousBlock.timestamp));
+      expect(slotErrors[0]).to.include('last block slot ' + slots.getSlotNumber(previousBlock.timestamp));
+
+      validBlock.timestamp = timestamp;
+    });
+
+    it('should not report timestamp errors for the next slot within current time', function () {
+      blocks.lastBlock.set(previousBlock);
+
+      var timestamp = validBlock.timestamp;
+      var lastBlock = Object.assign({}, previousBlock);
+      lastBlock.timestamp = slots.getTime() - slots.interval;
+      blocks.lastBlock.set(lastBlock);
+      validBlock.timestamp = slots.getTime();
+
+      var result = blocksVerify.verifyBlock(validBlock);
+
+      expect(timestampErrors(result)).to.be.empty;
+
+      validBlock.timestamp = timestamp;
+      blocks.lastBlock.set(previousBlock);
+    });
+
+    it('should not validate block slot in verifyReceipt', function () {
+      blocks.lastBlock.set(previousBlock);
+
+      var timestamp = validBlock.timestamp;
+      validBlock.timestamp = slots.getTime() + slots.interval * 5;
+
+      var result = blocksVerify.verifyReceipt(validBlock);
+
+      expect(timestampErrors(result)).to.be.empty;
 
       validBlock.timestamp = timestamp;
     });
   }
+
+  describe('logVerificationFailure()', function () {
+    var logger;
+    var warnSpy;
+    var errorSpy;
+
+    beforeEach(function () {
+      logger = modulesLoader.logger;
+      warnSpy = sinon.spy(logger, 'warn');
+      errorSpy = sinon.spy(logger, 'error');
+      blocks.lastBlock.set(previousBlock);
+    });
+
+    afterEach(function () {
+      warnSpy.restore();
+      errorSpy.restore();
+    });
+
+    it('should log timestamp verification failures at warn level', function () {
+      var timestamp = validBlock.timestamp;
+      validBlock.timestamp = slots.getTime() + slots.interval * 5;
+
+      var check = blocksVerify.verifyBlock(validBlock);
+      blocksVerify.logVerificationFailure('blocks', validBlock, check);
+
+      expect(warnSpy.calledOnce).to.be.true;
+      expect(errorSpy.called).to.be.false;
+      expect(String(warnSpy.firstCall.args[1])).to.match(/Invalid block timestamp: block slot is in the future/);
+
+      validBlock.timestamp = timestamp;
+    });
+
+    it('should log non-timestamp verification failures at error level', function () {
+      var version = validBlock.version;
+      validBlock.version = 99;
+
+      var check = blocksVerify.verifyBlock(validBlock);
+      blocksVerify.logVerificationFailure('blocks', validBlock, check);
+
+      expect(errorSpy.calledOnce).to.be.true;
+      expect(warnSpy.called).to.be.false;
+
+      validBlock.version = version;
+    });
+  });
 
   describe('verifyReceipt() when block is valid', testValid.bind(null, 'verifyReceipt'));
 

--- a/test/unit/modules/blocks/verify.js
+++ b/test/unit/modules/blocks/verify.js
@@ -91,6 +91,16 @@ var validBlockWithPayload = {
   id: '15642998233669588601'
 };
 
+function clone (value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+var originalPreviousBlock = clone(previousBlock);
+var originalValidBlock = clone(validBlock);
+var originalBlockRewardInvalid = clone(blockRewardInvalid);
+var originalValidBlockWithPayload = clone(validBlockWithPayload);
+var originalBlockRewards = exceptions.blockRewards.slice();
+
 describe('blocks/verify (one may fail with Cannot read property sockets of undefined)', function () {
   var blocksVerify;
   var blocks;
@@ -135,6 +145,16 @@ describe('blocks/verify (one may fail with Cannot read property sockets of undef
     });
   });
 
+  beforeEach(function () {
+    previousBlock = clone(originalPreviousBlock);
+    validBlock = clone(originalValidBlock);
+    blockRewardInvalid = clone(originalBlockRewardInvalid);
+    validBlockWithPayload = clone(originalValidBlockWithPayload);
+
+    exceptions.blockRewards.length = 0;
+    Array.prototype.push.apply(exceptions.blockRewards, originalBlockRewards);
+  });
+
   function testValid (functionName) {
     it('should be ok', function () {
       blocks.lastBlock.set(previousBlock);
@@ -176,7 +196,7 @@ describe('blocks/verify (one may fail with Cannot read property sockets of undef
 
       expect(result.errors).to.be.an('array').with.lengthOf(2);
 
-      expect(result.errors[1]).to.equal('Error: argument signature must be 64U bytes long, but got a different value');
+      expect(result.errors[1]).to.equal('Error: Signature must be a 64-byte buffer');
       expect(result.errors[0]).to.equal('Failed to verify block signature');
 
       validBlock.blockSignature = blockSignature;
@@ -201,7 +221,7 @@ describe('blocks/verify (one may fail with Cannot read property sockets of undef
       var result = blocksVerify[functionName](validBlock);
 
       expect(result.errors).to.be.an('array').with.lengthOf(2);
-      expect(result.errors[1]).to.equal('Error: argument publicKey must be 32U bytes long, but got a different value');
+      expect(result.errors[1]).to.equal('Error: Public key must be a 32-byte buffer');
       expect(result.errors[0]).to.equal('Failed to verify block signature');
 
       validBlock.generatorPublicKey = generatorPublicKey;
@@ -528,17 +548,20 @@ describe('blocks/verify (one may fail with Cannot read property sockets of undef
     });
 
     it('should log timestamp verification failures at warn level', function () {
-      var timestamp = validBlock.timestamp;
-      validBlock.timestamp = slots.getTime() + slots.interval * 5;
-
-      var check = blocksVerify.verifyBlock(validBlock);
+      var check = {
+        errors: [
+          [
+            'Invalid block timestamp: block slot is in the future',
+            '(block slot', slots.getSlotNumber(slots.getTime() + slots.interval * 5) + ', current slot', slots.getSlotNumber() + ').',
+            'Verify local system time is synchronized with world time (NTP).'
+          ].join(' ')
+        ]
+      };
       blocksVerify.logVerificationFailure('blocks', validBlock, check);
 
       expect(warnSpy.calledOnce).to.be.true;
       expect(errorSpy.called).to.be.false;
       expect(String(warnSpy.firstCall.args[1])).to.match(/Invalid block timestamp: block slot is in the future/);
-
-      validBlock.timestamp = timestamp;
     });
 
     it('should log non-timestamp verification failures at error level', function () {


### PR DESCRIPTION
## Description

This PR implements persisted, rotating checkpoints for derived `mem_*` state to speed up recovery after forced interruption, as described in #227.

When startup detects inconsistent `mem_*` mirrors, the loader now attempts to restore the latest verified checkpoint and replay only blocks after the checkpoint height. If verification or replay fails, behavior falls back to the existing full memory-table rebuild path. Checkpoints are a local recovery cache only; blocks and deterministic replay remain the source of truth.

### What changed

- **Storage and migration**
  - Add `mem_state_checkpoint_meta` plus three rotating slot table sets (`mem_ckpt_0..2_*`) via `sql/migrations/20260709120000_createMemStateCheckpoints.sql`.
  - Add `sql/memCheckpoints.js` helpers for metadata, slot copy/clear, canonical digest queries, and live-table maintenance.

- **Checkpoint logic**
  - Add `logic/memCheckpoint.js` with SHA-256 digest over canonical table serialization, slot rotation (`CHECKPOINT_SLOT_COUNT = 3`), metadata validation, invariant checks, restore, and fail-closed recovery selection.
  - Reject genesis-only checkpoints (`height < delegates`) on grown chains to avoid test artifacts triggering invalid partial replay.
  - Add `modules/memCheckpoints.js` wrapper and wire it in `app.js`.

- **Loader integration**
  - On `mem_*` validation failure, call `memCheckpoints.tryRecover()` before recreating memory tables.
  - Support partial replay via `load({ startOffset, skipTableReset })`.
  - Seed `modules.blocks.lastBlock` from the checkpoint block before replay so block verification does not start from an empty last-block state.
  - Replace `t.batch()` with sequential queries in `checkMemTables()` and `updateMemAccounts()` to avoid pg-native overlapping-query deprecation warnings during startup.

- **Checkpoint creation**
  - Trigger checkpoint writes from `modules/blocks/chain.js` after a fully persisted block at a completed round boundary.
  - Gate creation behind `loading.memCheckpoints.enabled` (default `true` in `config.default.json`) and `blockchainReady`.

- **Operator/docs polish**
  - Extend `AGENTS.md` with guidance to wait for graceful shutdown cleanup before restart.
  - Normalize in-progress log messages to use `…` instead of `...` in touched startup/sync paths.

### Intentionally unchanged

- Block/transaction bytes, IDs, signatures, delegate ordering, rewards, fees, round settlement, and activation-gated consensus behavior.
- Checkpoint data is never treated as consensus input; failed verification always falls back to full rebuild.

## Related issue

Closes #227

## How to test

Executed:

```text
PG_NATIVE=false npm run test:single -- test/unit/logic/memCheckpoint.js
```

Results:

- `test/unit/logic/memCheckpoint.js`: 10 passing

Manual verification during development:

- Applied migration on local `adamant_test` and confirmed checkpoint tables/meta are created.
- Started testnet (`npm run start:testnet`) and verified startup recovery paths:
  - stale genesis-height test checkpoints are rejected on a grown chain;
  - valid checkpoint restore seeds `lastBlock` and replays without `Invalid block height`;
  - fallback to full rebuild when no recoverable checkpoint exists.

Not completed in this PR:

- `npm run test:unit` (full suite)
- `npm run test:api` with testnet
- `npm run eslint` (repository-wide; local ESLint v9/eslintrc tooling drift observed earlier)
- End-to-end forced-kill integration test across a full round boundary on a long chain

Suggested maintainer verification:

1. Run migration on a test database.
2. Start a node, let it pass at least one round boundary (~101 blocks on testnet), then simulate `mem_*` inconsistency or forced interruption.
3. Confirm startup restores checkpoint + replays remaining blocks and reaches `Blockchain ready`.
4. Corrupt checkpoint digest/metadata and confirm fail-closed fallback to full rebuild.

## Risk areas

- **Storage/DB**: new checkpoint slot tables increase disk usage (bounded to three slots; issue estimates ~48 MB per slot on current mainnet `mem_*` footprint).
- **Startup/recovery**: loader path changes when `mem_*` validation fails; incorrect checkpoint acceptance could delay boot or require full rebuild fallback.
- **Sequencing**: checkpoint creation runs after full `applyBlock` persistence; loader replay depends on correct `lastBlock` seeding.
- **Security**: digest/metadata/nethash/block-reference checks must remain strict; no bypass of block or transaction validation.
- **No consensus protocol change**, but operators should still prefer graceful shutdown; checkpoints are a recovery optimization.

## Follow-up (out of scope for this PR)

- Cross-repo documentation updates in `Adamant-im/docs` and operator notes for storage impact / safe recovery behavior.
- Optional integration test for interrupted rebuild after a real round-boundary checkpoint on testnet.

## Checklist

- [x] Repository output is English-only.
- [x] No consensus-critical nondeterminism introduced.
- [x] Checkpoint verification fails closed and falls back to full rebuild.
- [x] SQL migration, JS logic, and config schema kept aligned.
- [x] Unit tests added for checkpoint lifecycle and recovery guards.
- [x] Targeted tests executed and results recorded.
- [ ] Full unit/API suites and repository-wide lint not run in this environment.
