### PR TITLE
Feat: Add client WebSocket block and balance events

### DIFF
--- a/app.js
+++ b/app.js
@@ -490,7 +490,7 @@ d.run(function () {
      * at least will contain the required elements.
      * @param {Function} cb - Callback function.
      */
-    logic: ['db', 'bus', 'schema', 'genesisblock', function (scope, cb) {
+    logic: ['db', 'bus', 'schema', 'genesisblock', 'clientWs', function (scope, cb) {
       var Transaction = require('./logic/transaction.js');
       var Chat = require('./logic/chat.js');
       var State = require('./logic/state.js');
@@ -532,8 +532,8 @@ d.run(function () {
           logger.info('consensus', 'Configured activation heights', consensus.activationHeights);
           cb(null, consensus);
         },
-        account: ['db', 'bus', 'ed', 'schema', 'genesisblock', 'logger', function (scope, cb) {
-          new Account(scope.db, scope.schema, scope.logger, cb);
+        account: ['db', 'bus', 'ed', 'schema', 'genesisblock', 'logger', 'clientWs', function (scope, cb) {
+          new Account(scope.db, scope.schema, scope.logger, scope.clientWs, cb);
         }],
         transaction: ['db', 'bus', 'ed', 'schema', 'genesisblock', 'account', 'logger', 'clientWs', 'consensus', function (scope, cb) {
           new Transaction(scope.db, scope.ed, scope.schema, scope.genesisblock, scope.account, scope.logger, scope.clientWs, scope.consensus, cb);

--- a/logic/account.js
+++ b/logic/account.js
@@ -986,7 +986,11 @@ Account.prototype.merge = function (address, diff, cb) {
       return Object.prototype.hasOwnProperty.call(update, field);
     });
 
-    if (changedBalanceFields.length && account.scope.clientWs) {
+    if (
+      changedBalanceFields.length &&
+      account.scope.clientWs &&
+      typeof account.scope.clientWs.emitBalanceChange === 'function'
+    ) {
       try {
         account.scope.clientWs.emitBalanceChange(
             address,

--- a/logic/account.js
+++ b/logic/account.js
@@ -22,13 +22,20 @@ var self, library, __private = {};
  * @param {Database} db
  * @param {ZSchema} schema
  * @param {object} logger
+ * @param {ClientWs} [clientWs] - Optional client WebSocket event publisher.
  * @param {function} cb - Callback function.
  * @return {setImmediateCallback} With `this` as data.
  */
-function Account (db, schema, logger, cb) {
+function Account (db, schema, logger, clientWs, cb) {
+  if (typeof clientWs === 'function') {
+    cb = clientWs;
+    clientWs = null;
+  }
+
   this.scope = {
     db: db,
-    schema: schema
+    schema: schema,
+    clientWs: clientWs
   };
 
   self = this;
@@ -750,6 +757,7 @@ Account.prototype.set = function (address, rawFields, cb) {
  */
 Account.prototype.merge = function (address, diff, cb) {
   var update = {}, remove = {}, insert = {}, insert_object = {}, remove_object = {}, round = [];
+  var account = this;
 
   // Verify public key
   this.verifyPublicKey(diff.publicKey);
@@ -974,6 +982,26 @@ Account.prototype.merge = function (address, diff, cb) {
   }
 
   this.scope.db.none(queries).then(function () {
+    const changedBalanceFields = ['balance', 'u_balance'].filter(function (field) {
+      return Object.prototype.hasOwnProperty.call(update, field);
+    });
+
+    if (changedBalanceFields.length && account.scope.clientWs) {
+      try {
+        account.scope.clientWs.emitBalanceChange(
+            address,
+            changedBalanceFields,
+            account.get.bind(account, { address: address }, ['address', 'balance', 'u_balance'])
+        );
+      } catch (err) {
+        library.logger.debug(
+            'ws-client-server',
+            `Unable to publish balance change for ${address}: ${err?.message || err}`,
+            err?.stack
+        );
+      }
+    }
+
     return done();
   }).catch(function (err) {
     library.logger.error('account', `An error occurred while trying to merge account data: ${err?.message || err}`, err.stack);

--- a/modules/blocks.js
+++ b/modules/blocks.js
@@ -52,7 +52,7 @@ function Blocks (cb, scope) {
     ),
     chain: new blocksChain(
         scope.logger, scope.logic.block, scope.logic.transaction, scope.db,
-        scope.genesisblock, scope.bus, scope.balancesSequence
+        scope.genesisblock, scope.bus, scope.balancesSequence, scope.clientWs
     )
   };
 

--- a/modules/blocks/chain.js
+++ b/modules/blocks/chain.js
@@ -340,7 +340,8 @@ Chain.prototype.applyBlock = function (block, broadcast, cb, saveBlock) {
   var balanceBatchStarted = false;
   if (
     library.clientWs &&
-    typeof library.clientWs.beginBalanceBatch === 'function'
+    typeof library.clientWs.beginBalanceBatch === 'function' &&
+    typeof library.clientWs.endBalanceBatch === 'function'
   ) {
     try {
       library.clientWs.beginBalanceBatch();
@@ -500,7 +501,7 @@ Chain.prototype.applyBlock = function (block, broadcast, cb, saveBlock) {
     function finalize (err) {
       if (balanceBatchStarted) {
         try {
-          library.clientWs.endBalanceBatch();
+          library.clientWs.endBalanceBatch(!err && Boolean(saveBlock));
         } catch (batchErr) {
           library.logger.debug(
               'ws-client-server',
@@ -510,7 +511,12 @@ Chain.prototype.applyBlock = function (block, broadcast, cb, saveBlock) {
         }
       }
 
-      if (!err && saveBlock && library.clientWs) {
+      if (
+        !err &&
+        saveBlock &&
+        library.clientWs &&
+        typeof library.clientWs.emitBlock === 'function'
+      ) {
         try {
           library.clientWs.emitBlock(block);
         } catch (emitErr) {
@@ -657,7 +663,8 @@ Chain.prototype.deleteLastBlock = function (cb) {
   var balanceBatchStarted = false;
   if (
     library.clientWs &&
-    typeof library.clientWs.beginBalanceBatch === 'function'
+    typeof library.clientWs.beginBalanceBatch === 'function' &&
+    typeof library.clientWs.endBalanceBatch === 'function'
   ) {
     try {
       library.clientWs.beginBalanceBatch();
@@ -675,7 +682,7 @@ Chain.prototype.deleteLastBlock = function (cb) {
   __private.popLastBlock(lastBlock, function (err, newLastBlock) {
     if (balanceBatchStarted) {
       try {
-        library.clientWs.endBalanceBatch();
+        library.clientWs.endBalanceBatch(!err);
       } catch (batchErr) {
         library.logger.debug(
             'ws-client-server',

--- a/modules/blocks/chain.js
+++ b/modules/blocks/chain.js
@@ -22,14 +22,16 @@ var modules, library, self, __private = {};
  * @param {object} genesisblock
  * @param {bus} bus
  * @param {Sequence} balancesSequence
+ * @param {ClientWs} clientWs - Client WebSocket event publisher
  */
-function Chain (logger, block, transaction, db, genesisblock, bus, balancesSequence) {
+function Chain (logger, block, transaction, db, genesisblock, bus, balancesSequence, clientWs) {
   library = {
     logger: logger,
     db: db,
     genesisblock: genesisblock,
     bus: bus,
     balancesSequence: balancesSequence,
+    clientWs: clientWs,
     logic: {
       block: block,
       transaction: transaction
@@ -335,6 +337,23 @@ Chain.prototype.applyBlock = function (block, broadcast, cb, saveBlock) {
   // Prevent shutdown during database writes.
   modules.blocks.isActive.set(true);
 
+  var balanceBatchStarted = false;
+  if (
+    library.clientWs &&
+    typeof library.clientWs.beginBalanceBatch === 'function'
+  ) {
+    try {
+      library.clientWs.beginBalanceBatch();
+      balanceBatchStarted = true;
+    } catch (batchErr) {
+      library.logger.debug(
+          'ws-client-server',
+          `Unable to begin balance event batch: ${batchErr?.message || batchErr}`,
+          batchErr?.stack
+      );
+    }
+  }
+
   // Transactions to rewind in case of error.
   var appliedTransactions = {};
 
@@ -479,6 +498,30 @@ Chain.prototype.applyBlock = function (block, broadcast, cb, saveBlock) {
     }
   }, function (err) {
     function finalize (err) {
+      if (balanceBatchStarted) {
+        try {
+          library.clientWs.endBalanceBatch();
+        } catch (batchErr) {
+          library.logger.debug(
+              'ws-client-server',
+              `Unable to finish balance event batch: ${batchErr?.message || batchErr}`,
+              batchErr?.stack
+          );
+        }
+      }
+
+      if (!err && saveBlock && library.clientWs) {
+        try {
+          library.clientWs.emitBlock(block);
+        } catch (emitErr) {
+          library.logger.debug(
+              'ws-client-server',
+              `Unable to publish block ${block.id}: ${emitErr?.message || emitErr}`,
+              emitErr?.stack
+          );
+        }
+      }
+
       // Allow shutdown, database writes are finished.
       modules.blocks.isActive.set(false);
 
@@ -611,8 +654,37 @@ Chain.prototype.deleteLastBlock = function (cb) {
     return setImmediate(cb, 'Cannot delete genesis block');
   }
 
+  var balanceBatchStarted = false;
+  if (
+    library.clientWs &&
+    typeof library.clientWs.beginBalanceBatch === 'function'
+  ) {
+    try {
+      library.clientWs.beginBalanceBatch();
+      balanceBatchStarted = true;
+    } catch (batchErr) {
+      library.logger.debug(
+          'ws-client-server',
+          `Unable to begin rollback balance event batch: ${batchErr?.message || batchErr}`,
+          batchErr?.stack
+      );
+    }
+  }
+
   // Delete last block, replace last block with previous block, undo things
   __private.popLastBlock(lastBlock, function (err, newLastBlock) {
+    if (balanceBatchStarted) {
+      try {
+        library.clientWs.endBalanceBatch();
+      } catch (batchErr) {
+        library.logger.debug(
+            'ws-client-server',
+            `Unable to finish rollback balance event batch: ${batchErr?.message || batchErr}`,
+            batchErr?.stack
+        );
+      }
+    }
+
     if (err) {
       library.logger.error('blocks', 'An error occurred while deleting last block', lastBlock);
     } else {

--- a/modules/clientWs.js
+++ b/modules/clientWs.js
@@ -15,6 +15,7 @@ class ClientWs {
     this.blockSubscriptions = new Set();
     this.balanceSubscriptions = new Map();
     this.balanceBatchDepth = 0;
+    this.discardBalanceBatch = false;
     this.pendingBalanceChanges = new Map();
     this.logger = logger;
 
@@ -110,7 +111,7 @@ class ClientWs {
       let pending = this.pendingBalanceChanges.get(normalizedAddress);
 
       if (!pending) {
-        pending = { fields: new Set(), getAccount: getAccount };
+        pending = { fields: new Set() };
         this.pendingBalanceChanges.set(normalizedAddress, pending);
       }
 
@@ -159,17 +160,26 @@ class ClientWs {
    * @return {void}
    */
   beginBalanceBatch () {
+    if (this.balanceBatchDepth === 0) {
+      this.discardBalanceBatch = false;
+    }
+
     this.balanceBatchDepth += 1;
   }
 
   /**
    * Flushes one final balance read per changed address after the outer batch.
+   * Suppressing any nested batch discards the complete outer batch.
    * @param {boolean} [emitChanges=true] - Whether to publish or discard the batch
    * @return {void}
    */
   endBalanceBatch (emitChanges = true) {
     if (this.balanceBatchDepth === 0) {
       return;
+    }
+
+    if (!emitChanges) {
+      this.discardBalanceBatch = true;
     }
 
     this.balanceBatchDepth -= 1;
@@ -179,8 +189,10 @@ class ClientWs {
 
     const pendingChanges = this.pendingBalanceChanges;
     this.pendingBalanceChanges = new Map();
+    const discardBalanceBatch = this.discardBalanceBatch;
+    this.discardBalanceBatch = false;
 
-    if (!emitChanges) {
+    if (discardBalanceBatch) {
       return;
     }
 

--- a/modules/clientWs.js
+++ b/modules/clientWs.js
@@ -11,6 +11,11 @@ class ClientWs {
   constructor (config, logger, cb) {
     this.enabled = Boolean(config && config.enabled);
     this.describes = {};
+    this.transactionSubscriptions = new Set();
+    this.blockSubscriptions = new Set();
+    this.balanceSubscriptions = new Map();
+    this.balanceBatchDepth = 0;
+    this.pendingBalanceChanges = new Map();
     this.logger = logger;
 
     if (!this.enabled) {
@@ -22,6 +27,7 @@ class ClientWs {
       allowEIO3: true,
       cors: config.cors
     });
+    this.io = io;
 
     io.sockets.on('connection', this.handleConnection.bind(this));
 
@@ -40,17 +46,139 @@ class ClientWs {
       return;
     }
 
-    if (lastTransactionsIds[t.id]) {
+    if (lastTransactionsIds.has(t.id)) {
       return;
     }
-    lastTransactionsIds[t.id] = getUTime();
+
+    lastTransactionsIds.set(t.id, getUTime());
     try {
-      const subs = findSubs(t, Object.values(this.describes));
+      const subs = findSubs(t, this.transactionSubscriptions);
       for (const subscription of subs) {
-        subscription.socket.emit('newTrans', t);
+        this.emitToSocket(subscription, 'newTrans', t);
       }
     } catch (e) {
-      this.logger.debug('ws-client-server', `Socket emit error: ${e?.message || e}`, e.stack);
+      this.logError('Socket transaction matching error', e);
+    }
+  }
+
+  /**
+   * Emits a compact public block header to sockets that opted in to blocks.
+   * Historical rebuilds are filtered by the caller before reaching this method.
+   * @param {block} block - Successfully applied block
+   * @return {void}
+   */
+  emitBlock (block) {
+    if (!this.enabled || !block || this.blockSubscriptions.size === 0) {
+      return;
+    }
+
+    if (lastBlocksIds.has(block.id)) {
+      return;
+    }
+
+    lastBlocksIds.set(block.id, getUTime());
+    const payload = formatBlock(block);
+
+    for (const subscription of this.blockSubscriptions) {
+      this.emitToSocket(subscription, 'newBlock', payload);
+    }
+  }
+
+  /**
+   * Fetches and emits changed account balance fields when an address has
+   * interested subscribers. The account lookup is skipped otherwise.
+   * @param {string} address - Changed account address
+   * @param {string[]} changedFields - Changed internal or public field names
+   * @param {Function} getAccount - Callback-style current account accessor
+   * @return {void}
+   */
+  emitBalanceChange (address, changedFields, getAccount) {
+    if (!this.enabled || typeof address !== 'string') {
+      return;
+    }
+
+    const normalizedAddress = address.toUpperCase();
+    const publicFields = normalizeBalanceFields(changedFields);
+
+    if (!this.hasBalanceSubscribers(normalizedAddress, publicFields)) {
+      return;
+    }
+
+    if (this.balanceBatchDepth > 0) {
+      let pending = this.pendingBalanceChanges.get(normalizedAddress);
+
+      if (!pending) {
+        pending = { fields: new Set(), getAccount: getAccount };
+        this.pendingBalanceChanges.set(normalizedAddress, pending);
+      }
+
+      for (const field of publicFields) {
+        pending.fields.add(field);
+      }
+      pending.getAccount = getAccount;
+      return;
+    }
+
+    try {
+      getAccount((err, account) => {
+        if (err) {
+          this.logError(`Unable to read balance for ${normalizedAddress}`, err);
+          return;
+        }
+
+        const subscriptions = this.balanceSubscriptions.get(normalizedAddress);
+        if (!account || !subscriptions) {
+          return;
+        }
+
+        for (const subscription of subscriptions) {
+          const payload = { address: normalizedAddress };
+
+          for (const field of publicFields) {
+            if (subscription.balanceFields.has(field)) {
+              const accountField = field === 'unconfirmedBalance' ? 'u_balance' : field;
+              payload[field] = String(account[accountField]);
+            }
+          }
+
+          if (Object.keys(payload).length > 1) {
+            this.emitToSocket(subscription, 'balances/change', payload);
+          }
+        }
+      });
+    } catch (e) {
+      this.logError(`Unable to schedule balance lookup for ${normalizedAddress}`, e);
+    }
+  }
+
+  /**
+   * Defers balance reads while a block apply or rollback mutates transient state.
+   * Nested batches are supported because chain operations are explicitly sequenced.
+   * @return {void}
+   */
+  beginBalanceBatch () {
+    this.balanceBatchDepth += 1;
+  }
+
+  /**
+   * Flushes one final balance read per changed address after the outer batch.
+   * @return {void}
+   */
+  endBalanceBatch () {
+    if (this.balanceBatchDepth === 0) {
+      return;
+    }
+
+    this.balanceBatchDepth -= 1;
+    if (this.balanceBatchDepth > 0) {
+      return;
+    }
+
+    const pendingChanges = this.pendingBalanceChanges;
+    this.pendingBalanceChanges = new Map();
+
+    for (const [address, pending] of pendingChanges) {
+      this.emitBalanceChange(address, pending.fields, pending.getAccount);
     }
   }
 
@@ -75,9 +203,17 @@ class ClientWs {
           'assetChatTypes',
           this.subscribe.bind(this, socket, describe, describe.subscribeToAssetChatTypes.bind(describe))
       );
+      socket.on(
+          'balances',
+          this.subscribe.bind(this, socket, describe, describe.subscribeToBalances.bind(describe))
+      );
+      socket.on(
+          'blocks',
+          this.subscribeToBlocks.bind(this, socket, describe)
+      );
       socket.on('disconnect', this.removeSubscription.bind(this, socket.id));
     } catch (e) {
-      this.logger.debug('ws-client-server', `Connection socket error: ${e?.message || e}`, e.stack);
+      this.logError('Connection socket error', e);
     }
   }
 
@@ -93,7 +229,63 @@ class ClientWs {
     const values = Array.isArray(value) ? value : [value];
 
     if (subscribe(...values)) {
+      this.registerSubscription(socket, describe);
+    }
+  }
+
+  /**
+   * Applies a scalar boolean block subscription request.
+   * @param {object} socket - Connected Socket.IO client
+   * @param {TransactionSubscription} describe - Subscription state
+   * @param {boolean} enabled - Desired block subscription state
+   * @return {void}
+   */
+  subscribeToBlocks (socket, describe, enabled) {
+    if (describe.subscribeToBlocks(enabled)) {
+      this.registerSubscription(socket, describe);
+    }
+  }
+
+  /**
+   * Retains a subscription and updates indexes used by high-frequency events.
+   * @param {object} socket - Connected Socket.IO client
+   * @param {TransactionSubscription} describe - Subscription state
+   * @return {void}
+   */
+  registerSubscription (socket, describe) {
+    if (describe.hasSubscriptions()) {
       this.describes[socket.id] = describe;
+    } else {
+      delete this.describes[socket.id];
+    }
+
+    if (describe.blocks) {
+      this.blockSubscriptions.add(describe);
+    } else {
+      this.blockSubscriptions.delete(describe);
+    }
+
+    if (
+      describe.addresses.size > 0 ||
+      describe.types.size > 0 ||
+      describe.assetChatTypes.size > 0
+    ) {
+      this.transactionSubscriptions.add(describe);
+    } else {
+      this.transactionSubscriptions.delete(describe);
+    }
+
+    if (describe.balanceFields.size > 0) {
+      for (const address of describe.addresses) {
+        let subscriptions = this.balanceSubscriptions.get(address);
+
+        if (!subscriptions) {
+          subscriptions = new Set();
+          this.balanceSubscriptions.set(address, subscriptions);
+        }
+
+        subscriptions.add(describe);
+      }
     }
   }
 
@@ -103,24 +295,118 @@ class ClientWs {
    * @return {void}
    */
   removeSubscription (socketId) {
+    const describe = this.describes[socketId];
+
+    if (!describe) {
+      return;
+    }
+
+    this.transactionSubscriptions.delete(describe);
+    this.blockSubscriptions.delete(describe);
+
+    for (const address of describe.addresses) {
+      const subscriptions = this.balanceSubscriptions.get(address);
+
+      if (subscriptions) {
+        subscriptions.delete(describe);
+        if (subscriptions.size === 0) {
+          this.balanceSubscriptions.delete(address);
+        }
+      }
+    }
+
     delete this.describes[socketId];
+  }
+
+  /**
+   * Stops the client Socket.IO server when an owner or test needs cleanup.
+   * @param {Function} [cb] - Completion callback
+   * @return {void}
+   */
+  close (cb) {
+    if (!this.io) {
+      if (cb) {
+        setImmediate(cb);
+      }
+      return;
+    }
+
+    this.io.close(cb);
+  }
+
+  /**
+   * Checks the address index before performing an account database read.
+   * @param {string} address - Normalized account address
+   * @param {Set<string>} changedFields - Changed public balance fields
+   * @return {boolean} Whether at least one socket needs the update
+   */
+  hasBalanceSubscribers (address, changedFields) {
+    const subscriptions = this.balanceSubscriptions.get(address);
+
+    if (!subscriptions || changedFields.size === 0) {
+      return false;
+    }
+
+    for (const subscription of subscriptions) {
+      for (const field of changedFields) {
+        if (subscription.balanceFields.has(field)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Isolates a broken client socket from all other recipients and node logic.
+   * @param {TransactionSubscription} subscription - Target subscription
+   * @param {string} event - Socket.IO event name
+   * @param {object} payload - Event payload
+   * @return {void}
+   */
+  emitToSocket (subscription, event, payload) {
+    try {
+      subscription.socket.emit(event, payload);
+    } catch (e) {
+      this.logError(`Socket emit error for ${event}`, e);
+    }
+  }
+
+  /**
+   * Writes client WebSocket diagnostics without assuming a logger is present.
+   * @param {string} message - Diagnostic context
+   * @param {*} error - Reported error
+   * @return {void}
+   */
+  logError (message, error) {
+    if (this.logger && typeof this.logger.debug === 'function') {
+      this.logger.debug(
+          'ws-client-server',
+          `${message}: ${error?.message || error}`,
+          error?.stack
+      );
+    }
   }
 }
 
-const lastTransactionsIds = {};
+const lastTransactionsIds = new Map();
+const lastBlocksIds = new Map();
 
-const cleanupInterval = setInterval(cleanupTransactionsCache, 60 * 1000);
+const cleanupInterval = setInterval(cleanupRecentIds, 60 * 1000);
 // This housekeeping timer must not keep short-lived scripts and test processes alive.
 cleanupInterval.unref();
 
 /**
- * Removes transaction ids after the duplicate-suppression window expires.
+ * Removes transaction and block ids after the duplicate-suppression window expires.
  * @return {void}
  */
-function cleanupTransactionsCache () {
-  for (let id in lastTransactionsIds) {
-    if (getUTime() - lastTransactionsIds[id] >= 60) {
-      delete lastTransactionsIds[id];
+function cleanupRecentIds () {
+  for (const ids of [lastTransactionsIds, lastBlocksIds]) {
+    for (const [id, timestamp] of ids) {
+      if (getUTime() - timestamp >= 60) {
+        ids.delete(id);
+      }
     }
   }
 }
@@ -136,7 +422,7 @@ function getUTime () {
 /**
  * Finds websocket subscriptions interested in a transaction.
  * @param {transaction} transaction - Transaction to match.
- * @param {TransactionSubscription[]} subs - Active subscriptions.
+ * @param {Iterable<TransactionSubscription>} subs - Active subscriptions.
  * @return {TransactionSubscription[]} Matching subscriptions.
  */
 function findSubs (transaction, subs) {
@@ -149,6 +435,43 @@ function findSubs (transaction, subs) {
   }
 
   return matchedSubscriptions;
+}
+
+/**
+ * Maps internal account fields to their public API names.
+ * @param {string[]} fields - Internal or public balance field names
+ * @return {Set<string>} Supported public field names
+ */
+function normalizeBalanceFields (fields) {
+  const normalized = new Set();
+
+  for (const field of fields || []) {
+    if (field === 'balance') {
+      normalized.add('balance');
+    } else if (field === 'u_balance' || field === 'unconfirmedBalance') {
+      normalized.add('unconfirmedBalance');
+    }
+  }
+
+  return normalized;
+}
+
+/**
+ * Selects the stable public header fields exposed by the client API.
+ * @param {block} block - Applied block
+ * @return {object} Compact public block header
+ */
+function formatBlock (block) {
+  return {
+    id: block.id,
+    height: block.height,
+    timestamp: block.timestamp,
+    generatorPublicKey: block.generatorPublicKey,
+    numberOfTransactions: block.numberOfTransactions,
+    totalAmount: block.totalAmount,
+    totalFee: block.totalFee,
+    reward: block.reward
+  };
 }
 
 module.exports = ClientWs;

--- a/modules/clientWs.js
+++ b/modules/clientWs.js
@@ -64,6 +64,7 @@ class ClientWs {
   /**
    * Emits a compact public block header to sockets that opted in to blocks.
    * Historical rebuilds are filtered by the caller before reaching this method.
+   * This public Socket.IO event is distinct from the internal `newBlock` bus event.
    * @param {block} block - Successfully applied block
    * @return {void}
    */
@@ -87,6 +88,7 @@ class ClientWs {
   /**
    * Fetches and emits changed account balance fields when an address has
    * interested subscribers. The account lookup is skipped otherwise.
+   * Account lookups are asynchronous, so delivery order remains best-effort.
    * @param {string} address - Changed account address
    * @param {string[]} changedFields - Changed internal or public field names
    * @param {Function} getAccount - Callback-style current account accessor
@@ -162,9 +164,10 @@ class ClientWs {
 
   /**
    * Flushes one final balance read per changed address after the outer batch.
+   * @param {boolean} [emitChanges=true] - Whether to publish or discard the batch
    * @return {void}
    */
-  endBalanceBatch () {
+  endBalanceBatch (emitChanges = true) {
     if (this.balanceBatchDepth === 0) {
       return;
     }
@@ -176,6 +179,10 @@ class ClientWs {
 
     const pendingChanges = this.pendingBalanceChanges;
     this.pendingBalanceChanges = new Map();
+
+    if (!emitChanges) {
+      return;
+    }
 
     for (const [address, pending] of pendingChanges) {
       this.emitBalanceChange(address, pending.fields, pending.getAccount);

--- a/modules/clientWs/transactionSubscription.js
+++ b/modules/clientWs/transactionSubscription.js
@@ -8,6 +8,7 @@ const {
 const transactionTypes = require('../../helpers/transactionTypes');
 
 const validator = new ZSchema({ noEmptyStrings: true });
+const BALANCE_FIELDS = new Set(['balance', 'unconfirmedBalance']);
 
 class TransactionSubscription {
   constructor (socket) {
@@ -31,6 +32,18 @@ class TransactionSubscription {
      * @type {Set<number>}
      */
     this.assetChatTypes = new Set();
+
+    /**
+     * Public account balance fields to include in change events
+     * @type {Set<string>}
+     */
+    this.balanceFields = new Set();
+
+    /**
+     * Whether the socket receives new block headers
+     * @type {boolean}
+     */
+    this.blocks = false;
   }
 
   /**
@@ -132,6 +145,50 @@ class TransactionSubscription {
     });
 
     return subscribed;
+  }
+
+  /**
+   * Subscribes to supported public account balance fields.
+   * @param {...string} fields - Public account fields to subscribe to
+   * @return {boolean} Whether at least one supported field was subscribed
+   */
+  subscribeToBalances (...fields) {
+    let subscribed = false;
+
+    fields.forEach((field) => {
+      if (BALANCE_FIELDS.has(field)) {
+        this.balanceFields.add(field);
+        subscribed = true;
+      }
+    });
+
+    return subscribed;
+  }
+
+  /**
+   * Enables or disables new block events for this socket.
+   * @param {boolean} enabled - Desired block subscription state
+   * @return {boolean} Whether the supplied state was valid
+   */
+  subscribeToBlocks (enabled) {
+    if (typeof enabled !== 'boolean') {
+      return false;
+    }
+
+    this.blocks = enabled;
+    return true;
+  }
+
+  /**
+   * Checks whether this socket has any active client WebSocket subscription.
+   * @return {boolean} Whether at least one subscription is active
+   */
+  hasSubscriptions () {
+    return this.addresses.size > 0 ||
+      this.types.size > 0 ||
+      this.assetChatTypes.size > 0 ||
+      this.balanceFields.size > 0 ||
+      this.blocks;
   }
 
   /**

--- a/modules/rounds.js
+++ b/modules/rounds.js
@@ -30,6 +30,7 @@ function Rounds (cb, scope) {
     db: scope.db,
     bus: scope.bus,
     network: scope.network,
+    clientWs: scope.clientWs,
     config: {
       loading: {
         snapshot: scope.config.loading.snapshot
@@ -173,6 +174,11 @@ Rounds.prototype.backwardTick = function (block, previousBlock, done) {
   ], function (err) {
     // Stop round ticking
     __private.ticking = false;
+
+    if (!err) {
+      __private.emitRoundBalanceChanges(scope);
+    }
+
     return done(err);
   });
 };
@@ -318,6 +324,10 @@ Rounds.prototype.tick = function (block, done) {
     // Stop round ticking
     __private.ticking = false;
 
+    if (!err) {
+      __private.emitRoundBalanceChanges(scope);
+    }
+
     if (scope.finishSnapshot) {
       return done('Snapshot finished');
     } else {
@@ -371,6 +381,42 @@ Rounds.prototype.onBlockchainReady = function () {
  */
 Rounds.prototype.onFinishRound = function (round) {
   library.network.wsServer.emit('rounds/change', { number: round });
+};
+
+/**
+ * Publishes reward-related balance changes after a complete round transaction.
+ * Subscriber indexes prevent account reads for addresses without listeners.
+ * @param {object} scope - Completed forward or backward round scope
+ * @return {void}
+ */
+__private.emitRoundBalanceChanges = function (scope) {
+  if (!scope.finishRound || !library.clientWs || !scope.roundDelegates) {
+    return;
+  }
+
+  const addresses = new Set(scope.roundDelegates.map(function (publicKey) {
+    return modules.accounts.generateAddressByPublicKey(publicKey);
+  }));
+
+  for (const address of addresses) {
+    try {
+      library.clientWs.emitBalanceChange(
+          address,
+          ['balance', 'u_balance'],
+          modules.accounts.getAccount.bind(
+              modules.accounts,
+              { address: address },
+              ['address', 'balance', 'u_balance']
+          )
+      );
+    } catch (err) {
+      library.logger.debug(
+          'ws-client-server',
+          `Unable to publish round balance change for ${address}: ${err?.message || err}`,
+          err?.stack
+      );
+    }
+  }
 };
 
 /**

--- a/modules/rounds.js
+++ b/modules/rounds.js
@@ -390,7 +390,12 @@ Rounds.prototype.onFinishRound = function (round) {
  * @return {void}
  */
 __private.emitRoundBalanceChanges = function (scope) {
-  if (!scope.finishRound || !library.clientWs || !scope.roundDelegates) {
+  if (
+    !scope.finishRound ||
+    !library.clientWs ||
+    typeof library.clientWs.emitBalanceChange !== 'function' ||
+    !scope.roundDelegates
+  ) {
     return;
   }
 

--- a/modules/rounds.js
+++ b/modules/rounds.js
@@ -324,7 +324,7 @@ Rounds.prototype.tick = function (block, done) {
     // Stop round ticking
     __private.ticking = false;
 
-    if (!err) {
+    if (!err && !scope.finishSnapshot) {
       __private.emitRoundBalanceChanges(scope);
     }
 

--- a/test/unit/logic/account.js
+++ b/test/unit/logic/account.js
@@ -109,6 +109,52 @@ describe('account', () => {
       });
     });
 
+    it('should publish changed balance fields after a successful merge', (done) => {
+      const clientWs = { emitBalanceChange: sinon.spy() };
+      account.scope.clientWs = clientWs;
+      diff.balance = 150;
+      diff.u_balance = -25;
+
+      account.merge(address, diff, (error) => {
+        expect(error).not.to.exist;
+        expect(clientWs.emitBalanceChange.calledOnce).to.equal(true);
+        expect(clientWs.emitBalanceChange.firstCall.args[0]).to.equal(address);
+        expect(clientWs.emitBalanceChange.firstCall.args[1]).to.deep.equal([
+          'balance',
+          'u_balance'
+        ]);
+        expect(clientWs.emitBalanceChange.firstCall.args[2]).to.be.a('function');
+        done();
+      });
+    });
+
+    it('should not publish balance fields when the database merge fails', (done) => {
+      const clientWs = { emitBalanceChange: sinon.spy() };
+      account.scope.clientWs = clientWs;
+      db.none = sinon.fake.returns(Promise.reject(new Error('database failed')));
+      diff.balance = 150;
+
+      account.merge(address, diff, (error) => {
+        expect(error).to.equal('Account#merge error');
+        expect(clientWs.emitBalanceChange.called).to.equal(false);
+        done();
+      });
+    });
+
+    it('should isolate balance event failures from account processing', (done) => {
+      account.scope.clientWs = {
+        emitBalanceChange: function () {
+          throw new Error('socket failed');
+        }
+      };
+      diff.balance = 150;
+
+      account.merge(address, diff, (error) => {
+        expect(error).not.to.exist;
+        done();
+      });
+    });
+
     it('should insert multiple complex objects', () => {
       diff.delegates = [
         { action: '+', value: delegate1 },

--- a/test/unit/logic/transaction.js
+++ b/test/unit/logic/transaction.js
@@ -1447,6 +1447,81 @@ describe('transaction', () => {
       transaction.applyUnconfirmed(trs, testSender, done);
     });
 
+    it('should publish the updated unconfirmed balance after account merge', async () => {
+      const trs = _.cloneDeep(validUnconfirmedTransaction);
+      trs.recipientPublicKey = trs.recipientPublicKey || 'b'.repeat(64);
+      const amount = new bignum(trs.amount.toString()).plus(trs.fee.toString());
+      const previousTransactionClientWs = transaction.scope.clientWs;
+      const previousAccountClientWs = transaction.scope.account.scope.clientWs;
+      const clientWs = {
+        emit: sinon.spy(),
+        emitBalanceChange: sinon.stub()
+      };
+      const getAccount = () => new Promise((resolve, reject) => {
+        accountModule.getAccount(
+            { publicKey: trs.senderPublicKey },
+            function (err, account) {
+              if (err) {
+                return reject(new Error(err));
+              }
+              resolve(account);
+            }
+        );
+      });
+      const accountBefore = await getAccount();
+      const balanceEvent = new Promise((resolve, reject) => {
+        clientWs.emitBalanceChange.callsFake(function (address, fields, readAccount) {
+          if (!fields.includes('u_balance')) {
+            return;
+          }
+
+          readAccount(function (err, account) {
+            if (err) {
+              return reject(new Error(err));
+            }
+            resolve({ address: address, account: account });
+          });
+        });
+      });
+
+      transaction.scope.clientWs = clientWs;
+      transaction.scope.account.scope.clientWs = clientWs;
+
+      try {
+        const applyResult = new Promise((resolve, reject) => {
+          transaction.applyUnconfirmed(trs, testSender, function (err) {
+            if (err) {
+              return reject(new Error(err));
+            }
+            resolve();
+          });
+        });
+        const [, event] = await Promise.all([applyResult, balanceEvent]);
+        const expectedBalance = new bignum(accountBefore.u_balance.toString())
+            .minus(amount)
+            .toString();
+
+        expect(event.address).to.equal(testSender.address);
+        expect(event.account.u_balance.toString()).to.equal(expectedBalance);
+        expect(clientWs.emit.called).to.equal(true);
+      } finally {
+        clientWs.emitBalanceChange.resetBehavior();
+        try {
+          await new Promise((resolve, reject) => {
+            transaction.undoUnconfirmed(trs, testSender, function (err) {
+              if (err) {
+                return reject(new Error(err));
+              }
+              resolve();
+            });
+          });
+        } finally {
+          transaction.scope.clientWs = previousTransactionClientWs;
+          transaction.scope.account.scope.clientWs = previousAccountClientWs;
+        }
+      }
+    });
+
     it('should return error on if balance is low', (done) => {
       const trs = _.cloneDeep(validUnconfirmedTransaction);
       trs.amount = '985045891180190800000000000000';

--- a/test/unit/modules/clientWs.integration.js
+++ b/test/unit/modules/clientWs.integration.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const { expect } = require('chai');
+const { io } = require('socket.io-client');
+const sinon = require('sinon');
+
+const ClientWs = require('../../../modules/clientWs');
+
+function waitFor (predicate, timeout = 2000) {
+  const started = Date.now();
+
+  return new Promise((resolve, reject) => {
+    function check () {
+      if (predicate()) {
+        return resolve();
+      }
+      if (Date.now() - started >= timeout) {
+        return reject(new Error('Timed out waiting for WebSocket state'));
+      }
+      setTimeout(check, 5);
+    }
+
+    check();
+  });
+}
+
+describe('ClientWs Socket.IO integration', function () {
+  this.timeout(5000);
+
+  let client;
+  let clientWs;
+
+  afterEach(async function () {
+    if (client) {
+      client.close();
+      client = null;
+    }
+    if (clientWs) {
+      await new Promise((resolve) => clientWs.close(resolve));
+      clientWs = null;
+    }
+  });
+
+  it('should deliver block and balance subscriptions over a real connection', async function () {
+    clientWs = new ClientWs(
+        { enabled: true, portWS: 0, cors: { origin: '*' } },
+        { debug: sinon.spy() }
+    );
+
+    await waitFor(() => clientWs.io.httpServer.address());
+    const port = clientWs.io.httpServer.address().port;
+    client = io(`http://127.0.0.1:${port}`, {
+      forceNew: true,
+      reconnection: false,
+      transports: ['websocket']
+    });
+
+    await new Promise((resolve, reject) => {
+      client.once('connect', resolve);
+      client.once('connect_error', reject);
+    });
+
+    client.emit('blocks', true);
+    client.emit('balances', ['balance', 'unconfirmedBalance']);
+    client.emit('address', 'u123456');
+
+    await waitFor(() =>
+      clientWs.blockSubscriptions.size === 1 &&
+      clientWs.balanceSubscriptions.has('U123456')
+    );
+
+    const blockEvent = new Promise((resolve) => client.once('newBlock', resolve));
+    const balanceEvent = new Promise((resolve) => client.once('balances/change', resolve));
+    const block = {
+      id: 'integration-block',
+      height: 2,
+      timestamp: 5,
+      generatorPublicKey: 'a'.repeat(64),
+      numberOfTransactions: 0,
+      totalAmount: 0,
+      totalFee: 0,
+      reward: 10000000
+    };
+
+    clientWs.emitBlock(block);
+    clientWs.emitBalanceChange('U123456', ['balance', 'u_balance'], function (cb) {
+      cb(null, { balance: '100', u_balance: '90' });
+    });
+
+    expect(await blockEvent).to.deep.equal(block);
+    expect(await balanceEvent).to.deep.equal({
+      address: 'U123456',
+      balance: '100',
+      unconfirmedBalance: '90'
+    });
+  });
+});

--- a/test/unit/modules/clientWs.js
+++ b/test/unit/modules/clientWs.js
@@ -268,6 +268,56 @@ describe('TransactionSubscription', () => {
     });
   });
 
+  describe('subscribeToBalances', () => {
+    it('should ignore unsupported fields and non-string values', () => {
+      const subscribed = sub.subscribeToBalances(
+          'votes',
+          'u_balance',
+          '',
+          0,
+          true,
+          null,
+          undefined,
+          {}
+      );
+
+      expect(subscribed).to.equal(false);
+      expect(sub.balanceFields).to.deep.equal(new Set());
+    });
+
+    it('should subscribe only to supported public balance fields', () => {
+      const subscribed = sub.subscribeToBalances(
+          'balance',
+          'unconfirmedBalance',
+          'balance'
+      );
+
+      expect(subscribed).to.equal(true);
+      expect(sub.balanceFields).to.deep.equal(
+          new Set(['balance', 'unconfirmedBalance'])
+      );
+    });
+  });
+
+  describe('subscribeToBlocks', () => {
+    it('should accept only scalar booleans', () => {
+      expect(sub.subscribeToBlocks('true')).to.equal(false);
+      expect(sub.subscribeToBlocks(1)).to.equal(false);
+      expect(sub.subscribeToBlocks([true])).to.equal(false);
+      expect(sub.blocks).to.equal(false);
+    });
+
+    it('should enable and disable block events', () => {
+      expect(sub.subscribeToBlocks(true)).to.equal(true);
+      expect(sub.blocks).to.equal(true);
+      expect(sub.hasSubscriptions()).to.equal(true);
+
+      expect(sub.subscribeToBlocks(false)).to.equal(true);
+      expect(sub.blocks).to.equal(false);
+      expect(sub.hasSubscriptions()).to.equal(false);
+    });
+  });
+
   describe('impliesTransaction', () => {
     const transaction = {
       id: '12154642911137703318',
@@ -375,7 +425,7 @@ describe('TransactionSubscription', () => {
       expect(implies).to.equal(false);
     });
 
-    it('should return false when subsribed to another transaction asset chat type', () => {
+    it('should return false when subscribed to another transaction asset chat type', () => {
       sub.subscribeToAssetChatTypes(TransactionType.CHAT_MESSAGE_TYPES.SIGNAL_MESSAGE);
 
       const implies = sub.impliesTransaction(transaction);
@@ -383,7 +433,7 @@ describe('TransactionSubscription', () => {
       expect(implies).to.equal(false);
     });
 
-    it('should return false when subsribed to another transaction asset chat type with correct address', () => {
+    it('should return false when subscribed to another transaction asset chat type with correct address', () => {
       sub.subscribeToAddresses(transaction.recipientId);
       sub.subscribeToAssetChatTypes(TransactionType.CHAT_MESSAGE_TYPES.SIGNAL_MESSAGE);
 
@@ -392,7 +442,7 @@ describe('TransactionSubscription', () => {
       expect(implies).to.equal(false);
     });
 
-    it('should return true when not subsribed to message transaction type but to asset chat type', () => {
+    it('should return true when not subscribed to message transaction type but to asset chat type', () => {
       sub.subscribeToAssetChatTypes(TransactionType.CHAT_MESSAGE_TYPES.ORDINARY_MESSAGE);
 
       const implies = sub.impliesTransaction(transaction);
@@ -400,7 +450,7 @@ describe('TransactionSubscription', () => {
       expect(implies).to.equal(true);
     });
 
-    it('should return true for chat message transaction when subsribed to another transaction type but also to asset chat type', () => {
+    it('should return true for chat message transaction when subscribed to another transaction type but also to asset chat type', () => {
       sub.subscribeToTypes(TransactionType.SEND);
       sub.subscribeToAssetChatTypes(TransactionType.CHAT_MESSAGE_TYPES.ORDINARY_MESSAGE);
 

--- a/test/unit/modules/clientWs.server.js
+++ b/test/unit/modules/clientWs.server.js
@@ -235,6 +235,28 @@ describe('ClientWs server', function () {
     expect(clientWs.pendingBalanceChanges.size).to.equal(0);
   });
 
+  it('should discard the outer balance batch when a nested batch is suppressed', function () {
+    const { handlers, socket } = createSocket('socket-nested-balance-discard');
+    const clientWs = new ClientWs({ enabled: false }, { debug: sinon.spy() });
+    const getAccount = sinon.spy();
+
+    clientWs.handleConnection(socket);
+    handlers.address('U123456');
+    handlers.balances('balance');
+    clientWs.enabled = true;
+
+    clientWs.beginBalanceBatch();
+    clientWs.beginBalanceBatch();
+    clientWs.emitBalanceChange('U123456', ['balance'], getAccount);
+    clientWs.endBalanceBatch(false);
+    clientWs.endBalanceBatch();
+
+    expect(getAccount.called).to.equal(false);
+    expect(socket.emit.called).to.equal(false);
+    expect(clientWs.pendingBalanceChanges.size).to.equal(0);
+    expect(clientWs.discardBalanceBatch).to.equal(false);
+  });
+
   it('should skip account reads without a matching balance subscription', function () {
     const invalid = createSocket('socket-invalid-balance');
     const clientWs = new ClientWs({ enabled: false }, { debug: sinon.spy() });

--- a/test/unit/modules/clientWs.server.js
+++ b/test/unit/modules/clientWs.server.js
@@ -5,26 +5,34 @@ const sinon = require('sinon');
 
 const ClientWs = require('../../../modules/clientWs');
 
+function createSocket (id, emit) {
+  const handlers = {};
+  const socket = {
+    id,
+    emit: emit || sinon.spy(),
+    on: function (event, handler) {
+      handlers[event] = handler;
+    }
+  };
+
+  return { handlers, socket };
+}
+
 describe('ClientWs server', function () {
-  it('should ignore transactions when disabled', function () {
+  it('should ignore all event types when disabled', function () {
     const clientWs = new ClientWs({ enabled: false });
 
     expect(function () {
-      clientWs.emit({ id: '1' });
+      clientWs.emit({ id: 'disabled-transaction' });
+      clientWs.emitBlock({ id: 'disabled-block' });
+      clientWs.emitBalanceChange('U1', ['balance'], sinon.spy());
     }).to.not.throw();
   });
 
   it('should emit matching transactions and remove disconnected subscriptions', function () {
-    const handlers = {};
-    const socket = {
-      id: 'socket-1',
-      emit: sinon.spy(),
-      on: function (event, handler) {
-        handlers[event] = handler;
-      }
-    };
+    const { handlers, socket } = createSocket('socket-transaction');
     const clientWs = new ClientWs({ enabled: false }, { debug: sinon.spy() });
-    const transaction = { id: '2', type: 0 };
+    const transaction = { id: 'server-transaction', type: 0 };
 
     clientWs.handleConnection(socket);
     handlers.types(0);
@@ -37,5 +45,238 @@ describe('ClientWs server', function () {
     handlers.disconnect();
 
     expect(clientWs.describes).not.to.have.property(socket.id);
+  });
+
+  it('should accept scalar and array parameters for every list subscription', function () {
+    const { handlers, socket } = createSocket('socket-parameters');
+    const clientWs = new ClientWs({ enabled: false }, { debug: sinon.spy() });
+
+    clientWs.handleConnection(socket);
+    handlers.address(['U123456', 'u4697606961271319613']);
+    handlers.types(0);
+    handlers.assetChatTypes([0, 1]);
+    handlers.balances(['balance', 'unconfirmedBalance']);
+    handlers.blocks(true);
+
+    const subscription = clientWs.describes[socket.id];
+    expect(subscription.addresses).to.deep.equal(
+        new Set(['U123456', 'U4697606961271319613'])
+    );
+    expect(subscription.types).to.deep.equal(new Set([0]));
+    expect(subscription.assetChatTypes).to.deep.equal(new Set([0, 1]));
+    expect(subscription.balanceFields).to.deep.equal(
+        new Set(['balance', 'unconfirmedBalance'])
+    );
+    expect(subscription.blocks).to.equal(true);
+
+    handlers.blocks([false]);
+    expect(subscription.blocks).to.equal(true);
+  });
+
+  it('should emit one compact block event only to opted-in sockets', function () {
+    const subscribed = createSocket('socket-blocks');
+    const transactionOnly = createSocket('socket-no-blocks');
+    const clientWs = new ClientWs({ enabled: false }, { debug: sinon.spy() });
+    const block = {
+      id: 'server-block-1',
+      height: 53532078,
+      timestamp: 278966175,
+      generatorPublicKey: 'a'.repeat(64),
+      numberOfTransactions: 2,
+      totalAmount: 10000000,
+      totalFee: 100000,
+      reward: 10000000,
+      transactions: [{ id: 'not-public' }],
+      blockSignature: 'not-public'
+    };
+
+    clientWs.handleConnection(subscribed.socket);
+    clientWs.handleConnection(transactionOnly.socket);
+    subscribed.handlers.blocks(true);
+    transactionOnly.handlers.types(0);
+    clientWs.enabled = true;
+
+    expect(
+        clientWs.transactionSubscriptions.has(clientWs.describes[subscribed.socket.id])
+    ).to.equal(false);
+
+    clientWs.emitBlock(block);
+    clientWs.emitBlock(block);
+
+    expect(subscribed.socket.emit.calledOnce).to.equal(true);
+    expect(subscribed.socket.emit.firstCall.args).to.deep.equal([
+      'newBlock',
+      {
+        id: block.id,
+        height: block.height,
+        timestamp: block.timestamp,
+        generatorPublicKey: block.generatorPublicKey,
+        numberOfTransactions: block.numberOfTransactions,
+        totalAmount: block.totalAmount,
+        totalFee: block.totalFee,
+        reward: block.reward
+      }
+    ]);
+    expect(transactionOnly.socket.emit.called).to.equal(false);
+
+    subscribed.handlers.blocks(false);
+    clientWs.emitBlock(Object.assign({}, block, { id: 'server-block-2' }));
+    expect(subscribed.socket.emit.calledOnce).to.equal(true);
+  });
+
+  it('should index balance subscriptions regardless of parameter order', function () {
+    const { handlers, socket } = createSocket('socket-balance-order');
+    const clientWs = new ClientWs({ enabled: false }, { debug: sinon.spy() });
+    const getAccount = sinon.spy(function (cb) {
+      cb(null, { balance: 12, u_balance: 10 });
+    });
+
+    clientWs.handleConnection(socket);
+    handlers.balances('unconfirmedBalance');
+    handlers.address('u123456');
+    clientWs.enabled = true;
+    clientWs.emitBalanceChange('U123456', ['u_balance'], getAccount);
+
+    expect(getAccount.calledOnce).to.equal(true);
+    expect(socket.emit.calledOnceWith('balances/change', {
+      address: 'U123456',
+      unconfirmedBalance: '10'
+    })).to.equal(true);
+  });
+
+  it('should fetch once and emit only requested changed balance fields', function () {
+    const confirmed = createSocket('socket-confirmed-balance');
+    const unconfirmed = createSocket('socket-unconfirmed-balance');
+    const unrelated = createSocket('socket-unrelated-balance');
+    const clientWs = new ClientWs({ enabled: false }, { debug: sinon.spy() });
+    const getAccount = sinon.spy(function (cb) {
+      cb(null, { balance: 100000000, u_balance: 99900000 });
+    });
+
+    for (const client of [confirmed, unconfirmed, unrelated]) {
+      clientWs.handleConnection(client.socket);
+    }
+    confirmed.handlers.address('U123456');
+    confirmed.handlers.balances('balance');
+    unconfirmed.handlers.address('U123456');
+    unconfirmed.handlers.balances('unconfirmedBalance');
+    unrelated.handlers.address('U654321');
+    unrelated.handlers.balances(['balance', 'unconfirmedBalance']);
+    clientWs.enabled = true;
+
+    clientWs.emitBalanceChange(
+        'u123456',
+        ['balance', 'u_balance'],
+        getAccount
+    );
+
+    expect(getAccount.calledOnce).to.equal(true);
+    expect(confirmed.socket.emit.calledOnceWith('balances/change', {
+      address: 'U123456',
+      balance: '100000000'
+    })).to.equal(true);
+    expect(unconfirmed.socket.emit.calledOnceWith('balances/change', {
+      address: 'U123456',
+      unconfirmedBalance: '99900000'
+    })).to.equal(true);
+    expect(unrelated.socket.emit.called).to.equal(false);
+  });
+
+  it('should batch transient balance mutations into one final account read', function () {
+    const { handlers, socket } = createSocket('socket-balance-batch');
+    const clientWs = new ClientWs({ enabled: false }, { debug: sinon.spy() });
+    const firstGetAccount = sinon.spy();
+    const finalGetAccount = sinon.spy(function (cb) {
+      cb(null, { balance: 75, u_balance: 70 });
+    });
+
+    clientWs.handleConnection(socket);
+    handlers.address('U123456');
+    handlers.balances(['balance', 'unconfirmedBalance']);
+    clientWs.enabled = true;
+
+    clientWs.beginBalanceBatch();
+    clientWs.beginBalanceBatch();
+    clientWs.emitBalanceChange('U123456', ['balance'], firstGetAccount);
+    clientWs.emitBalanceChange('U123456', ['u_balance'], finalGetAccount);
+    clientWs.endBalanceBatch();
+
+    expect(firstGetAccount.called).to.equal(false);
+    expect(finalGetAccount.called).to.equal(false);
+    expect(socket.emit.called).to.equal(false);
+
+    clientWs.endBalanceBatch();
+
+    expect(firstGetAccount.called).to.equal(false);
+    expect(finalGetAccount.calledOnce).to.equal(true);
+    expect(socket.emit.calledOnceWith('balances/change', {
+      address: 'U123456',
+      balance: '75',
+      unconfirmedBalance: '70'
+    })).to.equal(true);
+  });
+
+  it('should skip account reads without a matching balance subscription', function () {
+    const invalid = createSocket('socket-invalid-balance');
+    const clientWs = new ClientWs({ enabled: false }, { debug: sinon.spy() });
+    const getAccount = sinon.spy();
+
+    clientWs.handleConnection(invalid.socket);
+    invalid.handlers.address('U123456');
+    invalid.handlers.balances(['votes', 'u_balance']);
+    clientWs.enabled = true;
+
+    clientWs.emitBalanceChange('U123456', ['balance'], getAccount);
+
+    expect(getAccount.called).to.equal(false);
+    expect(invalid.socket.emit.called).to.equal(false);
+  });
+
+  it('should remove balance indexes when a socket disconnects', function () {
+    const { handlers, socket } = createSocket('socket-balance-disconnect');
+    const clientWs = new ClientWs({ enabled: false }, { debug: sinon.spy() });
+    const getAccount = sinon.spy();
+
+    clientWs.handleConnection(socket);
+    handlers.address('U123456');
+    handlers.balances('balance');
+    handlers.disconnect();
+    clientWs.enabled = true;
+
+    clientWs.emitBalanceChange('U123456', ['balance'], getAccount);
+
+    expect(getAccount.called).to.equal(false);
+    expect(clientWs.balanceSubscriptions.has('U123456')).to.equal(false);
+  });
+
+  it('should isolate socket emit failures from other subscribers', function () {
+    const logger = { debug: sinon.spy() };
+    const broken = createSocket('socket-broken', function () {
+      throw new Error('socket failed');
+    });
+    const healthy = createSocket('socket-healthy');
+    const clientWs = new ClientWs({ enabled: false }, logger);
+
+    clientWs.handleConnection(broken.socket);
+    clientWs.handleConnection(healthy.socket);
+    broken.handlers.blocks(true);
+    healthy.handlers.blocks(true);
+    clientWs.enabled = true;
+
+    expect(function () {
+      clientWs.emitBlock({
+        id: 'server-block-failure',
+        height: 1,
+        timestamp: 0,
+        generatorPublicKey: 'a'.repeat(64),
+        numberOfTransactions: 0,
+        totalAmount: 0,
+        totalFee: 0,
+        reward: 0
+      });
+    }).to.not.throw();
+
+    expect(healthy.socket.emit.calledOnce).to.equal(true);
+    expect(logger.debug.calledOnce).to.equal(true);
   });
 });

--- a/test/unit/modules/clientWs.server.js
+++ b/test/unit/modules/clientWs.server.js
@@ -216,6 +216,25 @@ describe('ClientWs server', function () {
     })).to.equal(true);
   });
 
+  it('should discard a balance batch when publication is suppressed', function () {
+    const { handlers, socket } = createSocket('socket-balance-discard');
+    const clientWs = new ClientWs({ enabled: false }, { debug: sinon.spy() });
+    const getAccount = sinon.spy();
+
+    clientWs.handleConnection(socket);
+    handlers.address('U123456');
+    handlers.balances('balance');
+    clientWs.enabled = true;
+
+    clientWs.beginBalanceBatch();
+    clientWs.emitBalanceChange('U123456', ['balance'], getAccount);
+    clientWs.endBalanceBatch(false);
+
+    expect(getAccount.called).to.equal(false);
+    expect(socket.emit.called).to.equal(false);
+    expect(clientWs.pendingBalanceChanges.size).to.equal(0);
+  });
+
   it('should skip account reads without a matching balance subscription', function () {
     const invalid = createSocket('socket-invalid-balance');
     const clientWs = new ClientWs({ enabled: false }, { debug: sinon.spy() });

--- a/test/unit/modules/rounds.js
+++ b/test/unit/modules/rounds.js
@@ -61,6 +61,7 @@ describe('rounds', function () {
 
       sinon.stub(Round.prototype, 'mergeBlockGenerator').resolves();
       sinon.stub(Round.prototype, 'land').resolves();
+      sinon.stub(Round.prototype, 'truncateBlocks').resolves();
 
       new Rounds(function (err, instance) {
         if (err) {
@@ -110,6 +111,16 @@ describe('rounds', function () {
           'u_balance'
         ]);
         expect(clientWs.emitBalanceChange.firstCall.args[2]).to.be.a('function');
+        done();
+      });
+    });
+
+    it('should not publish delegate balances when a snapshot finishes', function (done) {
+      testRounds.setSnapshotRounds(1);
+
+      testRounds.tick({ id: 'snapshot-block', height: 1 }, function (err) {
+        expect(err).to.equal('Snapshot finished');
+        expect(clientWs.emitBalanceChange.called).to.equal(false);
         done();
       });
     });

--- a/test/unit/modules/rounds.js
+++ b/test/unit/modules/rounds.js
@@ -1,9 +1,11 @@
 'use strict';
 
 const { expect } = require('chai');
+const sinon = require('sinon');
 var express = require('express');
 var _ = require('lodash');
 var Rounds = require('../../../modules/rounds.js');
+var Round = require('../../../logic/round.js');
 var modulesLoader = require('../../common/initModule').modulesLoader;
 
 describe('rounds', function () {
@@ -31,6 +33,85 @@ describe('rounds', function () {
       var res = rounds.calc(Number.MAX_VALUE);
       expect(_.isNumber(res)).to.be.true;
       expect(res).to.be.below(Number.MAX_VALUE);
+    });
+  });
+
+  describe('balance notifications', function () {
+    var accounts;
+    var clientWs;
+    var db;
+    var testRounds;
+
+    beforeEach(function (done) {
+      accounts = {
+        generateAddressByPublicKey: sinon.stub().returns('U123456'),
+        getAccount: sinon.spy()
+      };
+      clientWs = { emitBalanceChange: sinon.spy() };
+      db = {
+        query: sinon.stub().resolves([{
+          fees: 0,
+          rewards: [0],
+          delegates: ['a'.repeat(64)]
+        }]),
+        tx: sinon.stub().callsFake(function (handler) {
+          return Promise.resolve(handler({}));
+        })
+      };
+
+      sinon.stub(Round.prototype, 'mergeBlockGenerator').resolves();
+      sinon.stub(Round.prototype, 'land').resolves();
+
+      new Rounds(function (err, instance) {
+        if (err) {
+          return done(err);
+        }
+
+        testRounds = instance;
+        testRounds.onBind({
+          accounts: accounts,
+          blocks: {},
+          delegates: {}
+        });
+        done();
+      }, {
+        bus: { message: sinon.spy() },
+        clientWs: clientWs,
+        config: { loading: { snapshot: 0 } },
+        db: db,
+        logger: {
+          debug: sinon.spy(),
+          error: sinon.spy(),
+          trace: sinon.spy()
+        },
+        network: { wsServer: { emit: sinon.spy() } }
+      });
+    });
+
+    afterEach(function () {
+      sinon.restore();
+    });
+
+    it('should not publish delegate balances on an intermediate block', function (done) {
+      testRounds.tick({ id: 'intermediate-block', height: 2 }, function (err) {
+        expect(err).not.to.exist;
+        expect(clientWs.emitBalanceChange.called).to.equal(false);
+        done();
+      });
+    });
+
+    it('should publish delegate balances after completing a round', function (done) {
+      testRounds.tick({ id: 'round-block', height: 1 }, function (err) {
+        expect(err).not.to.exist;
+        expect(clientWs.emitBalanceChange.calledOnce).to.equal(true);
+        expect(clientWs.emitBalanceChange.firstCall.args[0]).to.equal('U123456');
+        expect(clientWs.emitBalanceChange.firstCall.args[1]).to.deep.equal([
+          'balance',
+          'u_balance'
+        ]);
+        expect(clientWs.emitBalanceChange.firstCall.args[2]).to.be.a('function');
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
## Description

Add opt-in client Socket.IO subscriptions for new blocks and account balance changes.

- `socket.emit('blocks', true)` enables compact `newBlock` events after successful block application.
- `address` plus `balances` subscriptions enable `balances/change` events for `balance`, `unconfirmedBalance`, or both.
- Balance payloads use public REST field names and decimal strings.
- Block, transaction, and balance subscriptions use dedicated indexes so unrelated clients are not scanned and account reads are skipped when nobody subscribed to the changed address and field.
- Balance changes during block apply or rollback are batched into one final account read per address.
- Socket and event-publication failures are isolated from account, transaction, round, and block processing.

The existing `address`, `types`, `assetChatTypes`, and `newTrans` contracts remain backward-compatible.

## Related issue

Closes #217
Closes #256

## External links (optional)

- Documentation follow-up: Adamant-im/docs#34 and Adamant-im/docs#35
- Schema follow-up: Adamant-im/adamant-schema#47 and Adamant-im/adamant-schema#48

## Screenshots or videos (optional)

Not applicable. This is a Socket.IO API and node-internal publication change.

## Breaking changes

None. Both new event families are opt-in. Existing transaction subscribers receive no additional traffic unless they explicitly subscribe to blocks or balance fields.

## How to test

Environment checks:

```sh
pg_isready -h localhost -p 5432
redis-cli -h 127.0.0.1 -p 6379 ping
```

Targeted WebSocket, account, block, and round tests:

```sh
PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run test:single -- \
  test/unit/modules/clientWs.js \
  test/unit/modules/clientWs.server.js \
  test/unit/modules/clientWs.integration.js \
  test/unit/logic/account.js \
  test/unit/logic/transaction.js \
  test/unit/modules/blocks.js \
  test/unit/modules/rounds.js
```

Expected result: `226 passing`.

Broader fast unit coverage and lint:

```sh
PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run test:unit:fast
PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run eslint
git diff --check origin/dev...HEAD
```

Expected results: `938 passing`, ESLint `Done.`, and no diff errors.

The full non-fast unit suite, local testnet, and API suite were not run because the change does not alter consensus validation, serialization, SQL, peer transport, or REST endpoints, and the directly affected paths are covered by unit and real Socket.IO integration tests.

## Notes for reviewers

- `newBlock` is emitted only after the block pipeline succeeds and only when the block is being saved; database replay does not create client events.
- Account events are scheduled only after a successful account merge. Round completion explicitly publishes affected delegate balance fields.
- Block apply and rollback use nested balance batches to avoid exposing transient unconfirmed-pool rewind state.
- The balance subscription index prevents account database reads when no socket subscribed to the affected address and field.
- Duplicate transaction and block IDs are suppressed for at least 60 seconds; periodic cleanup can extend the effective window to approximately two minutes.
- Event delivery is best-effort and non-durable; clients should restore subscriptions after reconnecting and reconcile state through REST.

## Risk areas

- **Consensus and protocol:** No transaction or block bytes, IDs, signatures, validation rules, activation gates, reward calculations, delegate ordering, or slot timing are changed.
- **Replay and storage:** No SQL schema, migration, or persisted model changes. Historical database replay does not emit `newBlock`.
- **Security and privacy:** Existing client WebSocket exposure is preserved. Inputs remain allowlisted, no authentication or peer-handshake behavior changes, and no sensitive values are logged.
- **Performance:** Subscription indexes avoid unrelated scans and account reads; block apply/rollback coalesces balance notifications into final-state reads.

## Checklist

- [x] Code is formatted
- [x] Tests added/updated (if needed)
- [x] Documentation updated (if needed)
- [x] Changes tested in all relevant environments
