### PR TITLE
Feat: Expose consensus schedules and delegate forged amounts

### DIFF
--- a/logic/consensus/consensus.js
+++ b/logic/consensus/consensus.js
@@ -56,6 +56,42 @@ class Consensus {
   }
 
   /**
+   * Returns a copy of the effective consensus activation schedule.
+   * @return {object} Per-upgrade activation heights.
+   */
+  getActivationHeights () {
+    return { ...this.activationHeights };
+  }
+
+  /**
+   * Returns the latest consensus upgrade active at a block height.
+   * Uses the current blockchain height when `height` is omitted.
+   * @param {number} [height] - Block height to check.
+   * @return {?string} Active upgrade code name, or null before the first activation.
+   */
+  getActiveCodeName (height) {
+    if (height !== undefined && typeof height !== 'number') {
+      throw new Error(`Expected height to be a number but got ${typeof height}`);
+    }
+
+    const currentHeight = height === undefined ? this.getCurrentHeight() : height;
+    let activeCodeName = null;
+    let activeHeight = -Infinity;
+
+    Object.entries(this.activationHeights).forEach(([codeName, activationHeight]) => {
+      const isLaterActivation = activationHeight > activeHeight;
+      const isDeterministicTieBreak = activationHeight === activeHeight && codeName > activeCodeName;
+
+      if (activationHeight <= currentHeight && (isLaterActivation || isDeterministicTieBreak)) {
+        activeCodeName = codeName;
+        activeHeight = activationHeight;
+      }
+    });
+
+    return activeCodeName;
+  }
+
+  /**
    * Checks if a given consensus upgrade is activated based on a block height.
    * Uses the current blockchain height when `height` is omitted.
    * @param {string} codeName - The name of the consensus upgrade

--- a/modules/blocks.js
+++ b/modules/blocks.js
@@ -38,7 +38,8 @@ function Blocks (cb, scope) {
   // Initialize submodules with library content
   this.submodules = {
     api: new blocksAPI(
-        scope.logger, scope.db, scope.logic.block, scope.schema, scope.dbSequence
+        scope.logger, scope.db, scope.logic.block, scope.schema, scope.dbSequence,
+        scope.logic.consensus || scope.consensus
     ),
     verify: new blocksVerify(scope.logger, scope.logic.block,
         scope.logic.transaction, scope.db

--- a/modules/blocks/api.js
+++ b/modules/blocks/api.js
@@ -22,15 +22,17 @@ __private.blockReward = new BlockReward();
  * @param {Block} block
  * @param {ZSchema} schema
  * @param {Sequence} dbSequence
+ * @param {Consensus} consensus
  */
