### PR TITLE
Fix: Optimize blocks API queries

### DIFF
--- a/modules/blocks/api.js
+++ b/modules/blocks/api.js
@@ -97,8 +97,7 @@ __private.list = function (filter, cb) {
     params.generatorPublicKey = filter.generatorPublicKey;
   }
 
-  // FIXME: Useless condition
-  if (filter.numberOfTransactions) {
+  if (filter.numberOfTransactions >= 0) {
     where.push('"b_numberOfTransactions" = ${numberOfTransactions}');
     params.numberOfTransactions = filter.numberOfTransactions;
   }

--- a/schema/blocks.js
+++ b/schema/blocks.js
@@ -40,6 +40,10 @@ module.exports = {
         type: 'string',
         format: 'publicKey'
       },
+      numberOfTransactions: {
+        type: 'integer',
+        minimum: 0
+      },
       totalAmount: {
         type: 'integer',
         minimum: 0,

--- a/sql/migrations/20260714120000_createBlocksGeneratorPublicKeyHeightIndex.sql
+++ b/sql/migrations/20260714120000_createBlocksGeneratorPublicKeyHeightIndex.sql
@@ -1,0 +1,12 @@
+/*
+ * Support generatorPublicKey filtering together with the default height order.
+ */
+
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS "blocks_generator_public_key_height"
+ON "blocks" ("text_generatorPublicKey", "height" DESC);
+
+DROP INDEX IF EXISTS "blocks_b_generator_public_key";
+
+COMMIT;

--- a/test/api/blocks.js
+++ b/test/api/blocks.js
@@ -8,6 +8,9 @@ var block = {
   blockHeight: 0,
   id: 0,
   generatorPublicKey: '',
+  numberOfTransactions: 0,
+  previousBlock: '',
+  reward: 0,
   totalAmount: 0,
   totalFee: 0
 };
@@ -248,6 +251,9 @@ describe('GET /blocks', function () {
       node.expect(res.body.blocks[0].height).to.equal(block.blockHeight);
       block.id = res.body.blocks[0].id;
       block.generatorPublicKey = res.body.blocks[0].generatorPublicKey;
+      block.numberOfTransactions = res.body.blocks[0].numberOfTransactions;
+      block.previousBlock = res.body.blocks[0].previousBlock;
+      block.reward = res.body.blocks[0].reward;
       block.totalAmount = res.body.blocks[0].totalAmount;
       block.totalFee = res.body.blocks[0].totalFee;
       done();
@@ -271,10 +277,6 @@ describe('GET /blocks', function () {
       node.expect(res.body.blocks[0]).to.have.property('blockSignature');
       node.expect(res.body.blocks[0]).to.have.property('numberOfTransactions');
       node.expect(res.body.blocks[0].height).to.equal(10);
-      block.id = res.body.blocks[0].id;
-      block.generatorPublicKey = res.body.blocks[0].generatorPublicKey;
-      block.totalAmount = res.body.blocks[0].totalAmount;
-      block.totalFee = res.body.blocks[0].totalFee;
       done();
     });
   });
@@ -286,6 +288,25 @@ describe('GET /blocks', function () {
       for (var i = 0; i < res.body.blocks.length; i++) {
         node.expect(res.body.blocks[i].generatorPublicKey).to.equal(block.generatorPublicKey);
       }
+      done();
+    });
+  });
+
+  it('using an unknown generatorPublicKey should return an empty list', function (done) {
+    const unknownPublicKey = 'aa11111111111111111111111111111111111111111111111111111111111111';
+
+    getBlocks(`generatorPublicKey=${unknownPublicKey}&orderBy=height:desc&limit=1`, function (err, res) {
+      node.expect(res.body).to.have.property('success').to.be.true;
+      node.expect(res.body).to.have.property('blocks').that.eql([]);
+      done();
+    });
+  });
+
+  it('using numberOfTransactions == 0 should be ok', function (done) {
+    getBlocks('numberOfTransactions=0&orderBy=height:asc&limit=1', function (err, res) {
+      node.expect(res.body).to.have.property('success').to.be.true;
+      node.expect(res.body).to.have.property('blocks').that.is.an('array').and.is.not.empty;
+      node.expect(res.body.blocks[0].numberOfTransactions).to.equal(0);
       done();
     });
   });
@@ -312,21 +333,58 @@ describe('GET /blocks', function () {
     });
   });
 
