### PR TITLE
Fix: Reset syncProtocol when tearing down outbound WS peers

### DIFF
--- a/api/ws/transport.js
+++ b/api/ws/transport.js
@@ -47,8 +47,11 @@ class TransportWsApi {
 
     self.logger.info('ws-node-client', `Connecting to random peers via WebSocket…`);
 
-    // Clear existing connections
-    self.connections.forEach(({ socket }) => {
+    // Clear existing connections. Reset syncProtocol before removing listeners
+    // so peers remain eligible for a later WebSocket upgrade (removeAllListeners
+    // would otherwise prevent handleDisconnect from calling switchToHttp).
+    self.connections.forEach(({ socket, peer }) => {
+      self.peers.switchToHttp(peer);
       socket.removeAllListeners();
       socket.disconnect();
     });
@@ -287,7 +290,7 @@ class TransportWsApi {
             maxConnections: this.maxConnections
           });
         } else {
-          const reason = err ?? 'Every peer is already connected via WebSocket';
+          const reason = err ?? 'No more suitable HTTP peers available for WebSocket connections';
           self.logger.info('ws-node-client', `${reason}. No peers updated.`, {
             connectedPeers: this.connections.size,
             maxConnections: this.maxConnections
@@ -311,6 +314,9 @@ class TransportWsApi {
     const connection = this.connections.get(peerUrl);
 
     if (connection) {
+      // Must reset before removeAllListeners(): disconnect handlers are cleared
+      // intentionally, so handleDisconnect will not run switchToHttp.
+      this.peers.switchToHttp(peer);
       connection.socket.removeAllListeners();
       connection.socket.disconnect();
       this.connections.delete(peerUrl);

--- a/api/ws/transport.js
+++ b/api/ws/transport.js
@@ -47,15 +47,10 @@ class TransportWsApi {
 
     self.logger.info('ws-node-client', `Connecting to random peers via WebSocket…`);
 
-    // Clear existing connections. Reset syncProtocol before removing listeners
-    // so peers remain eligible for a later WebSocket upgrade (removeAllListeners
-    // would otherwise prevent handleDisconnect from calling switchToHttp).
-    self.connections.forEach(({ socket, peer }) => {
-      self.peers.switchToHttp(peer);
-      socket.removeAllListeners();
-      socket.disconnect();
+    // Tear down via cleanupConnection so syncProtocol reset stays in one place.
+    self.connections.forEach(({ peer }) => {
+      self.cleanupConnection(peer);
     });
-    self.connections.clear();
 
     // Connect to multiple peers
     self.getRandomPeers(self.maxConnections, (err, peers) => {
@@ -314,8 +309,8 @@ class TransportWsApi {
     const connection = this.connections.get(peerUrl);
 
     if (connection) {
-      // Must reset before removeAllListeners(): disconnect handlers are cleared
-      // intentionally, so handleDisconnect will not run switchToHttp.
+      // Reset here because removeAllListeners() prevents handleDisconnect from
+      // running switchToHttp, so peers would stay marked ws without a live socket.
       this.peers.switchToHttp(peer);
       connection.socket.removeAllListeners();
       connection.socket.disconnect();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adamant",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adamant",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "GPL-3.0",
       "dependencies": {
         "async": "=3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adamant",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "ADAMANT Blockchain Node",
   "private": true,
   "engines": {

--- a/test/unit/api/ws/transport.js
+++ b/test/unit/api/ws/transport.js
@@ -82,4 +82,24 @@ describe('TransportWsApi peer syncProtocol lifecycle', function () {
     expect(socketB.removeAllListeners.calledOnce).to.equal(true);
     expect(transport.connections.size).to.equal(0);
   });
+
+  it('should reset syncProtocol via cleanupConnection during rotatePeers()', function () {
+    const peer = { ip: '1.2.3.4', port: 36666 };
+    const replacement = { ip: '9.9.9.9', port: 36666 };
+    const socket = fakeSocket();
+
+    transport.connections.set('ws://1.2.3.4:36666', { socket, peer });
+    peers.list.callsFake(function (options, cb) {
+      cb(null, [replacement]);
+    });
+    sinon.stub(transport, 'connectToPeer');
+
+    transport.rotatePeers();
+
+    expect(peers.switchToHttp.calledWith(peer)).to.equal(true);
+    expect(socket.removeAllListeners.calledOnce).to.equal(true);
+    expect(socket.disconnect.calledOnce).to.equal(true);
+    expect(transport.connections.has('ws://1.2.3.4:36666')).to.equal(false);
+    expect(transport.connectToPeer.calledOnceWith(replacement)).to.equal(true);
+  });
 });

--- a/test/unit/api/ws/transport.js
+++ b/test/unit/api/ws/transport.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const { expect } = require('chai');
+const sinon = require('sinon');
+const EventEmitter = require('events');
+
+const TransportWsApi = require('../../../../api/ws/transport');
+
+describe('TransportWsApi peer syncProtocol lifecycle', function () {
+  let clock;
+  let peers;
+  let transport;
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers();
+    peers = {
+      events: new EventEmitter(),
+      switchToHttp: sinon.spy(),
+      switchToWs: sinon.spy(),
+      list: sinon.stub(),
+      isBanned: sinon.stub().returns(false),
+      recordRequest: sinon.spy()
+    };
+
+    transport = new TransportWsApi(
+        {
+          peers,
+          system: { getNonce: () => 'test-nonce', getBroadhash: () => 'bh' },
+          transport: { internal: {} }
+        },
+        { logger: { info: sinon.spy(), log: sinon.spy(), debug: sinon.spy(), warn: sinon.spy() } },
+        { maxReceiveConnections: 25 }
+    );
+  });
+
+  afterEach(function () {
+    transport.stopRotation();
+    peers.events.removeAllListeners();
+    clock.restore();
+  });
+
+  function fakeSocket () {
+    return {
+      removeAllListeners: sinon.spy(),
+      disconnect: sinon.spy(),
+      on: sinon.spy()
+    };
+  }
+
+  it('should reset syncProtocol to http when cleaning up a connection', function () {
+    const peer = { ip: '1.2.3.4', port: 36666 };
+    const socket = fakeSocket();
+
+    transport.connections.set('ws://1.2.3.4:36666', { socket, peer });
+    transport.cleanupConnection(peer);
+
+    expect(peers.switchToHttp.calledOnceWith(peer)).to.equal(true);
+    expect(socket.removeAllListeners.calledOnce).to.equal(true);
+    expect(socket.disconnect.calledOnce).to.equal(true);
+    expect(peers.switchToHttp.calledBefore(socket.removeAllListeners)).to.equal(true);
+    expect(transport.connections.has('ws://1.2.3.4:36666')).to.equal(false);
+  });
+
+  it('should reset syncProtocol to http for every peer during initialize()', function () {
+    const peerA = { ip: '1.1.1.1', port: 36666 };
+    const peerB = { ip: '2.2.2.2', port: 36666 };
+    const socketA = fakeSocket();
+    const socketB = fakeSocket();
+
+    transport.connections.set('ws://1.1.1.1:36666', { socket: socketA, peer: peerA });
+    transport.connections.set('ws://2.2.2.2:36666', { socket: socketB, peer: peerB });
+
+    peers.list.callsFake(function (options, cb) {
+      cb(null, []);
+    });
+
+    transport.initialize();
+
+    expect(peers.switchToHttp.calledWith(peerA)).to.equal(true);
+    expect(peers.switchToHttp.calledWith(peerB)).to.equal(true);
+    expect(socketA.removeAllListeners.calledOnce).to.equal(true);
+    expect(socketB.removeAllListeners.calledOnce).to.equal(true);
+    expect(transport.connections.size).to.equal(0);
+  });
+});


### PR DESCRIPTION
## Description

Outbound `ws-node-client` was exhausting its WebSocket peer pool on public nodes: after rotation or re-initialize, peers stayed marked `syncProtocol: "ws"` even though the live socket was gone. Candidate selection only upgrades peers still on `http`, so `connectedPeers` collapsed to ~0–3 while logs claimed every peer was already connected.

Root cause: `cleanupConnection()` and `initialize()` called `socket.removeAllListeners()` before `disconnect()`, which prevented `handleDisconnect()` from running `switchToHttp()`.

This change resets `syncProtocol` to `http` before tearing down those sockets, and clarifies the empty-candidate log message.

## Related issue

Closes #270

## How to test

1. `npm run test:single -- test/unit/api/ws/transport.js`
2. Optionally on a mainnet node after deploy: confirm `connectedPeers` can refill toward `maxReceiveConnections`, and `/api/peers` no longer shows nearly all `state: 2` peers stuck on `syncProtocol: "ws"` with only 1–2 live WS sockets.

## Checklist

- [x] English-only repository artifacts
- [x] No consensus / serialization changes
- [x] Targeted unit tests added and run
- [x] Risk: peer/WS connectivity only (non-consensus)