-function API (logger, db, block, schema, dbSequence) {
+function API (logger, db, block, schema, dbSequence, consensus) {
   library = {
     logger: logger,
     db: db,
     schema: schema,
     dbSequence: dbSequence,
     logic: {
-      block: block
+      block: block,
+      consensus: consensus
     }
   };
   self = this;
@@ -298,6 +300,7 @@ API.prototype.getStatus = function (req, cb) {
     broadhash: modules.system.getBroadhash(),
     epoch: constants.epochTime,
     height: lastBlock.height,
+    consensus: library.logic.consensus.getActiveCodeName(lastBlock.height),
     fee: library.logic.block.calculateFee(),
     milestone: __private.blockReward.calcMilestone(lastBlock.height),
     nethash: modules.system.getNethash(),

--- a/modules/blocks/api.js
+++ b/modules/blocks/api.js
@@ -295,6 +295,9 @@ API.prototype.getStatus = function (req, cb) {
   }
 
   var lastBlock = modules.blocks.lastBlock.get();
+  if (!Number.isFinite(lastBlock.height)) {
+    return setImmediate(cb, 'Blockchain is loading');
+  }
 
   return setImmediate(cb, null, {
     broadhash: modules.system.getBroadhash(),

--- a/modules/blocks/api.js
+++ b/modules/blocks/api.js
@@ -300,7 +300,7 @@ API.prototype.getStatus = function (req, cb) {
     broadhash: modules.system.getBroadhash(),
     epoch: constants.epochTime,
     height: lastBlock.height,
-    consensus: library.logic.consensus.getActiveCodeName(lastBlock.height),
+    consensusCodeName: library.logic.consensus.getActiveCodeName(lastBlock.height),
     fee: library.logic.block.calculateFee(),
     milestone: __private.blockReward.calcMilestone(lastBlock.height),
     nethash: modules.system.getNethash(),

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -845,7 +845,12 @@ Delegates.prototype.shared = {
       var currentBlock = modules.blocks.lastBlock.get();
       var limit = req.body.limit || 10;
 
-      modules.delegates.generateDelegateList(currentBlock.height, function (err, activeDelegates) {
+      // This response is a snapshot for the current chain tip. Height advances
+      // only after a block is accepted, so every projected slot must use the
+      // delegate list for the next block. Clients should refresh the snapshot
+      // after accepting a block instead of inferring future height transitions.
+      var nextBlockHeight = currentBlock.height + 1;
+      modules.delegates.generateDelegateList(nextBlockHeight, function (err, activeDelegates) {
         if (err) {
           return setImmediate(cb, err);
         }

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -452,7 +452,7 @@ Delegates.prototype.getDelegates = function (query, filter, cb) {
     ...filter,
     isDelegate: 1,
     sort: sortFilter
-  }, ['username', 'address', 'publicKey', 'votesWeight', 'vote', 'missedblocks', 'producedblocks'], function (err, delegates) {
+  }, ['username', 'address', 'publicKey', 'votesWeight', 'vote', 'missedblocks', 'producedblocks', 'fees', 'rewards'], function (err, delegates) {
     if (err) {
       return setImmediate(cb, err);
     }
@@ -471,6 +471,10 @@ Delegates.prototype.getDelegates = function (query, filter, cb) {
       totalSupply = __private.blockReward.calcSupply(lastBlock.height);
 
     for (var i = 0; i < delegates.length; i++) {
+      delegates[i].forged = new bignum(delegates[i].fees).plus(new bignum(delegates[i].rewards)).toString();
+      delete delegates[i].fees;
+      delete delegates[i].rewards;
+
       // TODO: 'rate' property is deprecated and need to be removed after transitional period
       delegates[i].rate = i + 1;
       delegates[i].rank = i + 1;

--- a/modules/delegates.js
+++ b/modules/delegates.js
@@ -845,6 +845,10 @@ Delegates.prototype.shared = {
       var currentBlock = modules.blocks.lastBlock.get();
       var limit = req.body.limit || 10;
 
+      if (!Number.isFinite(currentBlock.height)) {
+        return setImmediate(cb, 'Blockchain is loading');
+      }
+
       // This response is a snapshot for the current chain tip. Height advances
       // only after a block is accepted, so every projected slot must use the
       // delegate list for the next block. Clients should refresh the snapshot

--- a/modules/node.js
+++ b/modules/node.js
@@ -34,7 +34,10 @@ function Node (cb, scope) {
     bus: scope.bus,
     nonce: scope.nonce,
     build: scope.build,
-    logic: scope.logic,
+    logic: {
+      block: scope.logic.block,
+      consensus: scope.logic.consensus || scope.consensus
+    },
     lastCommit: scope.lastCommit,
     config: {
       peers: scope.config.peers,
@@ -42,7 +45,6 @@ function Node (cb, scope) {
       wsClient: scope.config.wsClient
     }
   };
-  library.logic.consensus = scope.logic.consensus || scope.consensus;
   self = this;
 
   setImmediate(cb, null, self);
@@ -107,6 +109,7 @@ Node.prototype.shared = {
    */
   getStatus: function (req, cb) {
     var lastBlock = modules.blocks.lastBlock.get();
+    var hasBlockHeight = Number.isFinite(lastBlock.height);
     var nodeTimestampMs = slots.getTimeMs();
     var wsClientOptions = {
       enabled: false
@@ -131,7 +134,7 @@ Node.prototype.shared = {
             broadhash: modules.system.getBroadhash(),
             epoch: constants.epochTime,
             height: lastBlock.height,
-            consensus: library.logic.consensus.getActiveCodeName(lastBlock.height),
+            consensusCodeName: hasBlockHeight ? library.logic.consensus.getActiveCodeName(lastBlock.height) : null,
             fee: library.logic.block.calculateFee(),
             milestone: lastBlock.height ? __private.blockReward.calcMilestone(lastBlock.height) : undefined,
             nethash: modules.system.getNethash(),

--- a/modules/node.js
+++ b/modules/node.js
@@ -42,6 +42,7 @@ function Node (cb, scope) {
       wsClient: scope.config.wsClient
     }
   };
+  library.logic.consensus = scope.logic.consensus || scope.consensus;
   self = this;
 
   setImmediate(cb, null, self);
@@ -130,11 +131,20 @@ Node.prototype.shared = {
             broadhash: modules.system.getBroadhash(),
             epoch: constants.epochTime,
             height: lastBlock.height,
+            consensus: library.logic.consensus.getActiveCodeName(lastBlock.height),
             fee: library.logic.block.calculateFee(),
             milestone: lastBlock.height ? __private.blockReward.calcMilestone(lastBlock.height) : undefined,
             nethash: modules.system.getNethash(),
             reward: lastBlock.height ? __private.blockReward.calcReward(lastBlock.height) : undefined,
             supply: lastBlock.height ? __private.blockReward.calcSupply(lastBlock.height) : undefined
+          },
+          consensusSchedule: {
+            activationHeights: library.logic.consensus.getActivationHeights()
+          },
+          milestoneSchedule: {
+            offset: constants.rewards.offset,
+            distance: constants.rewards.distance,
+            milestones: constants.rewards.milestones.slice()
           },
           version: {
             build: library.build,

--- a/test/api/blocks.js
+++ b/test/api/blocks.js
@@ -124,8 +124,8 @@ describe('GET /api/blocks/getStatus', function () {
       node.expect(res.body).to.have.property('broadhash').to.be.a('string');
       node.expect(res.body).to.have.property('epoch').to.be.a('string');
       node.expect(res.body).to.have.property('height').to.be.a('number');
-      node.expect(res.body).to.have.property('consensus').that.satisfy(function (consensus) {
-        return consensus === null || typeof consensus === 'string';
+      node.expect(res.body).to.have.property('consensusCodeName').that.satisfy(function (consensusCodeName) {
+        return consensusCodeName === null || typeof consensusCodeName === 'string';
       });
       node.expect(res.body).to.have.property('fee').to.be.a('number');
       node.expect(res.body).to.have.property('milestone').to.be.a('number');

--- a/test/api/blocks.js
+++ b/test/api/blocks.js
@@ -124,6 +124,9 @@ describe('GET /api/blocks/getStatus', function () {
       node.expect(res.body).to.have.property('broadhash').to.be.a('string');
       node.expect(res.body).to.have.property('epoch').to.be.a('string');
       node.expect(res.body).to.have.property('height').to.be.a('number');
+      node.expect(res.body).to.have.property('consensus').that.satisfy(function (consensus) {
+        return consensus === null || typeof consensus === 'string';
+      });
       node.expect(res.body).to.have.property('fee').to.be.a('number');
       node.expect(res.body).to.have.property('milestone').to.be.a('number');
       node.expect(res.body).to.have.property('nethash').to.be.a('string');

--- a/test/api/delegates.js
+++ b/test/api/delegates.js
@@ -130,7 +130,21 @@ describe('GET /api/delegates', function () {
       node.expect(res.body.delegates[0]).to.have.property('vote');
       node.expect(res.body.delegates[0]).to.have.property('rank');
       node.expect(res.body.delegates[0]).to.have.property('productivity');
+      node.expect(res.body.delegates[0]).to.have.property('forged').that.is.a('string').and.match(/^\d+$/);
       done();
+    });
+  });
+
+  it('should match the lifetime forged statistics endpoint', function (done) {
+    node.get('/api/delegates?limit=1', function (err, delegatesResponse) {
+      node.expect(delegatesResponse.body).to.have.property('success').to.be.true;
+      const delegate = delegatesResponse.body.delegates[0];
+
+      node.get('/api/delegates/forging/getForgedByAccount?generatorPublicKey=' + delegate.publicKey, function (err, forgedResponse) {
+        node.expect(forgedResponse.body).to.have.property('success').to.be.true;
+        node.expect(delegate.forged).to.equal(forgedResponse.body.forged);
+        done();
+      });
     });
   });
 
@@ -448,6 +462,7 @@ describe('GET /api/delegates/get', function () {
       node.expect(res.body).to.have.property('delegate').that.is.an('object');
       node.expect(res.body.delegate.username).to.equal(referenceDelegate.username);
       node.expect(res.body.delegate.rank).to.equal(referenceDelegate.rank);
+      node.expect(res.body.delegate.forged).to.equal(referenceDelegate.forged);
       // `rate` is a deprecated alias of `rank` and must keep matching it.
       node.expect(res.body.delegate.rate).to.equal(referenceDelegate.rank);
       // Regression guard: rank/rate must reflect the real position, not 1.

--- a/test/api/node.js
+++ b/test/api/node.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var node = require('./../node.js');
+
+describe('GET /api/node/status', function () {
+  it('should expose effective consensus and milestone schedules', function (done) {
+    node.get('/api/node/status', function (err, res) {
+      node.expect(res.body).to.have.property('success').to.be.true;
+      node.expect(res.body).to.have.nested.property('network.height').that.is.a('number');
+      node.expect(res.body).to.have.nested.property('network.consensus').that.satisfy(function (consensus) {
+        return consensus === null || typeof consensus === 'string';
+      });
+
+      node.expect(res.body).to.have.property('consensusSchedule').that.has.all.keys('activationHeights');
+      node.expect(res.body.consensusSchedule.activationHeights).to.deep.equal(node.config.consensusActivationHeights);
+
+      node.expect(res.body).to.have.property('milestoneSchedule');
+      node.expect(res.body.milestoneSchedule).to.deep.equal({
+        offset: node.constants.rewards.offset,
+        distance: node.constants.rewards.distance,
+        milestones: node.constants.rewards.milestones
+      });
+
+      done();
+    });
+  });
+
+  it('should report the same consensus as the blocks status endpoint', function (done) {
+    node.get('/api/node/status', function (err, nodeStatus) {
+      node.expect(nodeStatus.body).to.have.property('success').to.be.true;
+
+      node.get('/api/blocks/getStatus', function (err, blocksStatus) {
+        node.expect(blocksStatus.body).to.have.property('success').to.be.true;
+        node.expect(nodeStatus.body.network.consensus).to.equal(blocksStatus.body.consensus);
+        done();
+      });
+    });
+  });
+});

--- a/test/api/node.js
+++ b/test/api/node.js
@@ -7,8 +7,8 @@ describe('GET /api/node/status', function () {
     node.get('/api/node/status', function (err, res) {
       node.expect(res.body).to.have.property('success').to.be.true;
       node.expect(res.body).to.have.nested.property('network.height').that.is.a('number');
-      node.expect(res.body).to.have.nested.property('network.consensus').that.satisfy(function (consensus) {
-        return consensus === null || typeof consensus === 'string';
+      node.expect(res.body).to.have.nested.property('network.consensusCodeName').that.satisfy(function (consensusCodeName) {
+        return consensusCodeName === null || typeof consensusCodeName === 'string';
       });
 
       node.expect(res.body).to.have.property('consensusSchedule').that.has.all.keys('activationHeights');
@@ -25,13 +25,13 @@ describe('GET /api/node/status', function () {
     });
   });
 
-  it('should report the same consensus as the blocks status endpoint', function (done) {
+  it('should report the same consensus code name as the blocks status endpoint', function (done) {
     node.get('/api/node/status', function (err, nodeStatus) {
       node.expect(nodeStatus.body).to.have.property('success').to.be.true;
 
       node.get('/api/blocks/getStatus', function (err, blocksStatus) {
         node.expect(blocksStatus.body).to.have.property('success').to.be.true;
-        node.expect(nodeStatus.body.network.consensus).to.equal(blocksStatus.body.consensus);
+        node.expect(nodeStatus.body.network.consensusCodeName).to.equal(blocksStatus.body.consensusCodeName);
         done();
       });
     });

--- a/test/unit/logic/consensus.js
+++ b/test/unit/logic/consensus.js
@@ -74,4 +74,49 @@ describe('consensus', () => {
       expect(consensus.isActivated('fairSystem', 4359465)).to.be.true;
     });
   });
+
+  describe('getActivationHeights()', () => {
+    it('should return effective overrides without exposing mutable internal state', () => {
+      const consensus = createConsensus({ fairSystem: 10, spaceship: 20 }, 1);
+      const activationHeights = consensus.getActivationHeights();
+
+      expect(activationHeights).to.deep.equal({ fairSystem: 10, spaceship: 20 });
+
+      activationHeights.fairSystem = 999;
+      expect(consensus.getActivationHeights().fairSystem).to.equal(10);
+    });
+  });
+
+  describe('getActiveCodeName()', () => {
+    it('should return null before the first configured activation', () => {
+      const consensus = createConsensus({ fairSystem: 10, spaceship: 20 }, 9);
+
+      expect(consensus.getActiveCodeName()).to.be.null;
+    });
+
+    it('should activate an upgrade at its exact configured height', () => {
+      const consensus = createConsensus({ fairSystem: 10, spaceship: 20 }, 1);
+
+      expect(consensus.getActiveCodeName(10)).to.equal('fairSystem');
+    });
+
+    it('should return the latest activated upgrade after later activations', () => {
+      const consensus = createConsensus({ fairSystem: 10, spaceship: 20 }, 21);
+
+      expect(consensus.getActiveCodeName()).to.equal('spaceship');
+    });
+
+    it('should use effective activation height overrides', () => {
+      const consensus = createConsensus({ fairSystem: 30, spaceship: 40 }, 35);
+
+      expect(consensus.getActiveCodeName()).to.equal('fairSystem');
+      expect(consensus.getActiveCodeName(40)).to.equal('spaceship');
+    });
+
+    it('should break equal-height ties deterministically by code name', () => {
+      const consensus = createConsensus({ fairSystem: 10, spaceship: 10 }, 10);
+
+      expect(consensus.getActiveCodeName()).to.equal('spaceship');
+    });
+  });
 });

--- a/test/unit/modules/blocks.api.js
+++ b/test/unit/modules/blocks.api.js
@@ -50,6 +50,17 @@ describe('blocks API', function () {
     });
   });
 
+  it('rejects status while the applied block height is unavailable', function (done) {
+    blockHeight = undefined;
+
+    api.getStatus({}, function (err, data) {
+      expect(data).not.to.exist;
+      expect(err).to.equal('Blockchain is loading');
+      expect(consensus.getActiveCodeName.called).to.equal(false);
+      done();
+    });
+  });
+
   it('applies numberOfTransactions when it is zero', function (done) {
     api.getBlocks({ body: { numberOfTransactions: 0 } }, function (err, data) {
       expect(err).to.not.exist;

--- a/test/unit/modules/blocks.api.js
+++ b/test/unit/modules/blocks.api.js
@@ -39,12 +39,12 @@ describe('blocks API', function () {
     });
   });
 
-  it('returns consensus for the applied block height', function (done) {
+  it('returns the consensus code name for the applied block height', function (done) {
     blockHeight = 2;
 
     api.getStatus({}, function (err, data) {
       expect(err).to.not.exist;
-      expect(data.consensus).to.equal('fairSystem');
+      expect(data.consensusCodeName).to.equal('fairSystem');
       expect(consensus.getActiveCodeName.calledOnceWithExactly(blockHeight)).to.equal(true);
       done();
     });

--- a/test/unit/modules/blocks.api.js
+++ b/test/unit/modules/blocks.api.js
@@ -9,23 +9,44 @@ const z_schema = require('../../../helpers/z_schema.js');
 describe('blocks API', function () {
   let api;
   let db;
+  let blockHeight;
+  let consensus;
 
   beforeEach(function () {
     db = {
       query: sinon.stub().resolves([])
     };
+    blockHeight = 1;
+    consensus = {
+      getActiveCodeName: sinon.stub().callsFake((height) => height >= 2 ? 'fairSystem' : null)
+    };
 
     api = new API(
         { trace: sinon.spy(), error: sinon.spy() },
         db,
-        { dbRead: sinon.spy((row) => row) },
+        { dbRead: sinon.spy((row) => row), calculateFee: sinon.stub().returns(50000000) },
         new z_schema(),
-        { add: function (task, cb) { task(cb); } }
+        { add: function (task, cb) { task(cb); } },
+        consensus
     );
 
     api.onBind({
-      blocks: { lastBlock: { get: function () { return { height: 1 }; } } },
-      system: {}
+      blocks: { lastBlock: { get: function () { return { height: blockHeight }; } } },
+      system: {
+        getBroadhash: sinon.stub().returns('broadhash'),
+        getNethash: sinon.stub().returns('nethash')
+      }
+    });
+  });
+
+  it('returns consensus for the applied block height', function (done) {
+    blockHeight = 2;
+
+    api.getStatus({}, function (err, data) {
+      expect(err).to.not.exist;
+      expect(data.consensus).to.equal('fairSystem');
+      expect(consensus.getActiveCodeName.calledOnceWithExactly(blockHeight)).to.equal(true);
+      done();
     });
   });
 

--- a/test/unit/modules/delegates.js
+++ b/test/unit/modules/delegates.js
@@ -271,6 +271,25 @@ describe('delegates', function () {
         });
       });
 
+      it('should reject the request when the current block height is unavailable', (done) => {
+        modules.blocks.lastBlock.set({});
+        const generateDelegateListSpy = sinon.spy(delegates, 'generateDelegateList');
+
+        delegates.shared.getNextForgers({ body: {} }, (err, response) => {
+          generateDelegateListSpy.restore();
+          modules.blocks.lastBlock.set(dummyBlock);
+
+          try {
+            expect(response).not.to.exist;
+            expect(err).to.equal('Blockchain is loading');
+            expect(generateDelegateListSpy.called).to.be.false;
+            done();
+          } catch (assertionError) {
+            done(assertionError);
+          }
+        });
+      });
+
       it('should use the next block round schedule for every returned slot at a round boundary', (done) => {
         const roundBoundaryBlock = {
           ...dummyBlock,

--- a/test/unit/modules/delegates.js
+++ b/test/unit/modules/delegates.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { expect } = require('chai');
+const sinon = require('sinon');
 
 const { modulesLoader } = require('../../common/initModule.js');
 const {
@@ -12,6 +13,7 @@ const {
 
 const constants = require('../../../helpers/constants.js');
 const Delegates = require('../../../modules/delegates.js');
+const slots = require('../../../helpers/slots.js');
 
 const aDelegate = testAccount;
 
@@ -266,6 +268,54 @@ describe('delegates', function () {
           expect(err).not.to.exist;
           expect(response.delegates.length).to.equal(1);
           done();
+        });
+      });
+
+      it('should use the next block round schedule for every returned slot at a round boundary', (done) => {
+        const roundBoundaryBlock = {
+          ...dummyBlock,
+          height: constants.activeDelegates
+        };
+        const nextBlockHeight = roundBoundaryBlock.height + 1;
+        const currentSlot = 42;
+
+        delegates.generateDelegateList(nextBlockHeight, (err, nextRoundDelegates) => {
+          if (err) {
+            return done(err);
+          }
+
+          modules.blocks.lastBlock.set(roundBoundaryBlock);
+
+          const originalGetSlotNumber = slots.getSlotNumber;
+          const getSlotNumberStub = sinon.stub(slots, 'getSlotNumber').callsFake((timestamp) => {
+            return timestamp === undefined
+              ? currentSlot
+              : originalGetSlotNumber.call(slots, timestamp);
+          });
+          const generateDelegateListSpy = sinon.spy(delegates, 'generateDelegateList');
+
+          delegates.shared.getNextForgers({
+            body: { limit: constants.activeDelegates }
+          }, (err, response) => {
+            generateDelegateListSpy.restore();
+            getSlotNumberStub.restore();
+            modules.blocks.lastBlock.set(dummyBlock);
+
+            try {
+              expect(err).not.to.exist;
+              expect(generateDelegateListSpy.calledOnceWith(nextBlockHeight)).to.be.true;
+
+              const expectedDelegates = Array.from(
+                  { length: constants.activeDelegates },
+                  (_, index) => nextRoundDelegates[(currentSlot + index + 1) % slots.delegates]
+              );
+
+              expect(response.delegates).to.eql(expectedDelegates);
+              done();
+            } catch (assertionError) {
+              done(assertionError);
+            }
+          });
         });
       });
 

--- a/test/unit/modules/delegates.js
+++ b/test/unit/modules/delegates.js
@@ -92,8 +92,28 @@ describe('delegates', function () {
       delegates.getDelegates({}, {}, (err, response) => {
         expect(response.delegates).to.be.an('array');
         expect(response.count).to.greaterThanOrEqual(101);
+        expect(response.delegates[0].forged).to.be.a('string').and.match(/^\d+$/);
+        expect(response.delegates[0]).not.to.have.property('fees');
+        expect(response.delegates[0]).not.to.have.property('rewards');
         expect(err).not.to.exist;
         done();
+      });
+    });
+
+    it('should return the same lifetime forged amount as forging statistics', (done) => {
+      delegates.getDelegates({}, {}, (err, response) => {
+        expect(err).not.to.exist;
+
+        const delegate = response.delegates.find(({ publicKey }) => publicKey === validGeneratorPubicKey);
+        expect(delegate).to.exist;
+
+        delegates.shared.getForgedByAccount({
+          body: { generatorPublicKey: delegate.publicKey }
+        }, (err, forgedStats) => {
+          expect(err).not.to.exist;
+          expect(delegate.forged).to.equal(forgedStats.forged);
+          done();
+        });
       });
     });
   });
@@ -138,6 +158,7 @@ describe('delegates', function () {
           expect(delegate.username).to.equal(aDelegate.username);
           expect(delegate.publicKey).to.equal(aDelegate.publicKey);
           expect(delegate.address).to.equal(aDelegate.address);
+          expect(delegate.forged).to.be.a('string').and.match(/^\d+$/);
 
           done();
         });

--- a/test/unit/modules/node.js
+++ b/test/unit/modules/node.js
@@ -17,6 +17,7 @@ describe('node', function () {
   let nodeModule;
   let modules;
   let statusConsensus;
+  let sharedLogicConsensus;
 
   const dummyBlock = {
     id: '9314232245035524467',
@@ -41,6 +42,7 @@ describe('node', function () {
       modules = __modules;
 
       statusConsensus = new Consensus({ fairSystem: 2, spaceship: 3 });
+      sharedLogicConsensus = modulesLoader.scope.logic.consensus;
 
       const scope = {
         ...modulesLoader.scope,
@@ -48,8 +50,9 @@ describe('node', function () {
         consensus: statusConsensus
       };
 
-      modulesLoader.initModuleWithDb(
+      modulesLoader.initModule(
           Node,
+          scope,
           (err, module) => {
             if (err) {
               return done(err);
@@ -57,8 +60,7 @@ describe('node', function () {
 
             nodeModule = module;
             done();
-          },
-          scope
+          }
       );
     });
   });
@@ -67,6 +69,12 @@ describe('node', function () {
     it('should return false before delegates.onBind() was called', (done) => {
       expect(nodeModule.isLoaded()).to.be.false;
       done();
+    });
+  });
+
+  describe('constructor', () => {
+    it('should not mutate the shared scope logic object', () => {
+      expect(modulesLoader.scope.logic.consensus).to.equal(sharedLogicConsensus);
     });
   });
 
@@ -109,7 +117,7 @@ describe('node', function () {
 
           expect(response.network.epoch).to.equal(constants.epochTime);
           expect(response.network.height).to.equal(dummyBlock.height);
-          expect(response.network.consensus).to.be.null;
+          expect(response.network.consensusCodeName).to.be.null;
           expect(response.network.fee).to.be.greaterThan(0);
           expect(response.network.milestone).to.satisfy(Number.isInteger);
 
@@ -141,21 +149,33 @@ describe('node', function () {
         });
       });
 
-      it('should report consensus at exact overridden activation boundaries', (done) => {
+      it('should report the consensus code name at exact overridden activation boundaries', (done) => {
         modules.blocks.lastBlock.set({ ...dummyBlock, height: 2 });
 
         nodeModule.shared.getStatus({}, (err, firstActivation) => {
           expect(err).not.to.exist;
-          expect(firstActivation.network.consensus).to.equal('fairSystem');
+          expect(firstActivation.network.consensusCodeName).to.equal('fairSystem');
 
           modules.blocks.lastBlock.set({ ...dummyBlock, height: 3 });
           nodeModule.shared.getStatus({}, (err, secondActivation) => {
             modules.blocks.lastBlock.set(dummyBlock);
 
             expect(err).not.to.exist;
-            expect(secondActivation.network.consensus).to.equal('spaceship');
+            expect(secondActivation.network.consensusCodeName).to.equal('spaceship');
             done();
           });
+        });
+      });
+
+      it('should return a null consensus code name when the block height is unavailable', (done) => {
+        modules.blocks.lastBlock.set({});
+
+        nodeModule.shared.getStatus({}, (err, response) => {
+          modules.blocks.lastBlock.set(dummyBlock);
+
+          expect(err).not.to.exist;
+          expect(response.network.consensusCodeName).to.be.null;
+          done();
         });
       });
     });

--- a/test/unit/modules/node.js
+++ b/test/unit/modules/node.js
@@ -8,6 +8,7 @@ const { isHex } = require('../../common/assert.js');
 
 const Node = require('../../../modules/node.js');
 const constants = require('../../../helpers/constants.js');
+const Consensus = require('../../../logic/consensus/consensus.js');
 
 describe('node', function () {
   /**
@@ -15,6 +16,7 @@ describe('node', function () {
    */
   let nodeModule;
   let modules;
+  let statusConsensus;
 
   const dummyBlock = {
     id: '9314232245035524467',
@@ -38,9 +40,12 @@ describe('node', function () {
 
       modules = __modules;
 
+      statusConsensus = new Consensus({ fairSystem: 2, spaceship: 3 });
+
       const scope = {
         ...modulesLoader.scope,
-        ...library
+        ...library,
+        consensus: statusConsensus
       };
 
       modulesLoader.initModuleWithDb(
@@ -81,6 +86,8 @@ describe('node', function () {
           const keys = [
             'loader',
             'network',
+            'consensusSchedule',
+            'milestoneSchedule',
             'version',
             'nodeTimestampMs',
             'unixTimestampMs',
@@ -102,6 +109,7 @@ describe('node', function () {
 
           expect(response.network.epoch).to.equal(constants.epochTime);
           expect(response.network.height).to.equal(dummyBlock.height);
+          expect(response.network.consensus).to.be.null;
           expect(response.network.fee).to.be.greaterThan(0);
           expect(response.network.milestone).to.satisfy(Number.isInteger);
 
@@ -110,6 +118,15 @@ describe('node', function () {
 
           expect(response.network.reward).to.satisfy(Number.isInteger);
           expect(response.network.supply).to.satisfy(Number.isInteger);
+
+          expect(response.consensusSchedule).to.deep.equal({
+            activationHeights: statusConsensus.getActivationHeights()
+          });
+          expect(response.milestoneSchedule).to.deep.equal({
+            offset: constants.rewards.offset,
+            distance: constants.rewards.distance,
+            milestones: constants.rewards.milestones
+          });
 
           const versionKeys = ['build', 'commit', 'version'];
           expect(response.version).to.have.all.keys(versionKeys);
@@ -121,6 +138,24 @@ describe('node', function () {
           expect(response.unixTimestampMs).to.equal(constants.epochTime.getTime() + response.nodeTimestampMs);
 
           done();
+        });
+      });
+
+      it('should report consensus at exact overridden activation boundaries', (done) => {
+        modules.blocks.lastBlock.set({ ...dummyBlock, height: 2 });
+
+        nodeModule.shared.getStatus({}, (err, firstActivation) => {
+          expect(err).not.to.exist;
+          expect(firstActivation.network.consensus).to.equal('fairSystem');
+
+          modules.blocks.lastBlock.set({ ...dummyBlock, height: 3 });
+          nodeModule.shared.getStatus({}, (err, secondActivation) => {
+            modules.blocks.lastBlock.set(dummyBlock);
+
+            expect(err).not.to.exist;
+            expect(secondActivation.network.consensus).to.equal('spaceship');
+            done();
+          });
         });
       });
     });


### PR DESCRIPTION
## Description

Expose the node's effective consensus activation and block reward schedules through the public status APIs, include each delegate's lifetime forged amount in delegate list and single-delegate responses, and correct the next-forger schedule at round boundaries.

The status changes let clients, explorers, monitors, and operators discover:

- the latest cumulative consensus upgrade active at the applied block height;
- the effective activation heights after configuration defaults and runtime overrides are merged;
- the complete block reward milestone schedule.

The delegate changes:

- add `forged` as a base-10 integer string calculated from the existing lifetime `fees + rewards` account fields, without per-delegate database requests;
- make `GET /api/delegates/getNextForgers` use the delegate schedule for `currentBlock.height + 1`, matching the forging path at round boundaries;
- return the standard `Blockchain is loading` API error instead of evaluating a missing chain-tip height.

The new response fields are additive. The next-forger fix changes only the observation API's previously incorrect round-boundary output. Consensus validation, delegate ordering, reward calculation, block serialization, replay behavior, and storage are unchanged.

## Related issue

Closes #234
Closes #265
Closes #267

## External links (optional)

- Documentation companion PR: Adamant-im/docs#37
- OpenAPI companion PR: Adamant-im/adamant-schema#51

## Screenshots or videos (optional)

Not applicable; this PR changes JSON API responses only.

## Breaking changes

No contract-breaking fields are removed or renamed:

- `GET /api/blocks/getStatus` adds `consensusCodeName`;
- `GET /api/node/status` adds `network.consensusCodeName`, `consensusSchedule`, and `milestoneSchedule`;
- `GET /api/delegates` and `GET /api/delegates/get` add `forged`;
- `GET /api/delegates/getNextForgers` preserves its response shape while correcting the schedule used at round boundaries.

Clients supporting older node versions should continue to tolerate the absence of the additive fields.

## How to test

Run the focused unit tests:

```sh
PG_NATIVE=false npm run test:single -- test/unit/modules/blocks.api.js test/unit/modules/delegates.js
```

Run the broader fast unit suite:

```sh
PG_NATIVE=false npm run test:unit:fast
```

Observed results for the latest review follow-up:

- focused blocks/delegates unit tests: 49 passing;
- fast unit suite: 954 passing;
- ESLint for all touched files: passed;
- `git diff --check`: passed.

Earlier focused API coverage for the additive status and forged fields passed with 5 tests. The full long-running unit and API suites were not run because the focused and fast suites directly cover the changed paths.

`PG_NATIVE=false` was used because the local `libpq` addon targets Node ABI 127 while the active Node runtime expects ABI 147. The changes do not affect database driver behavior.

## Notes for reviewers

- `Consensus#getActiveCodeName()` is the single deterministic source used by both status endpoints. Activation begins exactly at height `H`, and equal-height entries use a deterministic codename tie-break.
- `consensusCodeName` avoids confusion with the existing numeric `loader.consensus` peer-agreement percentage and is synchronized with the companion docs and OpenAPI PRs.
- Status endpoints avoid invoking consensus and reward helpers until a finite applied block height is available.
- `getNextForgers` uses the next block height for one chain-tip snapshot; clients should refresh after another block is accepted.
- The consensus schedule is returned as a copy of the effective allowlisted activation-height map; unrelated configuration and secrets are not exposed.
- Delegate `forged` uses the same lifetime `fees + rewards` semantics and decimal-string representation as `getForgedByAccount`, without N+1 queries.
- Security, privacy, protocol validation, storage, serialization, replay, reward settlement, and delegate ranking behavior are unchanged.

## Checklist

- [x] Code is formatted
- [x] Tests added/updated (if needed)
- [x] Documentation updated (if needed)
- [x] Changes tested in all relevant environments