+  it('using reward should be ok', function (done) {
+    getBlocks('reward=' + block.reward, function (err, res) {
+      node.expect(res.body).to.have.property('success').to.be.true;
+      node.expect(res.body).to.have.property('blocks').that.is.an('array');
+      for (var i = 0; i < res.body.blocks.length; i++) {
+        node.expect(res.body.blocks[i].reward).to.equal(block.reward);
+      }
+      done();
+    });
+  });
+
+  it('using limit and offset should be ok', function (done) {
+    getBlocks('orderBy=height:asc&limit=2&offset=1', function (err, res) {
+      node.expect(res.body).to.have.property('success').to.be.true;
+      node.expect(res.body).to.have.property('blocks').that.has.length(2);
+      node.expect(res.body.blocks[0].height).to.equal(2);
+      node.expect(res.body.blocks[1].height).to.equal(3);
+      done();
+    });
+  });
+
+  it('using all equality filters together should be ok', function (done) {
+    const params = [
+      `generatorPublicKey=${block.generatorPublicKey}`,
+      `numberOfTransactions=${block.numberOfTransactions}`,
+      `previousBlock=${block.previousBlock}`,
+      `height=${block.blockHeight}`,
+      `totalAmount=${block.totalAmount}`,
+      `totalFee=${block.totalFee}`,
+      `reward=${block.reward}`
+    ].join('&');
+
+    getBlocks(params, function (err, res) {
+      node.expect(res.body).to.have.property('success').to.be.true;
+      node.expect(res.body).to.have.property('blocks').that.has.length(1);
+      node.expect(res.body.blocks[0].id).to.equal(block.id);
+      done();
+    });
+  });
+
   it('using previousBlock should be ok', function (done) {
-    if (block.id === null) {
+    if (!block.previousBlock) {
       return this.skip();
     }
 
-    var previousBlock = block.id;
-
-    node.onNewBlock(function (err) {
-      getBlocks('previousBlock=' + block.id, function (err, res) {
-        node.expect(res.body).to.have.property('success').to.be.true;
-        node.expect(res.body).to.have.property('blocks').that.is.an('array');
-        node.expect(res.body.blocks).to.have.length(1);
-        node.expect(res.body.blocks[0].previousBlock).to.equal(previousBlock);
-        done();
-      });
+    getBlocks('previousBlock=' + block.previousBlock, function (err, res) {
+      node.expect(res.body).to.have.property('success').to.be.true;
+      node.expect(res.body).to.have.property('blocks').that.is.an('array');
+      node.expect(res.body.blocks).to.have.length(1);
+      node.expect(res.body.blocks[0].id).to.equal(block.id);
+      node.expect(res.body.blocks[0].previousBlock).to.equal(block.previousBlock);
+      done();
     });
   });
 

--- a/test/unit/modules/blocks.api.js
+++ b/test/unit/modules/blocks.api.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const { expect } = require('chai');
+const sinon = require('sinon');
+
+const API = require('../../../modules/blocks/api.js');
+const z_schema = require('../../../helpers/z_schema.js');
+
+describe('blocks API', function () {
+  let api;
+  let db;
+
+  beforeEach(function () {
+    db = {
+      query: sinon.stub().resolves([])
+    };
+
+    api = new API(
+        { trace: sinon.spy(), error: sinon.spy() },
+        db,
+        { dbRead: sinon.spy((row) => row) },
+        new z_schema(),
+        { add: function (task, cb) { task(cb); } }
+    );
+
+    api.onBind({
+      blocks: { lastBlock: { get: function () { return { height: 1 }; } } },
+      system: {}
+    });
+  });
+
+  it('applies numberOfTransactions when it is zero', function (done) {
+    api.getBlocks({ body: { numberOfTransactions: 0 } }, function (err, data) {
+      expect(err).to.not.exist;
+      expect(data.blocks).to.eql([]);
+      expect(db.query.calledOnce).to.equal(true);
+
+      const [query, params] = db.query.firstCall.args;
+      expect(query).to.include('"b_numberOfTransactions" = ${numberOfTransactions}');
+      expect(params.numberOfTransactions).to.equal(0);
+      done();
+    });
+  });
+
+  it('rejects a negative numberOfTransactions', function (done) {
+    api.getBlocks({ body: { numberOfTransactions: -1 } }, function (err) {
+      expect(err).to.equal('Value -1 is less than minimum 0');
+      expect(db.query.called).to.equal(false);
+      done();
+    });
+  });
+
+  [
+    'id',
+    'timestamp',
+    'height',
+    'previousBlock',
+    'totalAmount',
+    'totalFee',
+    'reward',
+    'numberOfTransactions',
+    'generatorPublicKey'
+  ].forEach(function (field) {
+    it(`orders by ${field}`, function (done) {
+      api.getBlocks({ body: { orderBy: `${field}:desc` } }, function (err) {
+        expect(err).to.not.exist;
+        expect(db.query.calledOnce).to.equal(true);
+        expect(db.query.firstCall.args[0]).to.include(`ORDER BY \"b_${field}\" DESC`);
+        done();
+      });
+    });
+  });
+});

--- a/test/unit/sql/blocks.js
+++ b/test/unit/sql/blocks.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const { expect } = require('chai');
+
+const { modulesLoader } = require('../../common/initModule.js');
+
+describe('blocks SQL indexes', function () {
+  let db;
+
+  before(function (done) {
+    modulesLoader.getDbConnection(function (err, connection) {
+      db = connection;
+      done(err);
+    });
+  });
+
+  it('indexes generatorPublicKey together with height using btree', async function () {
+    const rows = await db.query([
+      'SELECT am.amname AS method, pg_get_indexdef(i.indexrelid) AS definition',
+      'FROM pg_index i',
+      'JOIN pg_class c ON c.oid = i.indexrelid',
+      'JOIN pg_am am ON am.oid = c.relam',
+      'WHERE c.relname = \'blocks_generator_public_key_height\''
+    ].join(' '));
+
+    expect(rows).to.have.length(1);
+    expect(rows[0].method).to.equal('btree');
+    expect(rows[0].definition).to.include('(\"text_generatorPublicKey\", height DESC)');
+  });
+
+  it('removes the obsolete generatorPublicKey hash index', async function () {
+    const rows = await db.query([
+      'SELECT 1',
+      'FROM pg_class',
+      'WHERE relname = \'blocks_b_generator_public_key\''
+    ].join(' '));
+
+    expect(rows).to.eql([]);
+  });
+});


### PR DESCRIPTION
## Description

Prevent `GET /api/blocks` from scanning the blocks table when a syntactically valid but unknown `generatorPublicKey` is combined with the default `height:desc` ordering.

The previous hash index could filter by generator but could not satisfy the ordering. PostgreSQL could therefore choose a backward scan of the height index and filter every block when the generator had no matches. This PR replaces it with a composite B-tree index on `(text_generatorPublicKey, height DESC)` and drops the obsolete hash index after the new index is created.

The blocks query audit also found that `numberOfTransactions=0` was ignored because the filter used a truthiness check. The filter and request schema now handle zero correctly.

Tests cover unknown generators, every supported equality filter, pagination, every allowed `orderBy` field, the zero-transaction edge case, and the resulting SQL index definitions.

## Related issue

Closes #258

## External links (optional)

- Related anti-abuse hardening: #218
- Documentation issue: https://github.com/Adamant-im/docs/issues/32
- Documentation PR: https://github.com/Adamant-im/docs/pull/33
- Schema issue: https://github.com/Adamant-im/adamant-schema/issues/45
- Schema PR: https://github.com/Adamant-im/adamant-schema/pull/46

## Screenshots or videos (optional)

Not applicable.

## Breaking changes

No API or consensus-breaking changes. The response contract remains unchanged.

The first startup after upgrading must build the new B-tree index. On mainnet databases with tens of millions of blocks, operators should allow additional migration time and disk space.

## How to test

1. Apply migrations to a PostgreSQL database containing blocks.
2. Request an unknown but valid generator key:

   ```sh
   curl 'http://localhost:36666/api/blocks?generatorPublicKey=aa11111111111111111111111111111111111111111111111111111111111111&orderBy=height:desc&limit=1'
   ```

3. Verify the response contains an empty `blocks` array without a timeout.
4. Run:

   ```sh
   PG_NATIVE=false npm run test:single -- test/unit/modules/blocks.api.js test/unit/sql/blocks.js
   PG_NATIVE=false npm run test:unit:fast
   npx eslint modules/blocks/api.js schema/blocks.js test/api/blocks.js test/unit/modules/blocks.api.js test/unit/sql/blocks.js
   git diff --check
   ```

Local validation results:

- Targeted unit and SQL tests: 13 passing.
- Fast unit suite: 918 passing.
- ESLint for touched JavaScript files: passed.
- `git diff --check`: passed.
- On a local 427,709-row blocks table, the unknown-generator query improved from approximately 9.48 seconds to 8.45 milliseconds.

The full blocks API suite was not completed because the local testnet began a long catch-up sync and serialized API access behind `dbSequence`. The node was stopped through the graceful shutdown path.

## Notes for reviewers

- The migration creates the composite index before removing the old hash index, inside one transaction.
- Existing indexes cover the remaining equality filters and sortable block fields.
- `count` is intentionally not restored to the `/api/blocks` response; it is absent from the current documented API contract and was previously removed for performance reasons.
- Consensus, block serialization, validation, and replay behavior are unchanged.

## Checklist

- [x] Code is formatted
- [x] Tests added/updated (if needed)
- [x] Documentation reviewed; companion updates submitted separately
- [x] Changes tested in all relevant local environments available for this change
